### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -20,7 +20,7 @@ The following tasks should generally be executed using `uv run poe <task_name>`.
         "isolated_process: test runs with process isolated agent",
     ]
    ```
-  By default, `uv run poe test` uses the markes set in the env var `PYTEST_MARKERS`, or, if it unset, uses `-m "not java and not rust and not isolated process"`.
+  By default, `uv run poe test` uses the markers set in the env var `PYTEST_MARKERS`, or, if it unset, uses `-m "not java and not rust and not isolated process"`.
   You can override this behavior by simply passing the `-m` option to `uv run poe test`, e.g. `uv run poe test -m "python or go"`.
 
 For finishing a task, make sure format, type-check and test pass! Run them at the end of the task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Also some improvements to prompts.
 
 # 2025-05-21
 
-**Signficant improvement in symbol finding!**
+**Significant improvement in symbol finding!**
 
 * Serena core:
     * `FindSymbolTool` now can look for symbols by specifying paths to them, not just the symbol name

--- a/lessons_learned.md
+++ b/lessons_learned.md
@@ -56,7 +56,7 @@ When developing the `ReplaceRegexTool` we were initially not able to make Claude
 examples nor explicit instructions helped. It was only after adding 
 
 ```
-IMPORTANT: REMEMBER TO USE WILDCARDS WEHEN APPROPRIATE! I WILL BE VERY UNHAPPY IF YOU WRITE LONG REGEXES WITHOUT USING WILDCARDS INSTEAD!
+IMPORTANT: REMEMBER TO USE WILDCARDS WHEN APPROPRIATE! I WILL BE VERY UNHAPPY IF YOU WRITE LONG REGEXES WITHOUT USING WILDCARDS INSTEAD!
 ```
 
 to the initial instructions and to the tool description that Claude finally started following the instructions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,3 +265,10 @@ markers = [
     "snapshot: snapshot tests for symbolic editing operations",
     "isolated_process: test runs with process isolated agent",
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg,*.lock,*.min.*'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/src/multilspy/lsp_protocol_handler/lsp_constants.py
+++ b/src/multilspy/lsp_protocol_handler/lsp_constants.py
@@ -31,7 +31,7 @@ class LSPConstants:
     # key used to represent the language a document is in - "java", "csharp", etc.
     LANGUAGE_ID = "languageId"
 
-    # key used to represent the version of a document (a shared value betwen the client and server)
+    # key used to represent the version of a document (a shared value between the client and server)
     VERSION = "version"
 
     # key used to represent the text of a document being sent from the client to the server on open

--- a/src/multilspy/lsp_protocol_handler/lsp_types.py
+++ b/src/multilspy/lsp_protocol_handler/lsp_types.py
@@ -2243,7 +2243,7 @@ class SignatureHelp(TypedDict):
     range of `signatures` the value defaults to zero or is ignored if
     the `SignatureHelp` has no signatures.
 
-    Whenever possible implementors should make an active decision about
+    Whenever possible implementers should make an active decision about
     the active signature and shouldn't rely on a default value.
 
     In future version of the protocol this property might become

--- a/src/multilspy/multilspy_logger.py
+++ b/src/multilspy/multilspy_logger.py
@@ -32,7 +32,7 @@ class MultilspyLogger:
 
     def log(self, debug_message: str, level: int, sanitized_error_message: str = "", stacklevel: int = 2) -> None:
         """
-        Log the debug and santized messages using the logger
+        Log the debug and sanitized messages using the logger
         """
 
         debug_message = debug_message.replace("'", '"').replace("\n", " ")

--- a/src/multilspy/multilspy_utils.py
+++ b/src/multilspy/multilspy_utils.py
@@ -109,7 +109,7 @@ class PathUtils:
             from urllib.parse import urlparse, unquote
             from urllib.request import url2pathname
         except ImportError:
-            # backwards compatability
+            # backwards compatibility
             from urlparse import urlparse
             from urllib import unquote, url2pathname
         parsed = urlparse(uri)
@@ -168,12 +168,12 @@ class FileUtils:
             response = requests.get(url, stream=True, timeout=60)
             if response.status_code != 200:
                 logger.log(f"Error downloading file '{url}': {response.status_code} {response.text}", logging.ERROR)
-                raise MultilspyException("Error downoading file.")
+                raise MultilspyException("Error downloading file.")
             with open(target_path, "wb") as f:
                 shutil.copyfileobj(response.raw, f)
         except Exception as exc:
             logger.log(f"Error downloading file '{url}': {exc}", logging.ERROR)
-            raise MultilspyException("Error downoading file.") from None
+            raise MultilspyException("Error downloading file.") from None
 
     @staticmethod
     def download_and_extract_archive(logger: MultilspyLogger, url: str, target_path: str, archive_type: str) -> None:

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -1681,7 +1681,7 @@ class ReplaceSymbolBodyTool(Tool, ToolMarkerCanEdit):
         as the tool will automatically add the indentation of the original symbol to each line. For example,
         for replacing a method in python, you can just write (using the standard python indentation):
         body="def my_method_replacement(self, ...):\n    first_line\n    second_line...". So each line after the first line only has
-        an indentation of 4 (the indentation relative to the first characted),
+        an indentation of 4 (the indentation relative to the first character),
         since the additional indentation will be added by the tool. Same for more deeply nested
         cases. You always only need to write the relative indentation to the first character of the first line, and that
         in turn should not have any indentation.
@@ -1718,7 +1718,7 @@ class InsertAfterSymbolTool(Tool, ToolMarkerCanEdit):
 
         :param name_path: for finding the symbol to insert after, same logic as in the `find_symbol` tool.
         :param relative_path: the relative path to the file containing the symbol
-        :param body: the body/content to be inserted. Important: the insterted code will automatically have the
+        :param body: the body/content to be inserted. Important: the inserted code will automatically have the
             same indentation as the symbol's body, so you do not need to provide any additional indentation.
         """
         self.symbol_manager.insert_after_symbol(
@@ -1748,7 +1748,7 @@ class InsertBeforeSymbolTool(Tool, ToolMarkerCanEdit):
 
         :param name_path: for finding the symbol to insert before, same logic as in the `find_symbol` tool.
         :param relative_path: the relative path to the file containing the symbol
-        :param body: the body/content to be inserted. Important: the insterted code will automatically have the
+        :param body: the body/content to be inserted. Important: the inserted code will automatically have the
             same indentation as the symbol's body, so you do not need to provide any additional indentation.
         """
         self.symbol_manager.insert_before_symbol(
@@ -1828,7 +1828,7 @@ class ReplaceRegexTool(Tool, ToolMarkerCanEdit):
         Always try to use wildcards to avoid specifying the exact content of the code to be replaced,
         especially if it spans several lines.
 
-        IMPORTANT: REMEMBER TO USE WILDCARDS WEHEN APPROPRIATE! I WILL BE VERY UNHAPPY IF YOU WRITE LONG REGEXES WITHOUT USING WILDCARDS INSTEAD!
+        IMPORTANT: REMEMBER TO USE WILDCARDS WHEN APPROPRIATE! I WILL BE VERY UNHAPPY IF YOU WRITE LONG REGEXES WITHOUT USING WILDCARDS INSTEAD!
 
         :param relative_path: the relative path to the file
         :param regex: a Python-style regular expression, matches of which will be replaced.

--- a/src/serena/resources/config/modes/editing.yml
+++ b/src/serena/resources/config/modes/editing.yml
@@ -27,7 +27,7 @@ prompt: |
   you are replacing or inserting above or below. In particular, keep in mind the description of the `replace_symbol_body` tool. If you want to add some new code at the end of the file, you should
   use the `insert_after_symbol` tool with the last top-level symbol in the file. If you want to add an import, often a good strategy is to use
   `insert_before_symbol` with the first top-level symbol in the file.
-  You can unterstand relationships between symbols by using the `find_referencing_symbols` tool. If not explicitly requested otherwise by a user,
+  You can understand relationships between symbols by using the `find_referencing_symbols` tool. If not explicitly requested otherwise by a user,
   you make sure that when you edit a symbol, it is either done in a backward-compatible way, or you find and adjust the references as needed.
   The `find_referencing_symbols` tool will give you code snippets around the references, as well as symbolic information.
   You will generally be able to use the info from the snippets and the regex-based approach to adjust the references as well.
@@ -52,7 +52,7 @@ prompt: |
     1. If the snippet to be replaced is likely to be unique within the file, you perform the replacement by directly using the escaped version of the 
        original.
     2. If the snippet is probably not unique, and you want to replace all occurrences, you use the `allow_multiple_occurrences` flag.
-    3. If the snippet is not unique, and you want to replace a specific occurence, you make use of the code surrounding the snippet
+    3. If the snippet is not unique, and you want to replace a specific occurrence, you make use of the code surrounding the snippet
        to extend the regex with content before/after such that the regex will have exactly one match.
     4. You generally assume that a snippet is unique, knowing that the tool will return an error on multiple matches. You only read more file content
        (for crafvarting a more specific regex) if such a failure unexpectedly occurs. 
@@ -102,7 +102,7 @@ prompt: |
 
   Generally, I remind you that you rely on the regex tool with providing you the correct feedback, no need for more verification!
 
-  IMPORTANT: REMEMBER TO USE WILDCARDS WEHEN APPROPRIATE! I WILL BE VERY UNHAPPY IF YOU WRITE LONG REGEXES WITHOUT USING WILDCARDS INSTEAD!
+  IMPORTANT: REMEMBER TO USE WILDCARDS WHEN APPROPRIATE! I WILL BE VERY UNHAPPY IF YOU WRITE LONG REGEXES WITHOUT USING WILDCARDS INSTEAD!
 excluded_tools: 
  - replace_lines
  - insert_at_line

--- a/src/serena/resources/config/prompt_templates/system_prompt.yml
+++ b/src/serena/resources/config/prompt_templates/system_prompt.yml
@@ -39,7 +39,7 @@ prompts:
     use `find_symbol` with the name path `Foo/__init__` and `include_body=True`. If you don't know yet which methods in `Foo` you need to read or edit,
     you can use `find_symbol` with the name path `Foo`, `include_body=False` and `depth=1` to get all (top-level) methods of `Foo` before proceeding
     to read the desired methods with `include_body=True`
-    You can unterstand relationships between symbols by using the `find_referencing_symbols` tool.
+    You can understand relationships between symbols by using the `find_referencing_symbols` tool.
 
     You generally have access to memories and it may be useful for you to read them, but also only if they help you
     to answer the question or complete the task. You can infer which memories are relevant to the current task by reading

--- a/src/serena/symbol.py
+++ b/src/serena/symbol.py
@@ -492,7 +492,7 @@ class SymbolManager:
         """
         :param lang_server: the language server to use for symbol retrieval as well as editing operations.
         :param agent: the agent to use (only needed for marking files as modified). You can pass None if you don't
-            need an agent to be avare of file modifications performed by the symbol manager.
+            need an agent to be aware of file modifications performed by the symbol manager.
         """
         self._lang_server = lang_server
         self.agent = agent

--- a/test/serena/test_symbol.py
+++ b/test/serena/test_symbol.py
@@ -107,7 +107,7 @@ class TestSymbolNameMatching:
                 "bar/foo", ["mod", "bar", "foobar"], True, True, id="R: 'bar/foo' matches ['mod', 'bar', 'foobar'] as substring (suffix)"
             ),
             pytest.param("bar/foo", ["bar", "bazfoo"], True, True, id="R: 'bar/foo' matches ['bar', 'bazfoo'] as substring"),
-            pytest.param("bar/fo", ["bar", "foo"], True, True, id="R: 'bar/fo' matches ['bar', 'foo'] as substring"),
+            pytest.param("bar/fo", ["bar", "foo"], True, True, id="R: 'bar/fo' matches ['bar', 'foo'] as substring"),  # codespell:ignore
             pytest.param("bar/foo", ["bar", "baz"], True, False, id="R: 'bar/foo' does not match ['bar', 'baz'] (last no substr)"),
             pytest.param(
                 "bar/foo", ["baz", "foobar"], True, False, id="R: 'bar/foo' does not match ['baz', 'foobar'] (first part mismatch)"
@@ -148,7 +148,7 @@ class TestSymbolNameMatching:
             # Substring matches (is_substring_match=True)
             pytest.param("/bar/foo", ["bar", "foobar"], True, True, id="A: '/bar/foo' matches ['bar', 'foobar'] as substring"),
             pytest.param("/bar/foo", ["bar", "bazfoo"], True, True, id="A: '/bar/foo' matches ['bar', 'bazfoo'] as substring"),
-            pytest.param("/bar/fo", ["bar", "foo"], True, True, id="A: '/bar/fo' matches ['bar', 'foo'] as substring"),
+            pytest.param("/bar/fo", ["bar", "foo"], True, True, id="A: '/bar/fo' matches ['bar', 'foo'] as substring"),  # codespell:ignore
             pytest.param("/bar/foo", ["bar", "baz"], True, False, id="A: '/bar/foo' does not match ['bar', 'baz'] (last no substr)"),
             pytest.param(
                 "/bar/foo", ["baz", "foobar"], True, False, id="A: '/bar/foo' does not match ['baz', 'foobar'] (first part mismatch)"


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.