### PR TITLE
Simplify & improve Serena configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ This and other settings can be adjusted in the [configuration](#configuration) a
    cd serena
    ```
 2. Optionally create a config file from the template and adjust it according to your preferences.
+   You can either place it in your user directory (`~/.serena/serena_config.yml`) or into 
+   the Serena installation directory:
    ```shell
    cp src/serena/resources/serena_config.template.yml serena_config.yml
    ```
@@ -279,7 +281,11 @@ Run with parameter `--help` to get a list of available options.
 
 Serena's behavior (active tools and prompts as well as logging configuration, etc.) is configured in four places:
 
-1. The `serena_config.yml` for general settings that apply to all clients and projects
+1. The `serena_config.yml` for general settings that apply to all clients and projects.
+   Serena will look for this file in your user directory under `.serena/serena_config.yml`
+   or within the Serena installation directory.
+   If you do not explicitly create the file, it will be auto-generated in the former location
+   when you first run Serena.
 2. In the arguments passed to the `serena-mcp-server` in your client's config (see below), 
    which will apply to all sessions started by the respective client. In particular, the [context](#contexts) parameter
    should be set appropriately for Serena to be best adjusted to existing tools and capabilities of your client.

--- a/scripts/demo_run_tools.py
+++ b/scripts/demo_run_tools.py
@@ -8,19 +8,8 @@ from pprint import pprint
 from serena.agent import *
 from serena.constants import REPO_ROOT
 
-
-@dataclass
-class InMemorySerenaConfig(SerenaConfigBase):
-    """
-    In-memory implementation of Serena configuration with the GUI disabled.
-    """
-
-    gui_log_window_enabled: bool = False
-    web_dashboard: bool = False
-
-
 if __name__ == "__main__":
-    agent = SerenaAgent(project=REPO_ROOT, serena_config=InMemorySerenaConfig())
+    agent = SerenaAgent(project=REPO_ROOT, serena_config=SerenaConfig(gui_log_window_enabled=False, web_dashboard=False))
 
     # apply a tool
     find_refs_tool = agent.get_tool(FindReferencingSymbolsTool)

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -681,7 +681,9 @@ class SerenaAgent:
             if self.serena_config.web_dashboard_open_on_launch:
                 webbrowser.open(f"http://localhost:{port}/dashboard/index.html")
 
+        # log fundamental information
         log.info(f"Starting Serena server (version={serena_version()}, process id={os.getpid()}, parent process id={os.getppid()})")
+        log.info("Configuration file: %s", self.serena_config.config_file_path)
         log.info("Available projects: {}".format(", ".join(self.serena_config.project_names)))
 
         # create executor for starting the language server and running tools in another thread

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -287,8 +287,20 @@ class SerenaConfig:
 
     @classmethod
     def _determine_config_file_path(cls) -> str:
-        config_file = cls.CONFIG_FILE_DOCKER if is_running_in_docker() else cls.CONFIG_FILE
-        return os.path.join(REPO_ROOT, config_file)
+        """
+        :return: the location where the Serena configuration file is stored/should be stored
+        """
+        if is_running_in_docker():
+            return os.path.join(REPO_ROOT, cls.CONFIG_FILE_DOCKER)
+        else:
+            candidates = [
+                str(Path.home() / SERENA_MANAGED_DIR_NAME / cls.CONFIG_FILE),
+                os.path.join(REPO_ROOT, cls.CONFIG_FILE),
+            ]
+            for candidate in candidates:
+                if os.path.exists(candidate):
+                    return candidate
+            return candidates[0]
 
     @classmethod
     def _load_commented_yaml(cls, config_file: str, generate_if_missing: bool = True) -> CommentedMap:

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -347,9 +347,9 @@ class SerenaConfig:
             project = Project.load(path)
             instance.projects.append(project)
 
-        # Force disable GUI in Docker environment
+        # set other configuration parameters
         if is_running_in_docker():
-            instance.gui_log_window_enabled = False
+            instance.gui_log_window_enabled = False  # not supported in Docker
         else:
             instance.gui_log_window_enabled = loaded_commented_yaml.get("gui_log_window", False)
         instance.log_level = loaded_commented_yaml.get("log_level", loaded_commented_yaml.get("gui_log_level", logging.INFO))

--- a/test/serena/test_serena_agent.py
+++ b/test/serena/test_serena_agent.py
@@ -1,29 +1,13 @@
 import json
 import os
 import time
-from dataclasses import dataclass
 
 import pytest
 
 import test.solidlsp.clojure as clj
-from serena.agent import FindReferencingSymbolsTool, FindSymbolTool, Project, ProjectConfig, SerenaAgent, SerenaConfigBase
+from serena.agent import FindReferencingSymbolsTool, FindSymbolTool, Project, ProjectConfig, SerenaAgent, SerenaConfig
 from solidlsp.ls_config import Language
 from test.conftest import get_repo_path
-
-
-@dataclass
-class SerenaConfigForTests(SerenaConfigBase):
-    """
-    In-memory implementation of Serena configuration with the GUI disabled.
-    """
-
-    gui_log_window_enabled: bool = False
-    web_dashboard: bool = False
-
-    def __post_init__(self):
-        # Initialize with empty projects list if not already set
-        if not hasattr(self, "projects") or self.projects is None:
-            self.projects = []
 
 
 @pytest.fixture
@@ -59,7 +43,7 @@ def serena_config():
             )
             test_projects.append(project)
 
-    config = SerenaConfigForTests()
+    config = SerenaConfig(gui_log_window_enabled=False, web_dashboard=False)
     config.projects = test_projects
     return config
 


### PR DESCRIPTION
* Simplify class structure, unifying `SerenaConfig` and `SerenaConfigBase` and removing all other specializations
* Remove contrived method `create_serena_config` and remove unnecessary constructor args of SerenaAgent
* Support additional configuration location `~/.serena/serena_config.yml` (new default)
* Some refactoring internal to `SerenaConfig` to improve clarity & simplicity