### PR TITLE
Feature/find symbol end position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,64 @@
-#
+# macOS specific files
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+Icon
+.fseventsd
+.DocumentRevisions-V100
+.TemporaryItems
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Windows specific files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+*.stackdump
+[Dd]esktop.ini
+$RECYCLE.BIN/
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+*.lnk
+
+# Linux specific files
+*~
+.fuse_hidden*
+.directory
+.Trash-*
+.nfs*
+
+# IDE/Text Editors
+# VS Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+.history/
+
+# JetBrains IDEs (beyond .idea/)
+*.iml
+*.ipr
+*.iws
+out/
+.idea_modules/
+
+# Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+*.sublime-workspace
+*.sublime-project
+
+# Project specific ignore
 .idea
 temp
 

--- a/src/serena/symbol.py
+++ b/src/serena/symbol.py
@@ -268,22 +268,29 @@ class Symbol(ToStringMixin):
         Convert the symbol to a dictionary.
 
         :param kind: whether to include the kind of the symbol
-        :param location: whether to include the location of the symbol
+        :param location: whether to include the location of the symbol (will also include end_location if available)
         :param depth: the depth of the symbol
         :param include_body: whether to include the body of the top-level symbol.
         :param include_children_body: whether to also include the body of the children.
             Note that the body of the children is part of the body of the parent symbol,
             so there is usually no need to set this to True unless you want process the output
             and pass the children without passing the parent body to the LM.
-        :return: a dictionary representation of the symbol
+        :return: a dictionary representation of the symbol with fields like 'name', 'kind', 'location', 'end_location'
         """
         result: dict[str, Any] = {"name": self.name, "name_path": self.get_name_path()}
-
         if kind:
             result["kind"] = self.kind
 
         if location:
             result["location"] = self.location.to_dict()
+            # Add end position information if available
+            end_pos = self.body_end_position
+            if end_pos is not None:
+                result["end_location"] = {
+                    "relative_path": self.relative_path,
+                    "line": end_pos["line"],
+                    "column": end_pos["character"]
+                }
 
         if include_body:
             if self.body is None:


### PR DESCRIPTION
Finally, some of the recent updates have fixed the line endings to symbol.py!

Now my change to add end_position shows the correct diffs for easy code review.

I also added some enhancements to gitignore for Mac users like myself. I also got Claude to put in every conceivable ignore for every other platform. It added quite a few and even some for Windows that weren't in the original gitignore, but should by like thumbs.db etc.