### PR TITLE
Refactor runtime dependency management

### DIFF
--- a/src/solidlsp/language_servers/clojure_lsp.py
+++ b/src/solidlsp/language_servers/clojure_lsp.py
@@ -14,6 +14,7 @@ from solidlsp.ls import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.ls_utils import FileUtils, PlatformUtils
+from .common import RuntimeDependency, RuntimeDependencyCollection
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 
@@ -44,32 +45,38 @@ class ClojureLSP(SolidLanguageServer):
     """
 
     clojure_lsp_releases = "https://github.com/clojure-lsp/clojure-lsp/releases/latest/download"
-    runtime_dependencies = [
-        {
-            "url": f"{clojure_lsp_releases}/clojure-lsp-native-macos-aarch64.zip",
-            "platformId": "osx-arm64",
-            "archiveType": "zip",
-            "binaryName": "clojure-lsp",
-        },
-        {
-            "url": f"{clojure_lsp_releases}/clojure-lsp-native-linux-aarch64.zip",
-            "platformId": "linux-arm64",
-            "archiveType": "zip",
-            "binaryName": "clojure-lsp",
-        },
-        {
-            "url": f"{clojure_lsp_releases}/clojure-lsp-native-linux-amd64.zip",
-            "platformId": "linux-x64",
-            "archiveType": "zip",
-            "binaryName": "clojure-lsp",
-        },
-        {
-            "url": f"{clojure_lsp_releases}/clojure-lsp-native-windows-amd64.zip",
-            "platformId": "win-x64",
-            "archiveType": "zip",
-            "binaryName": "clojure-lsp.exe",
-        },
-    ]
+    runtime_dependencies = RuntimeDependencyCollection(
+        [
+            RuntimeDependency(
+                id="clojure-lsp",
+                url=f"{clojure_lsp_releases}/clojure-lsp-native-macos-aarch64.zip",
+                platform_id="osx-arm64",
+                archive_type="zip",
+                binary_name="clojure-lsp",
+            ),
+            RuntimeDependency(
+                id="clojure-lsp",
+                url=f"{clojure_lsp_releases}/clojure-lsp-native-linux-aarch64.zip",
+                platform_id="linux-arm64",
+                archive_type="zip",
+                binary_name="clojure-lsp",
+            ),
+            RuntimeDependency(
+                id="clojure-lsp",
+                url=f"{clojure_lsp_releases}/clojure-lsp-native-linux-amd64.zip",
+                platform_id="linux-x64",
+                archive_type="zip",
+                binary_name="clojure-lsp",
+            ),
+            RuntimeDependency(
+                id="clojure-lsp",
+                url=f"{clojure_lsp_releases}/clojure-lsp-native-windows-amd64.zip",
+                platform_id="win-x64",
+                archive_type="zip",
+                binary_name="clojure-lsp.exe",
+            ),
+        ]
+    )
 
     def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
         """
@@ -92,21 +99,18 @@ class ClojureLSP(SolidLanguageServer):
     def _setup_runtime_dependencies(logger: LanguageServerLogger, config: LanguageServerConfig) -> str:
         """Setup runtime dependencies for clojure-lsp and return the command to start the server."""
         verify_clojure_cli()
-        platform_id = PlatformUtils.get_platform_id()
-
-        runtime_dependencies = [
-            dependency for dependency in ClojureLSP.runtime_dependencies if dependency["platformId"] == platform_id.value
-        ]
-        if len(runtime_dependencies) != 1:
-            raise RuntimeError(f"Could not find a suitable clojure-lsp runtime dependency for platform {platform_id.value}.")
-        dependency = runtime_dependencies[0]
+        deps = ClojureLSP.runtime_dependencies
+        dependency = deps.single_for_current_platform()
 
         clojurelsp_ls_dir = os.path.join(os.path.dirname(__file__), "static", "clojure-lsp")
-        clojurelsp_executable_path = os.path.join(clojurelsp_ls_dir, dependency["binaryName"])
+        clojurelsp_executable_path = deps.binary_path(clojurelsp_ls_dir)
         if not os.path.exists(clojurelsp_executable_path):
             os.makedirs(clojurelsp_ls_dir, exist_ok=True)
-            logger.log(f"Downloading and extracting clojure-lsp from {dependency['url']} to {clojurelsp_ls_dir}", logging.INFO)
-            FileUtils.download_and_extract_archive(logger, dependency["url"], clojurelsp_ls_dir, dependency["archiveType"])
+            logger.log(
+                f"Downloading and extracting clojure-lsp from {dependency.url} to {clojurelsp_ls_dir}",
+                logging.INFO,
+            )
+            deps.install(logger, clojurelsp_ls_dir)
         if not os.path.exists(clojurelsp_executable_path):
             raise FileNotFoundError(f"Download failed? Could not find clojure-lsp executable at {clojurelsp_executable_path}")
         os.chmod(clojurelsp_executable_path, stat.S_IEXEC)

--- a/src/solidlsp/language_servers/common.py
+++ b/src/solidlsp/language_servers/common.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Sequence, Dict
+
+from solidlsp.ls_logger import LanguageServerLogger
+from solidlsp.ls_utils import FileUtils, PlatformUtils
+
+
+@dataclass(kw_only=True)
+class RuntimeDependency:
+    """Represents a runtime dependency for a language server."""
+
+    id: str
+    platform_id: str | None = None
+    url: str | None = None
+    archive_type: str | None = None
+    binary_name: str | None = None
+    command: str | None = None
+    package_name: str | None = None
+    package_version: str | None = None
+    extract_path: str | None = None
+    description: str | None = None
+
+
+class RuntimeDependencyCollection:
+    """Utility to handle installation of runtime dependencies."""
+
+    def __init__(self, dependencies: Sequence[RuntimeDependency]):
+        self._dependencies = list(dependencies)
+
+    def for_platform(self, platform_id: str) -> list[RuntimeDependency]:
+        return [
+            d
+            for d in self._dependencies
+            if d.platform_id in (platform_id, "any", "platform-agnostic", None)
+        ]
+
+    def for_current_platform(self) -> list[RuntimeDependency]:
+        return self.for_platform(PlatformUtils.get_platform_id().value)
+
+    def single_for_current_platform(self) -> RuntimeDependency:
+        deps = self.for_current_platform()
+        if len(deps) != 1:
+            raise RuntimeError(
+                f"Expected exactly one runtime dependency for {PlatformUtils.get_platform_id().value}, found {len(deps)}"
+            )
+        return deps[0]
+
+    def binary_path(self, target_dir: str) -> str:
+        dep = self.single_for_current_platform()
+        if not dep.binary_name:
+            return target_dir
+        return os.path.join(target_dir, dep.binary_name)
+
+    def install(self, logger: LanguageServerLogger, target_dir: str) -> Dict[str, str]:
+        """Install all dependencies for the current platform into *target_dir*.
+
+        Returns a mapping from dependency id to the resolved binary path.
+        """
+        os.makedirs(target_dir, exist_ok=True)
+        results: Dict[str, str] = {}
+        for dep in self.for_current_platform():
+            if dep.url:
+                self._install_from_url(dep, logger, target_dir)
+            if dep.command:
+                self._run_command(dep.command, target_dir)
+            if dep.binary_name:
+                results[dep.id] = os.path.join(target_dir, dep.binary_name)
+            else:
+                results[dep.id] = target_dir
+        return results
+
+    @staticmethod
+    def _run_command(command: str, cwd: str) -> None:
+        if PlatformUtils.get_platform_id().value.startswith("win"):
+            subprocess.run(
+                command,
+                shell=True,
+                check=True,
+                cwd=cwd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            import pwd
+
+            user = pwd.getpwuid(os.getuid()).pw_name
+            subprocess.run(
+                command,
+                shell=True,
+                check=True,
+                user=user,
+                cwd=cwd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+    @staticmethod
+    def _install_from_url(dep: RuntimeDependency, logger: LanguageServerLogger, target_dir: str) -> None:
+        if dep.archive_type == "gz" and dep.binary_name:
+            dest = os.path.join(target_dir, dep.binary_name)
+            FileUtils.download_and_extract_archive(logger, dep.url, dest, dep.archive_type)
+        else:
+            FileUtils.download_and_extract_archive(logger, dep.url, target_dir, dep.archive_type or "zip")

--- a/src/solidlsp/language_servers/csharp_language_server.py
+++ b/src/solidlsp/language_servers/csharp_language_server.py
@@ -13,9 +13,10 @@ import tarfile
 import threading
 import urllib.request
 import zipfile
-from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
+
+from .common import RuntimeDependency
 
 from overrides import override
 
@@ -26,21 +27,6 @@ from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.ls_utils import PathUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
-
-
-@dataclass(kw_only=True)
-class RuntimeDependency:
-    """Represents a runtime dependency for the C# language server."""
-
-    id: str
-    description: str | None
-    platform_id: str
-    archive_type: str
-    binary_name: str
-    package_name: str | None = None
-    package_version: str | None = None
-    extract_path: str | None = None
-    url: str | None = None
 
 
 # Runtime dependencies configuration

--- a/src/solidlsp/language_servers/dart_language_server.py
+++ b/src/solidlsp/language_servers/dart_language_server.py
@@ -6,6 +6,7 @@ import stat
 from solidlsp.ls import SolidLanguageServer
 from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.ls_utils import FileUtils, PlatformUtils
+from .common import RuntimeDependency, RuntimeDependencyCollection
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 
 
@@ -31,60 +32,57 @@ class DartLanguageServer(SolidLanguageServer):
     def _setup_runtime_dependencies(cls, logger: "LanguageServerLogger") -> str:
         platform_id = PlatformUtils.get_platform_id()
 
-        runtime_dependencies = [
-            {
-                "id": "DartLanguageServer",
-                "description": "Dart Language Server for Linux (x64)",
-                "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-linux-x64-release.zip",
-                "platformId": "linux-x64",
-                "archiveType": "zip",
-                "binaryName": "dart-sdk/bin/dart",
-            },
-            {
-                "id": "DartLanguageServer",
-                "description": "Dart Language Server for Windows (x64)",
-                "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-windows-x64-release.zip",
-                "platformId": "win-x64",
-                "archiveType": "zip",
-                "binaryName": "dart-sdk/bin/dart.exe",
-            },
-            {
-                "id": "DartLanguageServer",
-                "description": "Dart Language Server for Windows (arm64)",
-                "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-windows-arm64-release.zip",
-                "platformId": "win-arm64",
-                "archiveType": "zip",
-                "binaryName": "dart-sdk/bin/dart.exe",
-            },
-            {
-                "id": "DartLanguageServer",
-                "description": "Dart Language Server for macOS (x64)",
-                "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-macos-x64-release.zip",
-                "platformId": "osx-x64",
-                "archiveType": "zip",
-                "binaryName": "dart-sdk/bin/dart",
-            },
-            {
-                "id": "DartLanguageServer",
-                "description": "Dart Language Server for macOS (arm64)",
-                "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-macos-arm64-release.zip",
-                "platformId": "osx-arm64",
-                "archiveType": "zip",
-                "binaryName": "dart-sdk/bin/dart",
-            },
-        ]
-
-        runtime_dependencies = [dependency for dependency in runtime_dependencies if dependency["platformId"] == platform_id.value]
-
-        assert len(runtime_dependencies) == 1
-        dependency = runtime_dependencies[0]
+        deps = RuntimeDependencyCollection(
+            [
+                RuntimeDependency(
+                    id="DartLanguageServer",
+                    description="Dart Language Server for Linux (x64)",
+                    url="https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-linux-x64-release.zip",
+                    platform_id="linux-x64",
+                    archive_type="zip",
+                    binary_name="dart-sdk/bin/dart",
+                ),
+                RuntimeDependency(
+                    id="DartLanguageServer",
+                    description="Dart Language Server for Windows (x64)",
+                    url="https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-windows-x64-release.zip",
+                    platform_id="win-x64",
+                    archive_type="zip",
+                    binary_name="dart-sdk/bin/dart.exe",
+                ),
+                RuntimeDependency(
+                    id="DartLanguageServer",
+                    description="Dart Language Server for Windows (arm64)",
+                    url="https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-windows-arm64-release.zip",
+                    platform_id="win-arm64",
+                    archive_type="zip",
+                    binary_name="dart-sdk/bin/dart.exe",
+                ),
+                RuntimeDependency(
+                    id="DartLanguageServer",
+                    description="Dart Language Server for macOS (x64)",
+                    url="https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-macos-x64-release.zip",
+                    platform_id="osx-x64",
+                    archive_type="zip",
+                    binary_name="dart-sdk/bin/dart",
+                ),
+                RuntimeDependency(
+                    id="DartLanguageServer",
+                    description="Dart Language Server for macOS (arm64)",
+                    url="https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.1/sdk/dartsdk-macos-arm64-release.zip",
+                    platform_id="osx-arm64",
+                    archive_type="zip",
+                    binary_name="dart-sdk/bin/dart",
+                ),
+            ]
+        )
 
         dart_ls_dir = cls.ls_resources_dir()
-        dart_executable_path = os.path.join(dart_ls_dir, dependency["binaryName"])
+        dart_executable_path = deps.binary_path(dart_ls_dir)
 
         if not os.path.exists(dart_ls_dir):
             os.makedirs(dart_ls_dir)
-            FileUtils.download_and_extract_archive(logger, dependency["url"], dart_ls_dir, dependency["archiveType"])
+            deps.install(logger, dart_ls_dir)
 
         assert os.path.exists(dart_executable_path)
         os.chmod(dart_executable_path, stat.S_IEXEC)


### PR DESCRIPTION
## Summary
- add shared helpers `single_for_current_platform` and `binary_path`
- use new helpers when resolving runtime dependencies in several language servers

## Testing
- `pip install sensai`
- `pip install -e .`
- `pip install pytest-snapshot`
- `pytest -q -o addopts=""` *(fails: tests cannot fetch remote assets)*

------
https://chatgpt.com/codex/tasks/task_e_686aacf40b64832091e0df09986c48f3