### PR TITLE
Parse parameter descriptions from docstring into MCP tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "pathspec>=0.12.1",
   "psutil>=7.0.0",
   "agno>=1.2.15",
+  "docstring_parser>=0.16",
 ]
 
 [project.scripts]

--- a/test/serena/test_mcp.py
+++ b/test/serena/test_mcp.py
@@ -1,0 +1,139 @@
+"""Tests for the mcp.py module in serena."""
+
+from serena.mcp import _process_parameter_descriptions
+
+
+def test_basic_parameter_processing() -> None:
+    """Test basic functionality with parameters and return description."""
+    params_props = {
+        "name": {},
+        "age": {},
+    }
+    func_doc = """This is a test function.
+
+    :param name: The person's name
+    :param age: The person's age
+    :return: A greeting message
+    """
+
+    result_doc = _process_parameter_descriptions(params_props, func_doc)
+
+    assert "param" not in result_doc
+    assert "Returns A greeting message" in result_doc
+    assert result_doc == "This is a test function. Returns A greeting message."
+    assert params_props["name"]["description"] == "The person's name."
+    assert params_props["age"]["description"] == "The person's age."
+
+
+def test_no_parameters() -> None:
+    """Test with a docstring that has no parameters."""
+    params_props = {}
+    func_doc = """This is a test function with no parameters.
+
+    :return: A simple result
+    """
+
+    result_doc = _process_parameter_descriptions(params_props, func_doc)
+
+    assert result_doc == "This is a test function with no parameters. Returns A simple result."
+    assert len(params_props) == 0
+
+
+def test_no_return_description() -> None:
+    """Test with a docstring that has no return description."""
+    params_props = {"name": {}}
+    func_doc = """This is a test function.
+
+    :param name: The parameter name
+    """
+
+    result_doc = _process_parameter_descriptions(params_props, func_doc)
+
+    assert result_doc == "This is a test function."
+    assert "description" in params_props["name"]
+    assert params_props["name"]["description"] == "The parameter name."
+
+
+def test_existing_parameter_description() -> None:
+    """Test when parameters already have descriptions in the properties dict."""
+    params_props = {
+        "name": {"description": "Existing name description"},
+        "age": {},
+    }
+    func_doc = """This is a test function.
+
+    :param name: The person's name
+    :param age: The person's age
+    """
+
+    result_doc = _process_parameter_descriptions(params_props, func_doc)
+
+    assert result_doc == "This is a test function."
+    assert params_props["name"]["description"] == "Existing name description"
+    assert params_props["age"]["description"] == "The person's age."
+
+
+def test_parameter_not_in_docstring() -> None:
+    """Test when a parameter in properties is not in the docstring."""
+    params_props = {
+        "name": {},
+        "missing_param": {},
+    }
+    func_doc = """This is a test function.
+
+    :param name: The person's name
+    """
+
+    result_doc = _process_parameter_descriptions(params_props, func_doc)
+
+    assert result_doc == "This is a test function."
+    assert params_props["name"]["description"] == "The person's name."
+    assert "description" not in params_props["missing_param"]
+
+
+def test_multiline_docstring() -> None:
+    """Test with a complex multi-line docstring."""
+    params_props = {
+        "project_file_path": {},
+        "host": {},
+        "port": {},
+    }
+    func_doc = """Create an MCP server.
+
+    This function creates and configures a Model Context Protocol server
+    with the specified settings.
+
+    :param project_file_path: The path to the project file, or None
+    :param host: The host to bind to
+    :param port: The port to bind to
+    :return: A configured FastMCP server instance
+    """
+
+    result_doc = _process_parameter_descriptions(params_props, func_doc)
+
+    assert "param" not in result_doc
+    assert "Returns A configured FastMCP server instance" in result_doc
+    assert params_props["project_file_path"]["description"] == "The path to the project file, or None."
+    assert params_props["host"]["description"] == "The host to bind to."
+    assert params_props["port"]["description"] == "The port to bind to."
+
+
+def test_capitalization_and_periods() -> None:
+    """Test that the function properly capitalizes descriptions and adds periods."""
+    params_props = {
+        "param1": {},
+        "param2": {},
+        "param3": {},
+    }
+    func_doc = """Test function.
+
+    :param param1: lowercase description
+    :param param2: description with period.
+    :param param3: description with Capitalized word.
+    """
+
+    _ = _process_parameter_descriptions(params_props, func_doc)
+
+    assert params_props["param1"]["description"] == "Lowercase description."
+    assert params_props["param2"]["description"] == "Description with period."
+    assert params_props["param3"]["description"] == "Description with Capitalized word."

--- a/uv.lock
+++ b/uv.lock
@@ -971,6 +971,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "agno" },
+    { name = "docstring-parser" },
     { name = "dotenv" },
     { name = "fastmcp" },
     { name = "jinja2" },
@@ -1017,6 +1018,7 @@ requires-dist = [
     { name = "agno", marker = "extra == 'agno'", specifier = ">=1.2.6" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.49.0" },
     { name = "black", extras = ["jupyter"], marker = "extra == 'dev'", specifier = ">=23.7.0" },
+    { name = "docstring-parser", specifier = ">=0.16" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "fastapi", marker = "extra == 'agno'", specifier = ">=0.115.12" },
     { name = "fastmcp", specifier = ">=0.4.1" },


### PR DESCRIPTION
## Summary
This PR enhances the MCP server by extracting parameter descriptions from Python docstrings - that would appear in the tools description - and passing them to the proper `description` field of each parameter. The change improves quality of tool documentation available to LLMs.

## Testing
The PR includes test coverage to validate the parameter description extraction functionality. Tests ensure that docstrings in various formats are correctly parsed and that the parameter descriptions are properly integrated into MCP tools.

## Impact
This enhancement will improve the parsing of the tools by LLMs and also the tool evaluating experience for users. Below is an example of the tool listing on RooCode before and after the change:

Before | After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/bbe33cdc-bf38-4d4f-830d-fa6cf65a6565) | ![image](https://github.com/user-attachments/assets/8988775a-5539-4999-bbb9-42172a1193f1)
