### PR TITLE
Add pytest-xdist for parallel tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
   "mypy>=1.4.1",
   "poethepoet>=0.20.0",
   "pytest>=8.0.2",
+  "pytest-xdist>=3.5.0",
   "ruff>=0.0.285",
   "toml-sort>=0.24.2",
   "types-pyyaml>=6.0.12.20241230",
@@ -116,7 +117,7 @@ PYDEVD_DISABLE_FILE_VALIDATION = "1"
 # Uses PYTEST_MARKERS env var for default markers
 # For custom markers, one can either adjust the env var or just use -m option in the command line,
 # as the second -m option will override the first one.
-test = "pytest test -vv -m \"${PYTEST_MARKERS:-not java and not rust and not isolated_process}\""
+test = "pytest test -n auto -vv -m \"${PYTEST_MARKERS:-not java and not rust and not isolated_process}\""
 _black_check = "black --check src scripts test"
 _ruff_check = "ruff check src scripts test"
 _black_format = "black src scripts test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ PYDEVD_DISABLE_FILE_VALIDATION = "1"
 # Uses PYTEST_MARKERS env var for default markers
 # For custom markers, one can either adjust the env var or just use -m option in the command line,
 # as the second -m option will override the first one.
-test = "pytest test -n auto -vv -m \"${PYTEST_MARKERS:-not java and not rust and not isolated_process}\""
+test = "pytest test -vv -m \"${PYTEST_MARKERS:-not java and not rust and not isolated_process}\""
 _black_check = "black --check src scripts test"
 _ruff_check = "ruff check src scripts test"
 _black_format = "black src scripts test"


### PR DESCRIPTION
Just that. Uses `-n auto` in the test suite for max speed. Should halve test time on CI given that GH uses 2 cores in their runners. But it's mostly nicer for local testing