### PR TITLE
fix(solargraph): Fix ImportError in Ruby language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Fixes:
 * Fix `ReplaceSymbolBodyTool` changing whitespace before/after the symbol
 * Fix repository indexing not following links and catch exceptions during indexing, allowing indexing
   to continue even if unexpected errors occur for individual files.
+* Fix `ImportError` in Ruby language server.
 
 # 2025-06-20
 

--- a/src/solidlsp/language_servers/solargraph/solargraph.py
+++ b/src/solidlsp/language_servers/solargraph/solargraph.py
@@ -10,7 +10,7 @@ import pathlib
 import stat
 import subprocess
 import threading
-from typing import override
+from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig


### PR DESCRIPTION
This change resolves an `ImportError` that prevented the Ruby language server (Solargraph) from starting correctly.
```
INFO  2025-06-28 19:01:01,012 [SerenaAgentExecutor_0] serena.agent:create_ls_for_project:686 - Creating language server instance for /Users/jonathan.mohrbacher/Code/fulfillment-engine.
ERROR 2025-06-28 19:01:01,013 [SerenaAgentExecutor_0] serena.agent:task:1404 - Error executing tool: cannot import name 'override' from 'typing' (/opt/homebrew/Cellar/python@3.11/3.11.12_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/typing.py). Consider restarting the language server to solve this (especially, if it's a timeout of a symbolic operation)
Traceback (most recent call last):
  File "/Users/jonathan.mohrbacher/.cache/uv/archive-v0/36vUvcO5zneVXnmapsJA7/lib/python3.11/site-packages/serena/agent.py", line 1395, in task
    self.agent.reset_language_server()
  File "/Users/jonathan.mohrbacher/.cache/uv/archive-v0/36vUvcO5zneVXnmapsJA7/lib/python3.11/site-packages/serena/agent.py", line 1139, in reset_language_server
    self.language_server = create_ls_for_project(
                           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jonathan.mohrbacher/.cache/uv/archive-v0/36vUvcO5zneVXnmapsJA7/lib/python3.11/site-packages/serena/agent.py", line 687, in create_ls_for_project
    return SolidLanguageServer.create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jonathan.mohrbacher/.cache/uv/archive-v0/36vUvcO5zneVXnmapsJA7/lib/python3.11/site-packages/solidlsp/ls.py", line 155, in create
    from solidlsp.language_servers.solargraph.solargraph import Solargraph
  File "/Users/jonathan.mohrbacher/.cache/uv/archive-v0/36vUvcO5zneVXnmapsJA7/lib/python3.11/site-packages/solidlsp/language_servers/solargraph/solargraph.py", line 13, in 
    from typing import override
ImportError: cannot import name 'override' from 'typing' (/opt/homebrew/Cellar/python@3.11/3.11.12_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/typing.py)
```

The issue was caused by an incorrect import for the `@override` decorator. This has been corrected to use the existing `overrides` package, ensuring the language server can be initialized without error.

I've tested this change locally and it works.