### PR TITLE
Refactoring solidlsp settings CC Vanilla

### DIFF
--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -5,11 +5,13 @@ from pathlib import Path
 import pathspec
 
 from serena.config.serena_config import DEFAULT_TOOL_TIMEOUT, ProjectConfig
+from serena.constants import SERENA_MANAGED_DIR_IN_HOME
 from serena.text_utils import MatchedConsecutiveLines, search_files
 from serena.util.file_system import GitignoreParser, match_path
 from solidlsp import SolidLanguageServer
 from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_logger import LanguageServerLogger
+from solidlsp.settings import SolidLSPSettings
 
 log = logging.getLogger(__name__)
 
@@ -271,4 +273,5 @@ class Project:
             ls_logger,
             self.project_root,
             timeout=ls_timeout,
+            solidlsp_settings=SolidLSPSettings(solidlsp_dir=SERENA_MANAGED_DIR_IN_HOME),
         )

--- a/src/solidlsp/language_servers/clangd_language_server.py
+++ b/src/solidlsp/language_servers/clangd_language_server.py
@@ -13,6 +13,7 @@ from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 from .common import RuntimeDependency, RuntimeDependencyCollection
 
@@ -24,25 +25,30 @@ class ClangdLanguageServer(SolidLanguageServer):
     Also make sure compile_commands.json is created at root of the source directory. Check clangd test case for example.
     """
 
-    def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
         """
         Creates a ClangdLanguageServer instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
-        clangd_executable_path = self._setup_runtime_dependencies(logger, config)
+        clangd_executable_path = self._setup_runtime_dependencies(logger, config, solidlsp_settings)
         super().__init__(
             config,
             logger,
             repository_root_path,
             ProcessLaunchInfo(cmd=clangd_executable_path, cwd=repository_root_path),
             "cpp",
+            solidlsp_settings,
         )
         self.server_ready = threading.Event()
         self.service_ready_event = threading.Event()
         self.initialize_searcher_command_available = threading.Event()
         self.resolve_main_method_available = threading.Event()
 
-    @staticmethod
-    def _setup_runtime_dependencies(logger: LanguageServerLogger, config: LanguageServerConfig) -> str:
+    @classmethod
+    def _setup_runtime_dependencies(
+        cls, logger: LanguageServerLogger, config: LanguageServerConfig, solidlsp_settings: SolidLSPSettings
+    ) -> str:
         """
         Setup runtime dependencies for ClangdLanguageServer and return the command to start the server.
         """
@@ -75,7 +81,7 @@ class ClangdLanguageServer(SolidLanguageServer):
             ]
         )
 
-        clangd_ls_dir = os.path.join(os.path.dirname(__file__), "static", "clangd")
+        clangd_ls_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "clangd")
         dep = deps.single_for_current_platform()
         clangd_executable_path = deps.binary_path(clangd_ls_dir)
         if not os.path.exists(clangd_executable_path):

--- a/src/solidlsp/language_servers/dart_language_server.py
+++ b/src/solidlsp/language_servers/dart_language_server.py
@@ -6,6 +6,7 @@ import stat
 from solidlsp.ls import SolidLanguageServer
 from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 from .common import RuntimeDependency, RuntimeDependencyCollection
 
@@ -15,21 +16,22 @@ class DartLanguageServer(SolidLanguageServer):
     Provides Dart specific instantiation of the LanguageServer class. Contains various configurations and settings specific to Dart.
     """
 
-    def __init__(self, config, logger, repository_root_path):
+    def __init__(self, config, logger, repository_root_path, solidlsp_settings: SolidLSPSettings):
         """
         Creates a DartServer instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
-        executable_path = self._setup_runtime_dependencies(logger)
+        executable_path = self._setup_runtime_dependencies(logger, solidlsp_settings)
         super().__init__(
             config,
             logger,
             repository_root_path,
             ProcessLaunchInfo(cmd=executable_path, cwd=repository_root_path),
             "dart",
+            solidlsp_settings,
         )
 
     @classmethod
-    def _setup_runtime_dependencies(cls, logger: "LanguageServerLogger") -> str:
+    def _setup_runtime_dependencies(cls, logger: "LanguageServerLogger", solidlsp_settings: SolidLSPSettings) -> str:
         deps = RuntimeDependencyCollection(
             [
                 RuntimeDependency(
@@ -75,7 +77,7 @@ class DartLanguageServer(SolidLanguageServer):
             ]
         )
 
-        dart_ls_dir = cls.ls_resources_dir()
+        dart_ls_dir = cls.ls_resources_dir(solidlsp_settings)
         dart_executable_path = deps.binary_path(dart_ls_dir)
 
         if not os.path.exists(dart_executable_path):

--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -51,7 +51,7 @@ class EclipseJDTLS(SolidLanguageServer):
         Creates a new EclipseJDTLS instance initializing the language server settings appropriately.
         This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
-        runtime_dependency_paths = self._setupRuntimeDependencies(logger, config)
+        runtime_dependency_paths = self._setupRuntimeDependencies(logger, config, solidlsp_settings)
         self.runtime_dependency_paths = runtime_dependency_paths
 
         # ws_dir is the workspace directory for the EclipseJDTLS server
@@ -157,7 +157,9 @@ class EclipseJDTLS(SolidLanguageServer):
         ]
 
     @classmethod
-    def _setupRuntimeDependencies(cls, logger: LanguageServerLogger, config: LanguageServerConfig) -> RuntimeDependencyPaths:
+    def _setupRuntimeDependencies(
+        cls, logger: LanguageServerLogger, config: LanguageServerConfig, solidlsp_settings: SolidLSPSettings
+    ) -> RuntimeDependencyPaths:
         """
         Setup runtime dependencies for EclipseJDTLS and return the paths.
         """
@@ -242,7 +244,7 @@ class EclipseJDTLS(SolidLanguageServer):
 
         gradle_path = str(
             PurePath(
-                cls.ls_resources_dir(),
+                cls.ls_resources_dir(solidlsp_settings),
                 "gradle-7.3.3",
             )
         )
@@ -258,7 +260,7 @@ class EclipseJDTLS(SolidLanguageServer):
         assert os.path.exists(gradle_path)
 
         dependency = runtime_dependencies["vscode-java"][platformId.value]
-        vscode_java_path = str(PurePath(cls.ls_resources_dir(), dependency["relative_extraction_path"]))
+        vscode_java_path = str(PurePath(cls.ls_resources_dir(solidlsp_settings), dependency["relative_extraction_path"]))
         os.makedirs(vscode_java_path, exist_ok=True)
         jre_home_path = str(PurePath(vscode_java_path, dependency["jre_home_path"]))
         jre_path = str(PurePath(vscode_java_path, dependency["jre_path"]))
@@ -287,7 +289,7 @@ class EclipseJDTLS(SolidLanguageServer):
         assert os.path.exists(jdtls_readonly_config_path)
 
         dependency = runtime_dependencies["intellicode"]["platform-agnostic"]
-        intellicode_directory_path = str(PurePath(cls.ls_resources_dir(), dependency["relative_extraction_path"]))
+        intellicode_directory_path = str(PurePath(cls.ls_resources_dir(solidlsp_settings), dependency["relative_extraction_path"]))
         os.makedirs(intellicode_directory_path, exist_ok=True)
         intellicode_jar_path = str(PurePath(intellicode_directory_path, dependency["intellicode_jar_path"]))
         intellisense_members_path = str(PurePath(intellicode_directory_path, dependency["intellisense_members_path"]))

--- a/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
+++ b/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
@@ -14,6 +14,7 @@ from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.ls_utils import FileUtils, PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 from ..common import RuntimeDependency
 
@@ -80,7 +81,9 @@ class ElixirTools(SolidLanguageServer):
         return None
 
     @classmethod
-    def _setup_runtime_dependencies(cls, logger: LanguageServerLogger, config: LanguageServerConfig) -> str:
+    def _setup_runtime_dependencies(
+        cls, logger: LanguageServerLogger, config: LanguageServerConfig, solidlsp_settings: SolidLSPSettings
+    ) -> str:
         """
         Setup runtime dependencies for Next LS.
         Downloads the Next LS binary for the current platform and returns the path to the executable.
@@ -110,7 +113,7 @@ class ElixirTools(SolidLanguageServer):
         ]
         assert platform_id in valid_platforms, f"Platform {platform_id} is not supported for Next LS at the moment"
 
-        next_ls_dir = os.path.join(cls.ls_resources_dir(), "next-ls")
+        next_ls_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "next-ls")
 
         # Define runtime dependencies inline
         runtime_deps = {
@@ -162,8 +165,10 @@ class ElixirTools(SolidLanguageServer):
         logger.log(f"Next LS binary ready at: {executable_path}", logging.INFO)
         return executable_path
 
-    def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
-        nextls_executable_path = self._setup_runtime_dependencies(logger, config)
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
+        nextls_executable_path = self._setup_runtime_dependencies(logger, config, solidlsp_settings)
 
         super().__init__(
             config,
@@ -171,6 +176,7 @@ class ElixirTools(SolidLanguageServer):
             repository_root_path,
             ProcessLaunchInfo(cmd=f'"{nextls_executable_path}" --stdio', cwd=repository_root_path),
             "elixir",
+            solidlsp_settings,
         )
         self.server_ready = threading.Event()
         self.request_id = 0

--- a/src/solidlsp/language_servers/gopls.py
+++ b/src/solidlsp/language_servers/gopls.py
@@ -11,6 +11,7 @@ from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 
 class Gopls(SolidLanguageServer):
@@ -70,7 +71,9 @@ class Gopls(SolidLanguageServer):
 
         return True
 
-    def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
         self._setup_runtime_dependency()
 
         super().__init__(
@@ -79,6 +82,7 @@ class Gopls(SolidLanguageServer):
             repository_root_path,
             ProcessLaunchInfo(cmd="gopls", cwd=repository_root_path),
             "go",
+            solidlsp_settings,
         )
         self.server_ready = threading.Event()
         self.request_id = 0

--- a/src/solidlsp/language_servers/jedi_server.py
+++ b/src/solidlsp/language_servers/jedi_server.py
@@ -13,6 +13,7 @@ from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 
 class JediServer(SolidLanguageServer):
@@ -20,7 +21,9 @@ class JediServer(SolidLanguageServer):
     Provides Python specific instantiation of the LanguageServer class. Contains various configurations and settings specific to Python.
     """
 
-    def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
         """
         Creates a JediServer instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
@@ -30,6 +33,7 @@ class JediServer(SolidLanguageServer):
             repository_root_path,
             ProcessLaunchInfo(cmd="jedi-language-server", cwd=repository_root_path),
             "python",
+            solidlsp_settings,
         )
 
     @override

--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -14,6 +14,7 @@ from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.ls_utils import FileUtils, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 
 @dataclasses.dataclass
@@ -32,11 +33,13 @@ class KotlinLanguageServer(SolidLanguageServer):
     Provides Kotlin specific instantiation of the LanguageServer class. Contains various configurations and settings specific to Kotlin.
     """
 
-    def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
         """
         Creates a Kotlin Language Server instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
-        runtime_dependency_paths = self._setup_runtime_dependencies(logger, config)
+        runtime_dependency_paths = self._setup_runtime_dependencies(logger, config, solidlsp_settings)
         self.runtime_dependency_paths = runtime_dependency_paths
 
         # Create command to execute the Kotlin Language Server script
@@ -51,10 +54,13 @@ class KotlinLanguageServer(SolidLanguageServer):
             repository_root_path,
             ProcessLaunchInfo(cmd=cmd, env=proc_env, cwd=repository_root_path),
             "kotlin",
+            solidlsp_settings,
         )
 
     @classmethod
-    def _setup_runtime_dependencies(cls, logger: LanguageServerLogger, config: LanguageServerConfig) -> KotlinRuntimeDependencyPaths:
+    def _setup_runtime_dependencies(
+        cls, logger: LanguageServerLogger, config: LanguageServerConfig, solidlsp_settings: SolidLSPSettings
+    ) -> KotlinRuntimeDependencyPaths:
         """
         Setup runtime dependencies for Kotlin Language Server and return the paths.
         """
@@ -111,7 +117,7 @@ class KotlinLanguageServer(SolidLanguageServer):
         java_dependency = runtime_dependencies["java"][platform_id.value]
 
         # Setup paths for dependencies
-        static_dir = os.path.join(cls.ls_resources_dir(), "kotlin_language_server")
+        static_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "kotlin_language_server")
         os.makedirs(static_dir, exist_ok=True)
 
         # Setup Java paths

--- a/src/solidlsp/language_servers/omnisharp.py
+++ b/src/solidlsp/language_servers/omnisharp.py
@@ -19,6 +19,7 @@ from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.ls_utils import DotnetVersion, FileUtils, PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 
 def breadth_first_file_scan(root) -> Iterable[str]:
@@ -59,11 +60,13 @@ class OmniSharp(SolidLanguageServer):
     Provides C# specific instantiation of the LanguageServer class. Contains various configurations and settings specific to C#.
     """
 
-    def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
         """
         Creates an OmniSharp instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
-        omnisharp_executable_path, dll_path = self._setup_runtime_dependencies(logger, config)
+        omnisharp_executable_path, dll_path = self._setup_runtime_dependencies(logger, config, solidlsp_settings)
 
         slnfilename = find_least_depth_sln_file(repository_root_path)
         if slnfilename is None:
@@ -102,7 +105,9 @@ class OmniSharp(SolidLanguageServer):
                 "formattingOptions:indentationSize=4",
             ]
         )
-        super().__init__(config, logger, repository_root_path, ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path), "csharp")
+        super().__init__(
+            config, logger, repository_root_path, ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path), "csharp", solidlsp_settings
+        )
 
         self.server_ready = threading.Event()
         self.definition_available = threading.Event()
@@ -138,7 +143,9 @@ class OmniSharp(SolidLanguageServer):
         return d
 
     @classmethod
-    def _setup_runtime_dependencies(cls, logger: LanguageServerLogger, config: LanguageServerConfig) -> tuple[str, str]:
+    def _setup_runtime_dependencies(
+        cls, logger: LanguageServerLogger, config: LanguageServerConfig, solidlsp_settings: SolidLSPSettings
+    ) -> tuple[str, str]:
         """
         Setup runtime dependencies for OmniSharp.
         """
@@ -181,7 +188,7 @@ class OmniSharp(SolidLanguageServer):
         assert "OmniSharp" in runtime_dependencies
         assert "RazorOmnisharp" in runtime_dependencies
 
-        omnisharp_ls_dir = os.path.join(cls.ls_resources_dir(), "OmniSharp")
+        omnisharp_ls_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "OmniSharp")
         if not os.path.exists(omnisharp_ls_dir):
             os.makedirs(omnisharp_ls_dir)
             FileUtils.download_and_extract_archive(logger, runtime_dependencies["OmniSharp"]["url"], omnisharp_ls_dir, "zip")
@@ -189,7 +196,7 @@ class OmniSharp(SolidLanguageServer):
         assert os.path.exists(omnisharp_executable_path)
         os.chmod(omnisharp_executable_path, stat.S_IEXEC)
 
-        razor_omnisharp_ls_dir = os.path.join(cls.ls_resources_dir(), "RazorOmnisharp")
+        razor_omnisharp_ls_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "RazorOmnisharp")
         if not os.path.exists(razor_omnisharp_ls_dir):
             os.makedirs(razor_omnisharp_ls_dir)
             FileUtils.download_and_extract_archive(logger, runtime_dependencies["RazorOmnisharp"]["url"], razor_omnisharp_ls_dir, "zip")

--- a/src/solidlsp/language_servers/pyright_server.py
+++ b/src/solidlsp/language_servers/pyright_server.py
@@ -15,6 +15,7 @@ from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 
 class PyrightServer(SolidLanguageServer):
@@ -23,7 +24,9 @@ class PyrightServer(SolidLanguageServer):
     Contains various configurations and settings specific to Python.
     """
 
-    def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
         """
         Creates a PyrightServer instance. This class is not meant to be instantiated directly.
         Use LanguageServer.create() instead.
@@ -36,6 +39,7 @@ class PyrightServer(SolidLanguageServer):
             # Note 2: we can also use `bpyright-langserver --stdio` if we ever are unhappy with pyright
             ProcessLaunchInfo(cmd="python -m pyright.langserver --stdio", cwd=repository_root_path),
             "python",
+            solidlsp_settings,
         )
 
         # Event to signal when initial workspace analysis is complete

--- a/src/solidlsp/language_servers/solargraph.py
+++ b/src/solidlsp/language_servers/solargraph.py
@@ -18,6 +18,7 @@ from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 
 class Solargraph(SolidLanguageServer):
@@ -26,7 +27,9 @@ class Solargraph(SolidLanguageServer):
     Contains various configurations and settings specific to Ruby.
     """
 
-    def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
         """
         Creates a Solargraph instance. This class is not meant to be instantiated directly.
         Use LanguageServer.create() instead.
@@ -38,6 +41,7 @@ class Solargraph(SolidLanguageServer):
             repository_root_path,
             ProcessLaunchInfo(cmd=f"{solargraph_executable_path} stdio", cwd=repository_root_path),
             "ruby",
+            solidlsp_settings,
         )
         self.server_ready = threading.Event()
         self.service_ready_event = threading.Event()

--- a/src/solidlsp/language_servers/vts_language_server.py
+++ b/src/solidlsp/language_servers/vts_language_server.py
@@ -19,6 +19,7 @@ from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.ls_utils import PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
 
 from .common import RuntimeDependency, RuntimeDependencyCollection
 
@@ -29,17 +30,20 @@ class VtsLanguageServer(SolidLanguageServer):
     Contains various configurations and settings specific to TypeScript via vtsls wrapper.
     """
 
-    def __init__(self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str):
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
         """
         Creates a VtsLanguageServer instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
-        vts_lsp_executable_path = self._setup_runtime_dependencies(logger, config)
+        vts_lsp_executable_path = self._setup_runtime_dependencies(logger, config, solidlsp_settings)
         super().__init__(
             config,
             logger,
             repository_root_path,
             ProcessLaunchInfo(cmd=vts_lsp_executable_path, cwd=repository_root_path),
             "typescript",
+            solidlsp_settings,
         )
         self.server_ready = threading.Event()
         self.initialize_searcher_command_available = threading.Event()
@@ -54,7 +58,9 @@ class VtsLanguageServer(SolidLanguageServer):
         ]
 
     @classmethod
-    def _setup_runtime_dependencies(cls, logger: LanguageServerLogger, config: LanguageServerConfig) -> str:
+    def _setup_runtime_dependencies(
+        cls, logger: LanguageServerLogger, config: LanguageServerConfig, solidlsp_settings: SolidLSPSettings
+    ) -> str:
         """
         Setup runtime dependencies for VTS Language Server and return the command to start the server.
         """
@@ -81,7 +87,7 @@ class VtsLanguageServer(SolidLanguageServer):
                 ),
             ]
         )
-        vts_ls_dir = os.path.join(cls.ls_resources_dir(), "vts-lsp")
+        vts_ls_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "vts-lsp")
         vts_executable_path = os.path.join(vts_ls_dir, "vtsls")
 
         # Verify both node and npm are installed

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -119,8 +119,8 @@ class SolidLanguageServer(ABC):
         config: LanguageServerConfig,
         logger: LanguageServerLogger,
         repository_root_path: str,
-        solidlsp_settings: SolidLSPSettings,
         timeout: float | None = None,
+        solidlsp_settings: SolidLSPSettings | None = None,
     ) -> "SolidLanguageServer":
         """
         Creates a language specific LanguageServer instance based on the given configuration, and appropriate settings for the programming language.
@@ -135,6 +135,8 @@ class SolidLanguageServer(ABC):
         :return LanguageServer: A language specific LanguageServer instance.
         """
         ls: SolidLanguageServer
+        if solidlsp_settings is None:
+            solidlsp_settings = SolidLSPSettings()
 
         if config.code_language == Language.PYTHON:
             from solidlsp.language_servers.pyright_server import (

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,11 +4,13 @@ from pathlib import Path
 import pytest
 from sensai.util.logging import configure
 
+from serena.constants import SERENA_MANAGED_DIR_IN_HOME
 from serena.project import Project
 from serena.util.file_system import GitignoreParser
 from solidlsp.ls import SolidLanguageServer
 from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_logger import LanguageServerLogger
+from solidlsp.settings import SolidLSPSettings
 
 configure(level=logging.ERROR)
 
@@ -43,7 +45,9 @@ def create_ls(
         ignored_paths.extend(spec.patterns)
     config = LanguageServerConfig(code_language=language, ignored_paths=ignored_paths, trace_lsp_communication=trace_lsp_communication)
     logger = LanguageServerLogger(log_level=log_level)
-    return SolidLanguageServer.create(config, logger, repo_path)
+    return SolidLanguageServer.create(
+        config, logger, repo_path, solidlsp_settings=SolidLSPSettings(solidlsp_dir=SERENA_MANAGED_DIR_IN_HOME)
+    )
 
 
 def create_default_ls(language: Language) -> SolidLanguageServer:

--- a/test/solidlsp/csharp/test_csharp_basic.py
+++ b/test/solidlsp/csharp/test_csharp_basic.py
@@ -13,6 +13,7 @@ from solidlsp.language_servers.csharp_language_server import (
 )
 from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import SymbolUtils
+from solidlsp.settings import SolidLSPSettings
 
 
 @pytest.mark.csharp
@@ -214,7 +215,9 @@ class TestCSharpSolutionProjectOpening:
             mock_config.ignored_paths = []
 
             # Create CSharpLanguageServer instance
-            CSharpLanguageServer(mock_config, mock_logger, str(temp_path))
+            mock_settings = Mock(spec=SolidLSPSettings)
+            mock_settings.ls_resources_dir = "/tmp/test_ls_resources"
+            CSharpLanguageServer(mock_config, mock_logger, str(temp_path), mock_settings)
 
             # Verify that logger was called with solution file discovery
             mock_logger.log.assert_any_call(f"Found solution/project file: {solution_file}", 20)  # logging.INFO
@@ -236,7 +239,9 @@ class TestCSharpSolutionProjectOpening:
             mock_config.ignored_paths = []
 
             # Create CSharpLanguageServer instance
-            CSharpLanguageServer(mock_config, mock_logger, str(temp_path))
+            mock_settings = Mock(spec=SolidLSPSettings)
+            mock_settings.ls_resources_dir = "/tmp/test_ls_resources"
+            CSharpLanguageServer(mock_config, mock_logger, str(temp_path), mock_settings)
 
             # Verify that logger was called with warning about no solution/project files
             mock_logger.log.assert_any_call(


### PR DESCRIPTION
Tokens: 5,213,813
Prompts:
- I recently added the non-optional parameter solidlsp_settings to the init of SolidLanguageServer, the create method, and the ls_resources_dir method. All language server subclasses now need to be adjusted  accordingly to use solidlsp_settings. Do that. You can have a look at relevant memories in .serena/memories to understand the repo structure
- don't execute elixir tests, they hang