### PR TITLE
Add missing dependencies to multilspy to run Dart LSP in Windows and MacOS

### DIFF
--- a/src/multilspy/language_servers/dart_language_server/runtime_dependencies.json
+++ b/src/multilspy/language_servers/dart_language_server/runtime_dependencies.json
@@ -8,6 +8,38 @@
             "platformId": "linux-x64",
             "archiveType": "zip",
             "binaryName": "dart-sdk/bin/dart"
+        },
+        {
+            "id": "DartLanguageServer",
+            "description": "Dart Language Server for Windows (x64)",
+            "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-windows-x64-release.zip",
+            "platformId": "win-x64",
+            "archiveType": "zip",
+            "binaryName": "dart-sdk/bin/dart.exe"
+        },
+        {
+            "id": "DartLanguageServer",
+            "description": "Dart Language Server for Windows (arm64)",
+            "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-windows-arm64-release.zip",
+            "platformId": "win-arm64",
+            "archiveType": "zip",
+            "binaryName": "dart-sdk/bin/dart.exe"
+        },
+        {
+            "id": "DartLanguageServer",
+            "description": "Dart Language Server for macOS (x64)",
+            "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-macos-x64-release.zip",
+            "platformId": "osx-x64",
+            "archiveType": "zip",
+            "binaryName": "dart-sdk/bin/dart"
+        },
+        {
+            "id": "DartLanguageServer",
+            "description": "Dart Language Server for macOS (arm64)",
+            "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-macos-arm64-release.zip",
+            "platformId": "osx-arm64",
+            "archiveType": "zip",
+            "binaryName": "dart-sdk/bin/dart"
         }
     ]
 }


### PR DESCRIPTION
This is the same content of the [PR to multispy](https://github.com/microsoft/multilspy/pull/105) to add support to other platforms for Dart LSP.