### PR TITLE
Auto-close dashboard tabs when server stops responding

### DIFF
--- a/RUN_UP.md
+++ b/RUN_UP.md
@@ -1,0 +1,94 @@
+# Run_up.md  
+Complete workflow to clone, run, and contribute to **Serena** with Claude Code (Aug 2025 CLI).
+
+---
+
+## 1 · Fresh clone & remote setup
+```bash
+# (Optional) remove any existing local copy
+rm -rf ~/dev/serena
+
+# Clone YOUR fork
+git clone https://github.com/liebertar/serena.git ~/dev/serena
+cd ~/dev/serena
+
+# Link the original repo for future sync
+git remote add upstream https://github.com/oraios/serena.git
+git remote -v          # verify origin + upstream
+```
+
+---
+
+## 2 · Keep your fork current
+```bash
+git checkout main
+git fetch upstream
+git merge upstream/main        # or: git rebase upstream/main
+git push origin main
+```
+
+---
+
+## 3 · Launch Serena locally (detached, no dashboard)
+```bash
+uv run serena start-mcp-server \
+  --context ide-assistant \
+  --mode no-onboarding &
+```
+*Add `--enable-web-dashboard` if you prefer the browser log UI.*
+
+---
+
+## 4 · Register Serena in Claude Code
+
+### 4‑1 Clean any old MCP entry
+```bash
+claude mcp remove serena || true
+```
+
+### 4‑2 Local stdio registration (recommended)
+```bash
+claude mcp add serena -- \
+  uv run --directory "$HOME/dev/serena" serena start-mcp-server \
+  --context ide-assistant --mode no-onboarding
+```
+
+### 4‑3 Remote SSE registration (silent background)
+```bash
+# Start Serena as a remote SSE server
+uv run serena start-mcp-server --transport sse --port 9121 \
+  --context ide-assistant --mode no-onboarding &
+
+# Add the endpoint to Claude Code (user‑wide)
+claude mcp remove serena || true
+claude mcp add --transport sse --scope user serena http://localhost:9121/sse
+```
+*Swap `--transport sse`→`http` if you change the server transport.*
+
+---
+
+## 5 · Daily contributor loop
+```bash
+# 1) Sync fork
+git checkout main
+git fetch upstream
+git merge upstream/main          # or: git rebase upstream/main
+git push origin main
+
+# 2) Create a work branch
+git checkout -b feat/<my-change>
+
+# 3) Hack, test, commit
+git commit -am "feat: <describe change>"
+
+# 4) Push & open PR
+git push origin feat/<my-change>
+gh pr create -B main -H feat/<my-change> --fill
+```
+
+---
+
+### Quick tips
+* **Logs:** bring the background job to foreground with `fg` or view with `jobs -l`.
+* **Port clash:** add `--port 9222` (server) and update the URL in `claude mcp add`.
+* **Dashboard:** globally enable/disable by editing `~/.serena/serena_config.yml` (`web_dashboard: true|false`).

--- a/src/serena/resources/dashboard/dashboard.js
+++ b/src/serena/resources/dashboard/dashboard.js
@@ -52,6 +52,7 @@ class Dashboard {
         this.toolNames = [];
         this.currentMaxIdx = -1;
         this.pollInterval = null;
+        this.failureCount = 0;
         this.$logContainer = $('#log-container');
         this.$errorContainer = $('#error-container');
         this.$loadButton = $('#load-logs');
@@ -161,6 +162,7 @@ class Dashboard {
                 start_idx: self.currentMaxIdx + 1
             }),
             success: function(response) {
+                self.failureCount = 0;
                 // Only append new messages if we have any
                 if (response.messages && response.messages.length > 0) {
                     let wasAtBottom = false;
@@ -190,6 +192,11 @@ class Dashboard {
             },
             error: function(xhr, status, error) {
                 console.error('Error polling for new logs:', error);
+                self.failureCount++;
+                if (self.failureCount >= 3) {
+                    console.log('Server appears to be down, closing tab');
+                    window.close();
+                }
             }
         });
     }


### PR DESCRIPTION
Addresses issue #388 by implementing auto-close functionality for dashboard tabs when the MCP server becomes unresponsive.

Found this minimal change can resolve the issue mentioned by users. Following @opcode81's suggestion (one of the 81 contributors), implemented the approach of detecting when server stops responding and automatically closing the tab.

Please review and accept if it is helpful\! Thanks.

Fixes #388