### PR TITLE
Fix: Improve Solargraph compatibility for various Ruby environments

### DIFF
--- a/src/solidlsp/language_servers/solargraph.py
+++ b/src/solidlsp/language_servers/solargraph.py
@@ -57,17 +57,6 @@ class Solargraph(SolidLanguageServer):
         """
         Setup runtime dependencies for Solargraph and return the command to start the server.
         """
-        runtime_dependencies = [
-            {
-                "url": "https://rubygems.org/downloads/solargraph-0.51.1.gem",
-                "installCommand": "gem install solargraph -v 0.51.1",
-                "binaryName": "solargraph",
-                "archiveType": "gem",
-            }
-        ]
-
-        dependency = runtime_dependencies[0]
-
         # Check if Ruby is installed
         try:
             result = subprocess.run(["ruby", "--version"], check=True, capture_output=True, cwd=repository_root_path)
@@ -86,6 +75,16 @@ class Solargraph(SolidLanguageServer):
             return solargraph_path
 
         # Fallback to gem exec
+        runtime_dependencies = [
+            {
+                "url": "https://rubygems.org/downloads/solargraph-0.51.1.gem",
+                "installCommand": "gem install solargraph -v 0.51.1",
+                "binaryName": "solargraph",
+                "archiveType": "gem",
+            }
+        ]
+
+        dependency = runtime_dependencies[0]
         try:
             result = subprocess.run(
                 ["gem", "list", "^solargraph$", "-i"], check=False, capture_output=True, text=True, cwd=repository_root_path

--- a/src/solidlsp/language_servers/solargraph.py
+++ b/src/solidlsp/language_servers/solargraph.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import pathlib
+import shutil
 import subprocess
 import threading
 
@@ -78,6 +79,13 @@ class Solargraph(SolidLanguageServer):
             raise RuntimeError("Ruby is not installed. Please install Ruby before continuing.") from e
 
         # Check if solargraph is installed
+        # First, try to find solargraph in PATH (includes asdf shims)
+        solargraph_path = shutil.which("solargraph")
+        if solargraph_path:
+            logger.log(f"Found solargraph at: {solargraph_path}", logging.INFO)
+            return solargraph_path
+
+        # Fallback to gem exec
         try:
             result = subprocess.run(
                 ["gem", "list", "^solargraph$", "-i"], check=False, capture_output=True, text=True, cwd=repository_root_path


### PR DESCRIPTION
## Summary
This PR improves Solargraph (Ruby Language Server) compatibility across different Ruby environments by modifying the binary discovery mechanism.

## Problem
The current implementation relies on `gem exec solargraph` command, which:
- Is not available in older RubyGems versions
- May not work correctly with Ruby version managers (asdf, rbenv, rvm) that provide their own shims

## Solution
- First attempt to find `solargraph` directly in PATH (which includes version manager shims)
- Fall back to `gem exec solargraph` only if direct PATH lookup fails
- This maintains backward compatibility while supporting more environments

## Affected Users
- Users with asdf/rbenv/rvm installed Ruby environments
- Users with older RubyGems versions that don't support `gem exec`
- Users who installed Solargraph via system package managers

## Testing
- Module import verified successfully
- Type checking passes
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)