### PR TITLE
support uvx run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ google = [
 [project.urls]
 Homepage = "https://github.com/oraios/serena"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/serena", "src/multilspy"]
+
 [tool.black]
 line-length = 140
 target-version = [


### PR DESCRIPTION
I'm a little bit lazy. I won't want to have to first download serena just to use it.

With this change, you will be able to run:
```
uvx --from git+https://github.com/oraios/serena  -U serena-list-tools
```
(You can try it from my fork:  `uvx --from git+https://github.com/EricAtORS/serena  -U serena-list-tools`)

The `-U` is only needed  is to force uv/uvx to refresh and update the serena package. It's only needed because no one is managing the version number.

I did not update the readme as I think it's still premature to use it in this way.