### PR TITLE
eclipse_jdtl launcher on osx intel

### DIFF
--- a/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
+++ b/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
@@ -23,6 +23,16 @@
             "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
             "jdtls_readonly_config_path": "extension/server/config_mac_arm"
         },
+        "osx-x64": {
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-x64-1.23.0.vsix",
+            "archiveType": "zip",
+            "relative_extraction_path": "vscode-java",
+            "jre_home_path": "extension/jre/17.0.8.1-macosx-x86_64",
+            "jre_path": "extension/jre/17.0.8.1-macosx-x86_64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jdtls_readonly_config_path": "extension/server/config_mac"
+        },
         "linux-arm64": {
             "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@linux-arm64-1.23.0.vsix",
             "archiveType": "zip",

--- a/src/multilspy/lsp_protocol_handler/server.py
+++ b/src/multilspy/lsp_protocol_handler/server.py
@@ -207,6 +207,7 @@ class LanguageServerHandler:
         child_proc_env.update(self.process_launch_info.env)
 
         log.info("Starting language server process via command: %s", self.process_launch_info.cmd)
+        log.debug("environment: %s", child_proc_env)
         self.process = await asyncio.create_subprocess_shell(
             self.process_launch_info.cmd,
             stdout=asyncio.subprocess.PIPE,

--- a/src/multilspy/lsp_protocol_handler/server.py
+++ b/src/multilspy/lsp_protocol_handler/server.py
@@ -207,7 +207,7 @@ class LanguageServerHandler:
         child_proc_env.update(self.process_launch_info.env)
 
         log.info("Starting language server process via command: %s", self.process_launch_info.cmd)
-        log.debug("environment: %s", child_proc_env)
+        log.debug("Language server process environment: %s", child_proc_env)
         self.process = await asyncio.create_subprocess_shell(
             self.process_launch_info.cmd,
             stdout=asyncio.subprocess.PIPE,


### PR DESCRIPTION
runtime dependency brought in from [multilspy repository](https://github.com/microsoft/multilspy/blob/ab588214afb733c8d0084451d34ee6c7d7b6e0f0/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json#L26C9-L35C11) for osx with x64 architecture.



