### PR TITLE
Add rust_analyzer RuntimeDependency for Linux Arm64

### DIFF
--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -70,6 +70,14 @@ class RustAnalyzer(SolidLanguageServer):
                 ),
                 RuntimeDependency(
                     id="RustAnalyzer",
+                    description="RustAnalyzer for Linux (arm64)",
+                    url="https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    platform_id="linux-arm64",
+                    archive_type="gz",
+                    binary_name="rust_analyzer",
+                ),
+                RuntimeDependency(
+                    id="RustAnalyzer",
                     description="RustAnalyzer for Windows (x64)",
                     url="https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-x86_64-pc-windows-msvc.zip",
                     platform_id="win-x64",


### PR DESCRIPTION
This pull request adds support for a new runtime dependency to the `RustAnalyzer` language server configuration. Specifically, it includes handling for the Linux (arm64) platform.

### Runtime dependency updates:
* [`src/solidlsp/language_servers/rust_analyzer.py`](diffhunk://#diff-e370f4b801fe8d62b22346fdf02623d6ebf7d9b5c2fdfb9d5729e5082092db46R71-R78): Added a new `RuntimeDependency` entry for `RustAnalyzer` targeting Linux (arm64), including the appropriate URL and platform-specific details.