### PR TITLE
Add checks for 'location' and 'relativePath' in fix_relative_path function

### DIFF
--- a/src/multilspy/language_server.py
+++ b/src/multilspy/language_server.py
@@ -952,14 +952,16 @@ class LanguageServer:
                     # TODO: Not sure if this is actually still needed given recent changes to relative path handling
                     def fix_relative_path(nodes: List[multilspy_types.UnifiedSymbolInformation]):
                         for node in nodes:
-                            path = Path(node["location"]["relativePath"])
-                            if path.is_absolute():
-                                try:
-                                    path = path.relative_to(self.repository_root_path)
-                                    node["location"]["relativePath"] = str(path)
-                                except:
-                                    pass
-                            fix_relative_path(node["children"])
+                            if "location" in node and "relativePath" in node["location"]:
+                                path = Path(node["location"]["relativePath"])
+                                if path.is_absolute():
+                                    try:
+                                        path = path.relative_to(self.repository_root_path)
+                                        node["location"]["relativePath"] = str(path)
+                                    except Exception:
+                                        pass
+                            if "children" in node:
+                                fix_relative_path(node["children"])
 
                     fix_relative_path(root_nodes)
 


### PR DESCRIPTION
```
Error executing tool: 'relativePath'
Traceback (most recent call last):
  File "/workspaces/serena/src/serena/agent.py", line 551, in apply_ex
    result = apply_fn(**kwargs)
             ^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/serena/agent.py", line 1247, in apply
    matches = self.language_server.search_files_for_pattern(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 2022, in search_files_for_pattern
    ).result(timeout=self.timeout)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/coder/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/coder/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/workspaces/serena/src/multilspy/language_server.py", line 1186, in search_files_for_pattern
    relative_file_paths = await self.request_parsed_files()
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 1148, in request_parsed_files
    roots = await self.request_full_symbol_tree()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 990, in request_full_symbol_tree
    return await process_directory(start_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 946, in process_directory
    child_symbols = await process_directory(item_path)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 946, in process_directory
    child_symbols = await process_directory(item_path)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 964, in process_directory
    fix_relative_path(root_nodes)
  File "/workspaces/serena/src/multilspy/language_server.py", line 955, in fix_relative_path
    path = Path(node["location"]["relativePath"])
                ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'relativePath'
```