### PR TITLE
Don't list ignored files and dirs

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -579,8 +579,12 @@ class ListDirTool(Tool):
             os.path.join(self.project_root, relative_path),
             relative_to=self.project_root,
             recursive=recursive,
-            ignored_dirs=self.project_config.ignored_paths,
         )
+
+        # Don't use the scan_directory ignoring mechanism, instead rely on the language server,
+        # which has all information about ignored paths
+        dirs = [d for d in dirs if not self.language_server.should_ignore_path(d)]
+        files = [f for f in files if not self.language_server.should_ignore_path(f)]
         result = json.dumps({"dirs": dirs, "files": files})
         return self._limit_length(result, max_answer_chars)
 


### PR DESCRIPTION
Turned out to be trivial... No need to change any interfaces, I just filter out everything afterwards. Since the scandir tool was also doing that, it's not even a performance hit