### PR TITLE
fixup: add missing description to ListDir tool

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -644,6 +644,8 @@ class ListDirTool(Tool):
 
     def apply(self, relative_path: str, recursive: bool, max_answer_chars: int = _DEFAULT_MAX_ANSWER_LENGTH) -> str:
         """
+        Lists files and directories in the given directory (optionally with recursion).
+
         :param relative_path: the relative path to the directory to list; pass "." to scan the project root
         :param recursive: whether to scan subdirectories recursively
         :param max_answer_chars: if the output is longer than this number of characters,
@@ -1092,7 +1094,7 @@ class WriteMemoryTool(Tool):
         """
         if len(content) > max_answer_chars:
             raise ValueError(
-                f"Content for {memory_file_name    } is too long. Max length is {max_answer_chars} characters. "
+                f"Content for {memory_file_name} is too long. Max length is {max_answer_chars} characters. "
                 + "Please make the content shorter."
             )
 


### PR DESCRIPTION
Fixes the following issue:
```
Traceback (most recent call last):
  File "/Users/user/serena/.venv/bin/serena-mcp-server", line 10, in <module>
    sys.exit(start_mcp_server())
             ^^^^^^^^^^^^^^^^^^
  File "/Users/user/serena/.venv/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/serena/.venv/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/user/serena/.venv/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/serena/.venv/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/serena/src/serena/mcp.py", line 187, in start_mcp_server
    mcp_server = create_mcp_server(project_file_path=project_file, host=host, port=port)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/serena/src/serena/mcp.py", line 135, in create_mcp_server
    update_tools()
  File "/Users/user/serena/src/serena/mcp.py", line 124, in update_tools
    mcp._tool_manager._tools[tool.get_name()] = make_tool(tool)
                                                ^^^^^^^^^^^^^^^
  File "/Users/user/serena/src/serena/mcp.py", line 65, in make_tool
    func_doc = f"{docstring.description.strip().strip('.')}."
```
Since `ListDir.apply` does not have a description the parsing tool returns `None`. The easiest fix was to correct the docstring itself.

The regression came from https://github.com/oraios/serena/pull/73