### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Use the official Python image for the base image.
 FROM python:3.11-slim
+SHELL ["/bin/bash", "-c"]
 
 # Set environment variables to make Python print directly to the terminal and avoid .pyc files.
 ENV PYTHONUNBUFFERED 1
@@ -26,12 +27,13 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 # Set the working directory
 WORKDIR /workspaces/serena
 
-# Copy the pyproject.toml file into the image.
+# Copy required files into the image
 COPY pyproject.toml /workspaces/serena/
+COPY README.md /workspaces/serena/
 
 # Create virtual environment and install dependencies
 RUN uv venv
-RUN source .venv/bin/activate
+RUN . .venv/bin/activate
 RUN uv pip install --all-extras -r pyproject.toml -e .
 ENV PATH="/workspaces/serena/.venv/bin:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     build-essential \
     git \
+    ssh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pipx.


### PR DESCRIPTION
The current `Dockerfile` fails to build at steps:

```
RUN source .venv/bin/activate
RUN uv pip install --all-extras -r pyproject.toml -e .
```

Missing `source`, and missing `README.md`.


This PR:

-  Changes the shell to bash to allow usage of the builtin `source`
- Adds the missing file

Additionally, it:

- Installs ssh to allow git+ssh