### PR TITLE
Fix runtime dependency check in DartLanguageServer setup

### DIFF
--- a/src/solidlsp/language_servers/dart_language_server.py
+++ b/src/solidlsp/language_servers/dart_language_server.py
@@ -78,8 +78,7 @@ class DartLanguageServer(SolidLanguageServer):
         dart_ls_dir = cls.ls_resources_dir()
         dart_executable_path = deps.binary_path(dart_ls_dir)
 
-        if not os.path.exists(dart_ls_dir):
-            os.makedirs(dart_ls_dir)
+        if not os.path.exists(dart_executable_path):
             deps.install(logger, dart_ls_dir)
 
         assert os.path.exists(dart_executable_path)


### PR DESCRIPTION
Closes #293

Dart deps werent being downloaded because the folder was already created