### PR TITLE
Auto-close dashboard tabs when server stops responding

### DIFF
--- a/src/serena/resources/dashboard/dashboard.js
+++ b/src/serena/resources/dashboard/dashboard.js
@@ -52,6 +52,7 @@ class Dashboard {
         this.toolNames = [];
         this.currentMaxIdx = -1;
         this.pollInterval = null;
+        this.failureCount = 0;
         this.$logContainer = $('#log-container');
         this.$errorContainer = $('#error-container');
         this.$loadButton = $('#load-logs');
@@ -161,6 +162,7 @@ class Dashboard {
                 start_idx: self.currentMaxIdx + 1
             }),
             success: function(response) {
+                self.failureCount = 0;
                 // Only append new messages if we have any
                 if (response.messages && response.messages.length > 0) {
                     let wasAtBottom = false;
@@ -190,6 +192,11 @@ class Dashboard {
             },
             error: function(xhr, status, error) {
                 console.error('Error polling for new logs:', error);
+                self.failureCount++;
+                if (self.failureCount >= 3) {
+                    console.log('Server appears to be down, closing tab');
+                    window.close();
+                }
             }
         });
     }


### PR DESCRIPTION
Addresses issue #388 by implementing auto-close functionality for dashboard tabs when the MCP server becomes unresponsive.

Found this minimal change can resolve the issue mentioned by users. Following @opcode81's suggestion (one of the 81 contributors), implemented the approach of detecting when server stops responding and automatically closing the tab.

Please review and accept if it is helpful\! Thanks.

Fixes #388