### PR TITLE
System Prompt command - PR by CC Vanilla

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 [project.scripts]
 serena-mcp-server = "serena.mcp:start_mcp_server"
 index-project = "serena.agent:index_project"
+print_system_prompt = "serena.agent:print_system_prompt"
 
 [project.license]
 text = "MIT"

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -124,6 +124,26 @@ def index_project(project: str, log_level: str = "INFO") -> None:
     print(f"Symbols saved to {ls.cache_path}")
 
 
+@click.command()
+@click.argument("project", type=click.Path(exists=True), required=False, default=os.getcwd())
+@click.option("--log-level", type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]), default="WARNING")
+def print_system_prompt(project: str, log_level: str = "WARNING") -> None:
+    """
+    Print the system prompt for the current project using InitialInstructionsTool.
+
+    :param project: the project to get the system prompt for. By default, the current working directory is used.
+    """
+    from serena.tools.workflow_tools import InitialInstructionsTool
+
+    log_level_int = logging.getLevelNamesMapping()[log_level.upper()]
+    logging.getLogger().setLevel(log_level_int)
+
+    agent = SerenaAgent(project=os.path.abspath(project))
+    initial_instructions_tool = agent.get_tool(InitialInstructionsTool)
+    system_prompt = initial_instructions_tool.apply()
+    print(system_prompt)
+
+
 class SerenaAgent:
     def __init__(
         self,


### PR DESCRIPTION
- Added new CLI command print_system_prompt in pyproject.toml
- Implemented print_system_prompt function in agent.py that instantiates SerenaAgent and calls InitialInstructionsTool.apply()
- Command accepts project path (defaults to current directory) and log level options
- Follows same pattern as existing index_project command

🤖 Generated with [Claude Code](https://claude.ai/code)