### PR TITLE
feat: Add Java 21 support to multilspy

### DIFF
--- a/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
+++ b/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
@@ -300,10 +300,10 @@ class EclipseJDTLS(LanguageServer):
         d["initializationOptions"]["bundles"] = bundles
 
         assert d["initializationOptions"]["settings"]["java"]["configuration"]["runtimes"] == [
-            {"name": "JavaSE-17", "path": "static/vscode-java/extension/jre/17.0.8.1-linux-x86_64", "default": True}
+            {"name": "JavaSE-21", "path": "static/vscode-java/extension/jre/21.0.7-linux-x86_64", "default": True}
         ]
         d["initializationOptions"]["settings"]["java"]["configuration"]["runtimes"] = [
-            {"name": "JavaSE-17", "path": self.runtime_dependency_paths.jre_home_path, "default": True}
+            {"name": "JavaSE-21", "path": self.runtime_dependency_paths.jre_home_path, "default": True}
         ]
 
         for runtime in d["initializationOptions"]["settings"]["java"]["configuration"]["runtimes"]:

--- a/src/multilspy/language_servers/eclipse_jdtls/initialize_params.json
+++ b/src/multilspy/language_servers/eclipse_jdtls/initialize_params.json
@@ -510,8 +510,8 @@
                     "workspaceCacheLimit": 90,
                     "runtimes": [
                         {
-                            "name": "JavaSE-17",
-                            "path": "static/vscode-java/extension/jre/17.0.8.1-linux-x86_64",
+                            "name": "JavaSE-21",
+                            "path": "static/vscode-java/extension/jre/21.0.7-linux-x86_64",
                             "default": true
                         }
                     ]
@@ -535,7 +535,7 @@
                         "version": null,
                         "home": "abs(static/gradle-7.3.3)",
                         "java": {
-                            "home": "abs(static/launch_jres/17.0.6-linux-x86_64)"
+                            "home": "abs(static/launch_jres/21.0.7-linux-x86_64)"
                         },
                         "offline": {
                             "enabled": false

--- a/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
+++ b/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
@@ -9,53 +9,53 @@
     },
     "vscode-java": {
         "darwin-arm64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-arm64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-darwin-arm64-1.42.0-561.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java"
         },
         "osx-arm64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-darwin-arm64-1.42.0-561.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java",
-            "jre_home_path": "extension/jre/17.0.8.1-macosx-x86_64",
-            "jre_path": "extension/jre/17.0.8.1-macosx-x86_64/bin/java",
-            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
-            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jre_home_path": "extension/jre/21.0.7-macosx-aarch64",
+            "jre_path": "extension/jre/21.0.7-macosx-aarch64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.36.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.7.0.v20250424-1814.jar",
             "jdtls_readonly_config_path": "extension/server/config_mac_arm"
         },
         "osx-x64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-darwin-x64-1.42.0-561.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java",
-            "jre_home_path": "extension/jre/17.0.8.1-macosx-x86_64",
-            "jre_path": "extension/jre/17.0.8.1-macosx-x86_64/bin/java",
-            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
-            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jre_home_path": "extension/jre/21.0.7-macosx-x86_64",
+            "jre_path": "extension/jre/21.0.7-macosx-x86_64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.36.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.7.0.v20250424-1814.jar",
             "jdtls_readonly_config_path": "extension/server/config_mac"
         },
         "linux-arm64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@linux-arm64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-linux-arm64-1.42.0-561.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java"
         },
         "linux-x64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@linux-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-linux-x64-1.42.0-561.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java",
-            "jre_home_path": "extension/jre/17.0.8.1-linux-x86_64",
-            "jre_path": "extension/jre/17.0.8.1-linux-x86_64/bin/java",
-            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
-            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jre_home_path": "extension/jre/21.0.7-linux-x86_64",
+            "jre_path": "extension/jre/21.0.7-linux-x86_64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.36.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.7.0.v20250424-1814.jar",
             "jdtls_readonly_config_path": "extension/server/config_linux"
         },
         "win-x64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@win32-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-win32-x64-1.42.0-561.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java",
-            "jre_home_path": "extension/jre/17.0.8.1-win32-x86_64",
-            "jre_path": "extension/jre/17.0.8.1-win32-x86_64/bin/java.exe",
-            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
-            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jre_home_path": "extension/jre/21.0.7-win32-x86_64",
+            "jre_path": "extension/jre/21.0.7-win32-x86_64/bin/java.exe",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.36.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.7.0.v20250424-1814.jar",
             "jdtls_readonly_config_path": "extension/server/config_win"
         }
     },

--- a/src/multilspy/language_servers/kotlin_language_server/runtime_dependencies.json
+++ b/src/multilspy/language_servers/kotlin_language_server/runtime_dependencies.json
@@ -8,34 +8,34 @@
     },
     "java": {
         "win-x64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@win32-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-win32-x64-1.42.0-561.vsix",
             "archiveType": "zip",
-            "java_home_path": "extension/jre/17.0.8.1-win32-x86_64",
-            "java_path": "extension/jre/17.0.8.1-win32-x86_64/bin/java.exe"
+            "java_home_path": "extension/jre/21.0.7-win32-x86_64",
+            "java_path": "extension/jre/21.0.7-win32-x86_64/bin/java.exe"
         },
         "linux-x64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@linux-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-linux-x64-1.42.0-561.vsix",
             "archiveType": "zip",
-            "java_home_path": "extension/jre/17.0.8.1-linux-x86_64", 
-            "java_path": "extension/jre/17.0.8.1-linux-x86_64/bin/java"
+            "java_home_path": "extension/jre/21.0.7-linux-x86_64", 
+            "java_path": "extension/jre/21.0.7-linux-x86_64/bin/java"
         },
         "linux-arm64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@linux-arm64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-linux-arm64-1.42.0-561.vsix",
             "archiveType": "zip",
-            "java_home_path": "extension/jre/17.0.8.1-linux-aarch64",
-            "java_path": "extension/jre/17.0.8.1-linux-aarch64/bin/java"
+            "java_home_path": "extension/jre/21.0.7-linux-aarch64",
+            "java_path": "extension/jre/21.0.7-linux-aarch64/bin/java"
         },
         "osx-x64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-darwin-x64-1.42.0-561.vsix",
             "archiveType": "zip",
-            "java_home_path": "extension/jre/17.0.8.1-macosx-x86_64",
-            "java_path": "extension/jre/17.0.8.1-macosx-x86_64/bin/java"
+            "java_home_path": "extension/jre/21.0.7-macosx-x86_64",
+            "java_path": "extension/jre/21.0.7-macosx-x86_64/bin/java"
         },
         "osx-arm64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-arm64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-darwin-arm64-1.42.0-561.vsix",
             "archiveType": "zip",
-            "java_home_path": "extension/jre/17.0.8.1-macosx-aarch64",
-            "java_path": "extension/jre/17.0.8.1-macosx-aarch64/bin/java"
+            "java_home_path": "extension/jre/21.0.7-macosx-aarch64",
+            "java_path": "extension/jre/21.0.7-macosx-aarch64/bin/java"
         }
     }
 }

--- a/test/resources/repos/java/test_repo/pom.xml
+++ b/test/resources/repos/java/test_repo/pom.xml
@@ -8,7 +8,22 @@
     <packaging>jar</packaging>
     <name>Java Test Repo</name>
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
     </properties>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## Summary
This PR updates the project to support Java 21, making it compatible with the latest Java LTS version while maintaining backward compatibility.

## Changes Made
- Updated Eclipse JDTLS to vscode-java v1.42.0 with embedded Java 21.0.7 JRE
- Updated Kotlin language server dependencies to use Java 21 runtime
- Updated test Maven project configuration for Java 21 compilation
- Updated runtime configuration from JavaSE-17 to JavaSE-21
- Updated dependency versions:
  - lombok: 1.18.30 → 1.18.36
  - Eclipse launcher: 1.6.500 → 1.7.0

## Test Plan
- [x] All Java multilspy tests pass
- [x] Test Maven project compiles successfully with Java 21
- [x] Eclipse JDTLS server starts correctly with Java 21 runtime
- [x] Language server functionality verified through test suite

🤖 Generated with [Claude Code](https://claude.ai/code)