### PR TITLE
Close #15: Don't try to use the GUI if unavailable

### DIFF
--- a/src/serena/agno.py
+++ b/src/serena/agno.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 from sensai.util.logging import LogTime
 
 from serena import serena_root_path
-from serena.agent import SerenaAgent, Tool
+from serena.agent import SerenaAgent, SerenaConfig, Tool
 from serena.gui_log_viewer import show_fatal_exception
 
 log = logging.getLogger(__name__)
@@ -150,7 +150,10 @@ class SerenaAgnoAgentProvider:
                 try:
                     serena_agent = SerenaAgent(project_file)
                 except Exception as e:
-                    show_fatal_exception(e)
+                    if SerenaConfig().gui_log_window_enabled:
+                        show_fatal_exception(e)
+                    else:
+                        log.exception("Failed to start Serena agent.")
                     raise
 
             # Even though we don't want to keep history between sessions,

--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -15,7 +15,7 @@ from mcp.server.fastmcp.utilities.func_metadata import func_metadata
 from sensai.util import logging
 from sensai.util.helper import mark_used
 
-from serena.agent import SerenaAgent, Tool
+from serena.agent import SerenaAgent, SerenaConfig, Tool
 from serena.gui_log_viewer import show_fatal_exception
 
 log = logging.getLogger(__name__)
@@ -100,7 +100,10 @@ def create_mcp_server() -> FastMCP:
             # project_activation_callback=update_tools
         )
     except Exception as e:
-        show_fatal_exception(e)
+        if SerenaConfig().gui_log_window_enabled:
+            show_fatal_exception(e)
+        else:
+            log.exception("Failed to start Serena MCP server.")
         raise
 
     @asynccontextmanager


### PR DESCRIPTION
This is just a quick fix that avoids creating a gui window when the gui has been deactivated in the config. I think centralized handling of gui / non-gui logging would make more sense, but in the interim this avoids an obscure crash. Closes #15 

PS: Sorry I can't provide a more general solution right now, but I will be offline for a few days and thought it best to at least patch the problem.