### PR TITLE
fixed runtime error.

### DIFF
--- a/src/multilspy/language_server.py
+++ b/src/multilspy/language_server.py
@@ -1046,10 +1046,10 @@ class LanguageServer:
         _, document_roots = await self.request_document_symbols(relative_file_path)
         return [
             (
-                root["name"],
-                root["kind"],
-                root["selectionRange"]["start"]["line"], # type: ignore
-                root["selectionRange"]["start"]["character"] # type: ignore
+                root.get("name"),
+                root.get("kind"),
+                root.get("selectionRange", {}).get("start", {}).get("line"), # type: ignore
+                root.get("selectionRange", {}).get("start", {}).get("character"), # type: ignore
             )
             for root in document_roots
         ]

--- a/src/multilspy/multilspy_utils.py
+++ b/src/multilspy/multilspy_utils.py
@@ -117,7 +117,10 @@ class FileUtils:
         """
         Reads the file at the given path and returns the contents as a string.
         """
-        encodings = ["utf-8-sig", "utf-16"]
+        if not os.path.exists(file_path):
+            logger.log(f"File read '{file_path}' failed: File does not exist.", logging.ERROR)
+            raise MultilspyException(f"File read '{file_path}' failed: File does not exist.")
+        encodings = ["utf-8-sig", "utf-16", "utf-8", "latin-1"]
         try:
             for encoding in encodings:
                 try:
@@ -125,6 +128,9 @@ class FileUtils:
                         return inp_file.read()
                 except UnicodeError:
                     continue
+            # Try system default encoding as a last resort
+            with open(file_path, "r") as inp_file:
+                return inp_file.read()
         except Exception as exc:
             logger.log(f"File read '{file_path}' failed: {exc}", logging.ERROR)
             raise MultilspyException("File read failed.") from None


### PR DESCRIPTION
## src/multilspy/language_server.py

```
Error executing tool: 'selectionRange'
Traceback (most recent call last):
  File "/workspaces/serena/src/serena/agent.py", line 551, in apply_ex
    result = apply_fn(**kwargs)
             ^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/serena/agent.py", line 692, in apply
    path_to_symbol_infos = self.language_server.request_overview(relative_path)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 1820, in request_overview
    ).result()
      ^^^^^^^^
  File "/home/coder/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/coder/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/workspaces/serena/src/multilspy/language_server.py", line 1069, in request_overview
    symbols_overview = await self.request_document_overview(within_relative_path)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 1047, in request_document_overview
    return [
           ^
  File "/workspaces/serena/src/multilspy/language_server.py", line 1051, in <listcomp>
    root["selectionRange"]["start"]["line"], # type: ignore
    ~~~~^^^^^^^^^^^^^^^^^^
KeyError: 'selectionRange'
```

## src/multilspy/multilspy_utils.py
```
Error executing tool: File read failed.
Traceback (most recent call last):
  File "/workspaces/serena/src/serena/agent.py", line 551, in apply_ex
    result = apply_fn(**kwargs)
             ^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/serena/agent.py", line 601, in apply
    result = self.language_server.retrieve_full_file_content(relative_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 1989, in retrieve_full_file_content
    return self.language_server.retrieve_full_file_content(relative_file_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 660, in retrieve_full_file_content
    with self.open_file(relative_file_path) as file_data:
  File "/home/coder/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/language_server.py", line 381, in open_file
    contents = FileUtils.read_file(self.logger, absolute_file_path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/serena/src/multilspy/multilspy_utils.py", line 127, in read_file
    raise MultilspyException("File read failed.") from None
multilspy.multilspy_exceptions.MultilspyException: File read failed.
```


