### PR TITLE
Fix handling of ignored paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 Changes prior to the next official version change will appear here.
 
 * Serena core:
-    * bugfix in find_symbol tool (a bug fixed in LS)
-    * merged the two overview tools (for dir and file) int a single one
-    * one-click setup for Cline enabled
-    * search for pattern tool can now (optionally) search in the entire project
-    * new tool for restarting the language server, in case of other sources of editing apart from Serena
+    * Bugfix in `FindSymbolTool` (a bug fixed in LS)
+    * Fix in `ListDirTool`: Do not ignore files with extensions not understood by the language server, only skip ignored directories
+      (error introduced in previous version)
+    * Merged the two overview tools (for directories and files) into a single one: `GetSymbolsOverviewTool`
+    * One-click setup for Cline enabled
+    * `SearchForPatternTool` can now (optionally) search in the entire project
+    * New tool `RestartLanguageServerTool` for restarting the language server (in case of other sources of editing apart from Serena)
     * Fix `CheckOnboardingPerformedTool`:
         * Tool description was incompatible with project change
         * Returned result was not as useful as it could be (now added list of memories)

--- a/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
+++ b/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
@@ -142,14 +142,14 @@ class EclipseJDTLS(LanguageServer):
         super().__init__(config, logger, repository_root_path, ProcessLaunchInfo(cmd, proc_env, proc_cwd), "java")
     
     @override
-    def should_always_ignore(self, dirname: str) -> bool:
+    def is_ignored_dirname(self, dirname: str) -> bool:
         # Ignore common Java build directories from different build tools:
         # - Maven: target
         # - Gradle: build, .gradle
         # - Eclipse: bin, .settings
         # - IntelliJ IDEA: out, .idea
         # - General: classes, dist, lib
-        return super().should_always_ignore(dirname) or dirname in [
+        return super().is_ignored_dirname(dirname) or dirname in [
             "target",      # Maven
             "build",       # Gradle
             "bin",         # Eclipse

--- a/src/multilspy/language_servers/gopls/gopls.py
+++ b/src/multilspy/language_servers/gopls/gopls.py
@@ -22,12 +22,12 @@ class Gopls(LanguageServer):
     """
     
     @override
-    def should_always_ignore(self, dirname: str) -> bool:
+    def is_ignored_dirname(self, dirname: str) -> bool:
         # For Go projects, we should ignore:
         # - vendor: third-party dependencies vendored into the project
         # - node_modules: if the project has JavaScript components
         # - dist/build: common output directories
-        return super().should_always_ignore(dirname) or dirname in ["vendor", "node_modules", "dist", "build"]
+        return super().is_ignored_dirname(dirname) or dirname in ["vendor", "node_modules", "dist", "build"]
 
     @staticmethod
     def _get_go_version():

--- a/src/multilspy/language_servers/jedi_language_server/jedi_server.py
+++ b/src/multilspy/language_servers/jedi_language_server/jedi_server.py
@@ -36,8 +36,8 @@ class JediServer(LanguageServer):
         )
         
     @override
-    def should_always_ignore(self, dirname: str) -> bool:
-        return super().should_always_ignore(dirname) or dirname in ["venv", "__pycache__"]
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        return super().is_ignored_dirname(dirname) or dirname in ["venv", "__pycache__"]
 
     def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
         """

--- a/src/multilspy/language_servers/omnisharp/omnisharp.py
+++ b/src/multilspy/language_servers/omnisharp/omnisharp.py
@@ -111,8 +111,8 @@ class OmniSharp(LanguageServer):
         self.references_available = asyncio.Event()
         
     @override
-    def should_always_ignore(self, dirname: str) -> bool:
-        return super().should_always_ignore(dirname) or dirname in ["bin", "obj"]
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        return super().is_ignored_dirname(dirname) or dirname in ["bin", "obj"]
 
     def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
         """

--- a/src/multilspy/language_servers/pyright_language_server/pyright_server.py
+++ b/src/multilspy/language_servers/pyright_language_server/pyright_server.py
@@ -39,8 +39,8 @@ class PyrightServer(LanguageServer):
         )
         
     @override
-    def should_always_ignore(self, dirname: str) -> bool:
-        return super().should_always_ignore(dirname) or dirname in ["venv", "__pycache__"]
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        return super().is_ignored_dirname(dirname) or dirname in ["venv", "__pycache__"]
 
     def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
         """

--- a/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
+++ b/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
@@ -42,8 +42,8 @@ class RustAnalyzer(LanguageServer):
         self.server_ready = asyncio.Event()
     
     @override
-    def should_always_ignore(self, dirname: str) -> bool:
-        return super().should_always_ignore(dirname) or dirname in ["target"]
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        return super().is_ignored_dirname(dirname) or dirname in ["target"]
 
     def setup_runtime_dependencies(self, logger: MultilspyLogger, config: MultilspyConfig) -> str:
         """

--- a/src/multilspy/language_servers/solargraph/solargraph.py
+++ b/src/multilspy/language_servers/solargraph/solargraph.py
@@ -44,8 +44,8 @@ class Solargraph(LanguageServer):
         self.server_ready = asyncio.Event()
         
     @override
-    def should_always_ignore(self, dirname: str) -> bool:
-        return super().should_always_ignore(dirname) or dirname in ["vendor"]
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        return super().is_ignored_dirname(dirname) or dirname in ["vendor"]
 
     def setup_runtime_dependencies(self, logger: MultilspyLogger, config: MultilspyConfig, repository_root_path: str) -> str:
         """

--- a/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
+++ b/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
@@ -57,8 +57,8 @@ class TypeScriptLanguageServer(LanguageServer):
         self.server_ready = asyncio.Event()
 
     @override
-    def should_always_ignore(self, dirname: str) -> bool:
-        return super().should_always_ignore(dirname) or dirname in [
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        return super().is_ignored_dirname(dirname) or dirname in [
             "node_modules",
             "dist",
             "build",

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -596,16 +596,18 @@ class ListDirTool(Tool):
             required for the task.
         :return: a JSON object with the names of directories and files within the given directory
         """
+
+        def is_ignored_dir(abs_path: str):
+            rel_path = os.path.relpath(abs_path, self.project_root)
+            return self.language_server.is_ignored_path(rel_path)
+
         dirs, files = scan_directory(
             os.path.join(self.project_root, relative_path),
             relative_to=self.project_root,
             recursive=recursive,
+            is_ignored_dir=is_ignored_dir,
         )
 
-        # Don't use the scan_directory ignoring mechanism, instead rely on the language server,
-        # which has all information about ignored paths
-        dirs = [d for d in dirs if not self.language_server.should_ignore_path(d)]
-        files = [f for f in files if not self.language_server.should_ignore_path(f)]
         result = json.dumps({"dirs": dirs, "files": files})
         return self._limit_length(result, max_answer_chars)
 

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -597,15 +597,16 @@ class ListDirTool(Tool):
         :return: a JSON object with the names of directories and files within the given directory
         """
 
-        def is_ignored_dir(abs_path: str):
+        def is_ignored_path(abs_path: str):
             rel_path = os.path.relpath(abs_path, self.project_root)
-            return self.language_server.is_ignored_path(rel_path)
+            return self.language_server.is_ignored_path(rel_path, ignore_unsupported_files=False)
 
         dirs, files = scan_directory(
             os.path.join(self.project_root, relative_path),
             relative_to=self.project_root,
             recursive=recursive,
-            is_ignored_dir=is_ignored_dir,
+            is_ignored_dir=is_ignored_path,
+            is_ignored_file=is_ignored_path,
         )
 
         result = json.dumps({"dirs": dirs, "files": files})

--- a/src/serena/util/file_system.py
+++ b/src/serena/util/file_system.py
@@ -7,12 +7,14 @@ def scan_directory(
     recursive: bool = False,
     relative_to: str | None = None,
     is_ignored_dir: Callable[[str], bool] = lambda x: False,
+    is_ignored_file: Callable[[str], bool] = lambda x: False,
 ) -> tuple[list[str], list[str]]:
     """
     :param path: the path to scan
     :param recursive: whether to recursively scan subdirectories
     :param relative_to: the path to which the results should be relative to; if None, provide absolute paths
     :param is_ignored_dir: a function with which to determine whether the given directory (abs. path) shall be ignored
+    :param is_ignored_file: a function with which to determine whether the given file (abs. path) shall be ignored
     :return: the list of directories and files
     """
     files = []
@@ -31,7 +33,8 @@ def scan_directory(
                 result_path = entry_path
 
             if entry.is_file():
-                files.append(result_path)
+                if not is_ignored_file(entry_path):
+                    files.append(result_path)
             elif entry.is_dir():
                 if not is_ignored_dir(entry_path):
                     directories.append(result_path)

--- a/src/serena/util/file_system.py
+++ b/src/serena/util/file_system.py
@@ -1,20 +1,18 @@
 import os
-from collections.abc import Sequence
+from collections.abc import Callable
 
 
 def scan_directory(
     path: str,
     recursive: bool = False,
     relative_to: str | None = None,
-    ignored_dirs: Sequence[str] = (),
-    ignored_files: Sequence[str] = (),
+    is_ignored_dir: Callable[[str], bool] = lambda x: False,
 ) -> tuple[list[str], list[str]]:
     """
     :param path: the path to scan
     :param recursive: whether to recursively scan subdirectories
     :param relative_to: the path to which the results should be relative to; if None, provide absolute paths
-    :param ignored_dirs: a list of directory names or relative paths to ignore
-    :param ignored_files: a list of file names or relative paths to ignore
+    :param is_ignored_dir: a function with which to determine whether the given directory (abs. path) shall be ignored
     :return: the list of directories and files
     """
     files = []
@@ -22,23 +20,6 @@ def scan_directory(
 
     abs_path = os.path.abspath(path)
     rel_base = os.path.abspath(relative_to) if relative_to else None
-
-    # Helper function to check if an item should be ignored
-    def is_ignored(entry_path: str, ignored_items: Sequence[str]) -> bool:
-        entry_name = os.path.basename(entry_path)
-
-        # Check if name is directly in ignored list
-        if entry_name in ignored_items:
-            return True
-
-        # Check if relative path matches any ignored path
-        if rel_base:
-            rel_path = os.path.relpath(entry_path, rel_base)
-            for item in ignored_items:
-                if rel_path == item or rel_path.startswith(f"{item}/"):
-                    return True
-
-        return False
 
     with os.scandir(abs_path) as entries:
         for entry in entries:
@@ -50,17 +31,15 @@ def scan_directory(
                 result_path = entry_path
 
             if entry.is_file():
-                if not is_ignored(entry_path, ignored_files):
-                    files.append(result_path)
+                files.append(result_path)
             elif entry.is_dir():
-                if not is_ignored(entry_path, ignored_dirs):
+                if not is_ignored_dir(entry_path):
                     directories.append(result_path)
                     if recursive:
                         sub_dirs, sub_files = scan_directory(
-                            entry_path, recursive=True, relative_to=relative_to, ignored_dirs=ignored_dirs, ignored_files=ignored_files
+                            entry_path, recursive=True, relative_to=relative_to, is_ignored_dir=is_ignored_dir
                         )
                         files.extend(sub_files)
                         directories.extend(sub_dirs)
 
-    # Note: I've swapped the return order to match your function signature
     return directories, files


### PR DESCRIPTION
Fix handling of ignored paths in ListDirTool:
Do not limit results to files not ignored by the LanguageServer, but retain ignoring of ignored directories

Improve handling of ignored paths in LanguageServer:
  * Improve method naming: 
      * should_always_ignore -> is_ignored_dirname 
      * should_ignore_path -> is_ignored_path
  * Fix is_ignored_dirname (should_always_ignore) being applied to filenames
  * Add option ignore_unsupported_files to is_ignored_path to improve versatility

Fixes #59 