### PR TITLE
feat: Add configurable memory and file size limits for Intelephense

### DIFF
--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -246,6 +246,7 @@ class Project:
         log_level: int = logging.INFO,
         ls_timeout: float | None = DEFAULT_TOOL_TIMEOUT - 5,
         trace_lsp_communication: bool = False,
+        intelephense_options: dict[str, int] | None = None,
     ) -> SolidLanguageServer:
         """
         Create a language server for a project. Note that you will have to start it
@@ -256,6 +257,7 @@ class Project:
         :param log_level: the log level for the language server
         :param ls_timeout: the timeout for the language server
         :param trace_lsp_communication: whether to trace LSP communication
+        :param intelephense_options: optional configuration options for Intelephense (PHP only)
         :return: the language server
         """
         ls_config = LanguageServerConfig(
@@ -266,9 +268,20 @@ class Project:
         ls_logger = LanguageServerLogger(log_level=log_level)
 
         log.info(f"Creating language server instance for {self.project_root}.")
-        return SolidLanguageServer.create(
-            ls_config,
-            ls_logger,
-            self.project_root,
-            timeout=ls_timeout,
-        )
+
+        # Pass intelephense_options if provided and language is PHP
+        if self.language == Language.PHP and intelephense_options:
+            return SolidLanguageServer.create(
+                ls_config,
+                ls_logger,
+                self.project_root,
+                timeout=ls_timeout,
+                intelephense_options=intelephense_options,
+            )
+        else:
+            return SolidLanguageServer.create(
+                ls_config,
+                ls_logger,
+                self.project_root,
+                timeout=ls_timeout,
+            )

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -101,7 +101,12 @@ class SolidLanguageServer(ABC):
 
     @classmethod
     def create(
-        cls, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, timeout: float | None = None
+        cls,
+        config: LanguageServerConfig,
+        logger: LanguageServerLogger,
+        repository_root_path: str,
+        timeout: float | None = None,
+        intelephense_options: dict[str, int] | None = None,
     ) -> "SolidLanguageServer":
         """
         Creates a language specific LanguageServer instance based on the given configuration, and appropriate settings for the programming language.
@@ -113,6 +118,7 @@ class SolidLanguageServer(ABC):
         :param config: The Multilspy configuration.
         :param logger: The logger to use.
         :param timeout: the timeout for requests to the language server. If None, no timeout will be used.
+        :param intelephense_options: optional configuration options for Intelephense (PHP language server only).
         :return LanguageServer: A language specific LanguageServer instance.
         """
         ls: SolidLanguageServer
@@ -190,7 +196,7 @@ class SolidLanguageServer(ABC):
         elif config.code_language == Language.PHP:
             from solidlsp.language_servers.intelephense import Intelephense
 
-            ls = Intelephense(config, logger, repository_root_path)
+            ls = Intelephense(config, logger, repository_root_path, intelephense_options=intelephense_options)
 
         elif config.code_language == Language.CLOJURE:
             from solidlsp.language_servers.clojure_lsp import ClojureLSP


### PR DESCRIPTION
## Summary
- Adds `--max-memory` and `--max-file-size` CLI options to `index-project` command
- Resolves PHP indexing hangs caused by large files exceeding Intelephense limits
- Provides minimal-impact, per-project configuration for Intelephense memory/file size

## Problem
Users experience indexing hangs on large PHP files (as reported in #206). Intelephense has default memory and file size limits that cause it to hang or crash when processing large files, making project indexing impossible.

## Solution
Added configurable CLI options that are passed through the architecture layers to Intelephense's `initializationOptions`:

### Usage
```bash
# Index with custom memory and file size limits
uv run index-project /path/to/php/project --max-memory 512 --max-file-size 500000

# Use minimum memory setting
uv run index-project /path/to/project --max-memory 256
```

### Parameters
- `--max-memory`: Maximum memory (MB) for Intelephense (minimum 256)
- `--max-file-size`: Maximum file size (bytes) for Intelephense to process

## Implementation Details
- **CLI Layer** (`src/serena/cli.py`): Added Click options with validation
- **Project Layer** (`src/serena/project.py`): Modified `create_language_server()` to accept options
- **Language Server Factory** (`src/solidlsp/ls.py`): Updated to pass options to Intelephense
- **Intelephense Class** (`src/solidlsp/language_servers/intelephense.py`): Added `initializationOptions` support

Options are only passed when:
1. Language is PHP 
2. Options are provided
3. Follows LSP `initializationOptions` standard

## Testing
- ✅ All PHP tests pass (8/8)
- ✅ Code formatting compliant 
- ✅ Tested with problematic PHP project - indexing completes successfully
- ✅ Validates CLI parameters (memory ≥ 256MB, file size > 0)

## Files Changed
- `src/serena/cli.py` - CLI options and validation
- `src/serena/project.py` - Language server option passing  
- `src/solidlsp/ls.py` - Factory method updates
- `src/solidlsp/language_servers/intelephense.py` - InitializationOptions implementation

Closes #206

## Test plan
- [ ] Test with various memory limits (256, 512, 1024 MB)
- [ ] Test with different file size limits
- [ ] Verify options only affect PHP projects
- [ ] Test backward compatibility (commands work without options)
- [ ] Test validation (negative values, below minimum memory)

🤖 Generated with [Claude Code](https://claude.ai/code)