### PR TITLE
Improve execute_shell_command - Timeout and without shell=True

### DIFF
--- a/src/serena/util/shell.py
+++ b/src/serena/util/shell.py
@@ -25,7 +25,7 @@ def execute_shell_command(command: str, cwd: str | None = None, capture_stderr: 
 
     process = subprocess.Popen(
         command,
-        shell=True,
+#        shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE if capture_stderr else None,
         text=True,
@@ -34,5 +34,5 @@ def execute_shell_command(command: str, cwd: str | None = None, capture_stderr: 
         cwd=cwd,
     )
 
-    stdout, stderr = process.communicate()
+    stdout, stderr = process.communicate(timeout=30)
     return ShellCommandResult(stdout=stdout, stderr=stderr, return_code=process.returncode, cwd=cwd)


### PR DESCRIPTION
Improved execute_shell_command, because I noticed that it was hanging a lot for me (running on Windows, maybe because of that?)
shell=True is usually not necessary, so commented it out, was it there for a reason?
I also added a timeout, although without shell=True it doesn't hang anymore