### PR TITLE
Gitignore handling and read-edit tools - important fixes and improvments

### DIFF
--- a/src/multilspy/multilspy_config.py
+++ b/src/multilspy/multilspy_config.py
@@ -82,8 +82,6 @@ class MultilspyConfig:
     start_independent_lsp_process: bool = True
     ignored_paths: list[str] = field(default_factory=list)
     """Paths, dirs or glob-like patterns. The matching will follow the same logic as for .gitignore entries"""
-    gitignore_file_content: str | None = None
-    """Optional content of the gitignore file. If passed, will be used in addition to the explicitly passed ignored_paths for deciding which paths to ignore."""
 
     @classmethod
     def from_dict(cls, env: dict):


### PR DESCRIPTION
1. Use all gitignore files in SerenaAgent, not just top level
2. Listing and file finding tools now can find all non-ignored files (previously they would only find code files)
3. Read and edit tools will raise an error on attempting to operate on an ignored file or a path outside the project root

Closes #137 