### PR TITLE
Add diagnostics tool with language server support

### DIFF
--- a/src/multilspy/language_servers/gopls/initialize_params.json
+++ b/src/multilspy/language_servers/gopls/initialize_params.json
@@ -10,6 +10,10 @@
                 "didSave": true,
                 "dynamicRegistration": true
             },
+            "diagnostic": {
+                "dynamicRegistration": true,
+                "relatedDocumentSupport": false
+            },
             "completion": {
                 "dynamicRegistration": true,
                 "completionItem": {
@@ -34,7 +38,8 @@
             "workspaceFolders": true,
             "didChangeConfiguration": {
                 "dynamicRegistration": true
-            }
+            },
+            "diagnostics": {"refreshSupport": true}
         }
     },
     "workspaceFolders": [

--- a/src/multilspy/language_servers/intelephense/initialize_params.json
+++ b/src/multilspy/language_servers/intelephense/initialize_params.json
@@ -10,6 +10,10 @@
                 "didSave": true,
                 "dynamicRegistration": true
             },
+            "diagnostic": {
+                "dynamicRegistration": true,
+                "relatedDocumentSupport": false
+            },
             "completion": {
                 "dynamicRegistration": true,
                 "completionItem": {
@@ -24,7 +28,8 @@
             "workspaceFolders": true,
             "didChangeConfiguration": {
                 "dynamicRegistration": true
-            }
+            },
+            "diagnostics": {"refreshSupport": true}
         }
     },
     "workspaceFolders": [

--- a/src/multilspy/language_servers/pyright_language_server/pyright_server.py
+++ b/src/multilspy/language_servers/pyright_language_server/pyright_server.py
@@ -68,6 +68,7 @@ class PyrightServer(LanguageServer):
                     "workspaceEdit": {"documentChanges": True},
                     "didChangeConfiguration": {"dynamicRegistration": True},
                     "didChangeWatchedFiles": {"dynamicRegistration": True},
+                    "diagnostics": {"refreshSupport": True},
                     "symbol": {
                         "dynamicRegistration": True,
                         "symbolKind": {
@@ -133,6 +134,7 @@ class PyrightServer(LanguageServer):
                     "onTypeFormatting": {"dynamicRegistration": True},
                     "rename": {"dynamicRegistration": True},
                     "publishDiagnostics": {"relatedInformation": True},
+                    "diagnostic": {"dynamicRegistration": True, "relatedDocumentSupport": False},
                 },
             },
             "workspaceFolders": [

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -1398,6 +1398,22 @@ class FindReferencingSymbolsTool(Tool):
         return self._limit_length(result, max_answer_chars)
 
 
+class DiagnosticsTool(Tool):
+    """Retrieve diagnostics for a file from the language server."""
+
+    def apply(self, relative_path: str, new_only: bool = False) -> str:
+        """Get diagnostics for the given file.
+
+        :param relative_path: path to the file within the project
+        :param new_only: if True, return only diagnostics that changed since the last call
+        :return: JSON list of diagnostics
+        """
+        self.agent.validate_relative_path(relative_path)
+        diags = self.language_server.request_diagnostics(relative_path, new_only=new_only)
+        result = json.dumps(diags)
+        return result
+
+
 class ReplaceSymbolBodyTool(Tool, ToolMarkerCanEdit):
     """
     Replaces the full definition of a symbol.

--- a/src/serena/resources/config/contexts/ide-assistant.yml
+++ b/src/serena/resources/config/contexts/ide-assistant.yml
@@ -10,3 +10,4 @@ excluded_tools:
   - replace_lines
   - insert_at_line
   - execute_shell_command
+  - diagnostics

--- a/test/multilspy/test_diagnostics.py
+++ b/test/multilspy/test_diagnostics.py
@@ -1,0 +1,33 @@
+import os
+
+import pytest
+
+from multilspy.language_server import SyncLanguageServer
+from multilspy.multilspy_config import Language
+
+FILE_MAP = {
+    Language.PYTHON: os.path.join("test_repo", "name_collisions.py"),
+    Language.GO: "main.go",
+    Language.JAVA: os.path.join("src", "main", "java", "test_repo", "Main.java"),
+    Language.RUST: os.path.join("src", "main.rs"),
+    Language.TYPESCRIPT: "index.ts",
+    Language.PHP: "index.php",
+}
+
+
+@pytest.mark.parametrize(
+    "language_server,language",
+    [
+        pytest.param(Language.PYTHON, Language.PYTHON, marks=pytest.mark.python),
+        pytest.param(Language.GO, Language.GO, marks=pytest.mark.go),
+        pytest.param(Language.JAVA, Language.JAVA, marks=pytest.mark.java),
+        pytest.param(Language.RUST, Language.RUST, marks=pytest.mark.rust),
+        pytest.param(Language.TYPESCRIPT, Language.TYPESCRIPT, marks=pytest.mark.typescript),
+        pytest.param(Language.PHP, Language.PHP, marks=pytest.mark.php),
+    ],
+    indirect=["language_server"],
+)
+def test_request_diagnostics(language_server: SyncLanguageServer, language: Language) -> None:
+    file_path = FILE_MAP[language]
+    diags = language_server.request_diagnostics(file_path)
+    assert isinstance(diags, list)


### PR DESCRIPTION
## Summary
- extend language servers with `diagnostics` capability
- implement async `request_diagnostics` and sync wrapper
- add `DiagnosticsTool` and disable it in the ide-assistant context
- test diagnostics for all languages and agent
- format diagnostics test

## Testing
- `uv run poe format`
- `uv run poe type-check`
- `uv run poe test` *(fails: blocked download for VisualStudioExptTeam.gallery.vsassets.io)*

------
https://chatgpt.com/codex/tasks/task_e_684bf959d4208320a81341f8511c2795