### PR TITLE
Pass initialization options to Kotlin language server

### DIFF
--- a/src/solidlsp/language_servers/kotlin_language_server/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server/kotlin_language_server.py
@@ -206,4 +206,5 @@ class KotlinLanguageServer(SolidLanguageServer):
         assert "semanticTokensProvider" in capabilities, "Server must support semantic tokens"
 
         self.server.notify.initialized({})
+        self.server.notify.workspace_did_change_configuration({"settings": initialize_params.get("initializationOptions", {})})
         self.completions_available.set()


### PR DESCRIPTION
Just like in https://github.com/oraios/serena/pull/266, this PR offers up a change that an AI pointed out to me while we were working on something else. Apparently, Serena's Kotlin language server client code doesn't pass its initialization options to the Kotlin language server, but it should.

Like I said in the other PR, I'm not totally sure of this change. I can't tell if the AI is telling the truth or just doubling down on a lie. But I'm offering this up as PR because it feels plausible. But I'll happily close this out if you disagree 👍

I've tested this locally.

After showing it both this repo's code and the code in the Kotlin language server, I asked the AI if I should keep this change, and it said:

> **Short Answer:** Yes, it is absolutely essential. Removing it would break the server's ability to use any configuration provided by Serena.
>
> **Detailed Explanation:**
>
> To understand why, we need to look at how the standard language server processes its settings. The key files are `KotlinLanguageServer.kt` and `KotlinWorkspaceService.kt`.
>
> 1.  **`KotlinLanguageServer.kt` (The `initialize` method):**
>     When Serena sends the `initialize` request, this method is called. Looking at its implementation, you can see it only handles a few high-level setup tasks:
>     *   It sets up server capabilities (hover, completion, etc.).
>     *   It reads `storagePath` from `initializationOptions`.
>     *   It checks client capabilities to enable snippets.
>     *   It adds workspace folders to the classpath.
>
>     Crucially, it **does not** process the detailed configuration options like compiler settings, diagnostics levels, or formatting styles from the `initializationOptions`.
>
> 2.  **`KotlinWorkspaceService.kt` (The `didChangeConfiguration` method):**
>     This is where the real configuration logic lives. This method is the handler for the `workspace/didChangeConfiguration` notification. Its code explicitly does the following:
>     *   It receives the settings payload (`params.settings`).
>     *   It parses the JSON object for keys like `"kotlin"`, `"compiler"`, `"diagnostics"`, `"formatting"`, etc.
>     *   It updates the server's internal `config` object with these values.
>     *   It then calls methods like `cp.updateCompilerConfiguration()` to make the changes take effect.
>
> **Conclusion:**
>
> The standard `fwcd/kotlin-language-server` follows a common LSP pattern: the `initialize` request establishes the connection and capabilities, but the actual, detailed configuration is applied via a subsequent `workspace/didChangeConfiguration` notification.
>
> Serena passes all its settings inside the `initializationOptions`. For the server to actually *use* those settings, Serena *must* send the `workspace_did_change_configuration` notification containing that same payload. Without this step, the language server would start up but would ignore all of Serena's settings and operate with its own defaults, which is not what we want.
>
> Therefore, the line `self.server.notify.workspace_did_change_configuration(...)` is not just beneficial; it is **required** for the standard `fwcd/kotlin-language-server` to work as intended with Serena. It should absolutely be kept.