### PR TITLE
Return system prompt even if language server isn't ready

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -2407,7 +2407,7 @@ class GetCurrentConfigTool(Tool):
         return self.agent.get_current_config_overview()
 
 
-class InitialInstructionsTool(Tool):
+class InitialInstructionsTool(Tool, ToolMarkerDoesNotRequireActiveProject):
     """
     Gets the initial instructions for the current project.
     Should only be used in settings where the system prompt cannot be set,


### PR DESCRIPTION
An AI pointed out to me that the `initial_instructions` endpoint that return the system prompt apparently blocks if the language server is not ready, but it shouldn't because the two have nothing to do with each other.

I'm not totally sure of this change. It's a byproduct of AI advice for another change that I'm working on. I can't tell if the AI is telling the truth or just doubling down on a lie. But I'm offering this up as PR because it feels plausible. But I'll happily close this out if you disagree 👍 

The AI's explanation:

> ### 2. Is the `InitialInstructionsTool` change necessary?
>
> **Short Answer:** Yes, this change is correct and should be kept for robustness, even though it didn't fix this specific hang.
>
> **Detailed Explanation:**
> The `SerenaAgent` uses a single-threaded executor to run tools sequentially. This prevents multiple tools from trying to edit files at the same time. When you make a request, two tasks are queued:
> 1.  `init_language_server` (if a project is active)
> 2.  `initial_instructions` (your tool call)
>
> The problem you were experiencing was that the `init_language_server` task was hanging indefinitely, which blocked the `initial_instructions` task from ever starting.
>
> By marking `InitialInstructionsTool` with `ToolMarkerDoesNotRequireActiveProject`, you are telling the agent's internal logic that this specific tool does not need the language server to be running. This is a correct and important piece of information. It decouples the tool from the state of the language server.
>
> While it didn't fix the hang (because the hang was *inside* the `init_language_server` task itself), it's a critical change for making the agent more resilient. If any other language server had a problem during initialization, this change would prevent it from deadlocking the entire agent for simple requests like getting instructions. You should absolutely keep it.
