### PR TITLE
ci: publish ARM-based Docker image too

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,7 @@ jobs:
       with:
         context: .
         target: production
+        platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
@@ -61,6 +62,7 @@ jobs:
       with:
         context: .
         target: development
+        platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Without ARM support, this is harder to use on MacBook Pros.

I copied the `platforms` tag example from the Docker docs. https://docs.docker.com/build/ci/github-actions/multi-platform/

Closes https://github.com/oraios/serena/issues/246