### PR TITLE
Add Ruby language test for language server integration

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -69,6 +69,10 @@ jobs:
         with:
           terraform_version: "1.5.0"
           terraform_wrapper: false
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
       - name: Install uv
         shell: bash
         run: curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -73,6 +73,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'
+      - name: Install Ruby language server
+        shell: bash
+        run: gem install solargraph
       - name: Install uv
         shell: bash
         run: curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,6 +260,7 @@ markers = [
   "elixir: language server running for Elixir",
   "terraform: language server running for Terraform",
   "snapshot: snapshot tests for symbolic editing operations",
+  "ruby: language server running for Ruby",
 ]
 
 [tool.codespell]

--- a/test/resources/repos/ruby/test_repo/.solargraph.yml
+++ b/test/resources/repos/ruby/test_repo/.solargraph.yml
@@ -1,3 +1,4 @@
 ---
 include:
   - "main.rb"
+  - "lib.rb"

--- a/test/resources/repos/ruby/test_repo/.solargraph.yml
+++ b/test/resources/repos/ruby/test_repo/.solargraph.yml
@@ -1,0 +1,3 @@
+---
+include:
+  - "main.rb"

--- a/test/resources/repos/ruby/test_repo/lib.rb
+++ b/test/resources/repos/ruby/test_repo/lib.rb
@@ -1,0 +1,9 @@
+class Calculator
+  def add(a, b)
+    a + b
+  end
+
+  def subtract(a, b)
+    a - b
+  end
+end

--- a/test/resources/repos/ruby/test_repo/main.rb
+++ b/test/resources/repos/ruby/test_repo/main.rb
@@ -1,3 +1,5 @@
+require './lib.rb'
+
 class DemoClass
   attr_accessor :value
 
@@ -12,6 +14,7 @@ end
 
 def helper_function(number = 42)
   demo = DemoClass.new(number)
+  Calculator.new.add(demo.value, 10)
   demo.print_value
 end
 

--- a/test/resources/repos/ruby/test_repo/main.rb
+++ b/test/resources/repos/ruby/test_repo/main.rb
@@ -1,0 +1,18 @@
+class DemoClass
+  attr_accessor :value
+
+  def initialize(value)
+    @value = value
+  end
+
+  def print_value
+    puts @value
+  end
+end
+
+def helper_function(number = 42)
+  demo = DemoClass.new(number)
+  demo.print_value
+end
+
+helper_function

--- a/test/solidlsp/ruby/test_ruby_basic.py
+++ b/test/solidlsp/ruby/test_ruby_basic.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -25,4 +26,17 @@ class TestRubyLanguageServer:
             if sym.get("name") == "helper_function":
                 helper_symbol = sym
                 break
+        print(helper_symbol)
         assert helper_symbol is not None, "Could not find 'helper_function' symbol in main.rb"   
+
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.RUBY], indirect=True)  
+    def test_find_definition_across_files(self, language_server: SolidLanguageServer, repo_path: Path) -> None:        
+        # Test finding Calculator.add method definition from line 17: Calculator.new.add(demo.value, 10)
+        definition_location_list = language_server.request_definition(str(repo_path / "main.rb"), 16,17)  # add method at line 17 (0-indexed 16), position 17
+           
+        assert len(definition_location_list) == 1
+        definition_location = definition_location_list[0]
+        print(f"Found definition: {definition_location}")
+        assert definition_location["uri"].endswith("lib.rb")
+        assert definition_location["range"]["start"]["line"] == 1  # add method on line 2 (0-indexed 1)

--- a/test/solidlsp/ruby/test_ruby_basic.py
+++ b/test/solidlsp/ruby/test_ruby_basic.py
@@ -1,0 +1,28 @@
+import os
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+from solidlsp.ls_utils import SymbolUtils
+
+
+@pytest.mark.ruby
+class TestRubyLanguageServer:
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    def test_find_symbol(self, language_server: SolidLanguageServer) -> None:
+        symbols = language_server.request_full_symbol_tree()
+        assert SymbolUtils.symbol_tree_contains_name(symbols, "DemoClass"), "DemoClass not found in symbol tree"
+        assert SymbolUtils.symbol_tree_contains_name(symbols, "helper_function"), "helper_function not found in symbol tree"
+        assert SymbolUtils.symbol_tree_contains_name(symbols, "print_value"), "print_value not found in symbol tree"
+
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    def test_find_referencing_symbols(self, language_server: SolidLanguageServer) -> None:
+        file_path = os.path.join("main.rb")
+        symbols = language_server.request_document_symbols(file_path)
+        helper_symbol = None
+        for sym in symbols[0]:
+            if sym.get("name") == "helper_function":
+                helper_symbol = sym
+                break
+        assert helper_symbol is not None, "Could not find 'helper_function' symbol in main.rb"   


### PR DESCRIPTION
This pull request adds initial support and tests for the Ruby language server integration. The main focus is on enabling and verifying Ruby language server functionality, including symbol detection and referencing in test repositories.

**Ruby language server integration:**

* Added `"ruby: language server running for Ruby"` marker to `pyproject.toml` to recognize Ruby language server status.
* Introduced a sample Ruby project in `test/resources/repos/ruby/test_repo/` with a `.solargraph.yml` configuration and a `main.rb` file containing example Ruby code for testing. [[1]](diffhunk://#diff-5f3ab12ac62a0089a91ede9c022a66a7cde1b9c14dd24bb75c859c03efe442f9R1-R3) [[2]](diffhunk://#diff-307747c41e30bc467f5acb170a9331e9192d75ac6cfa9f5d51303e9f9e67026eR1-R18)

**Testing and validation:**

* Added `test_ruby_basic.py` with tests to verify that the Ruby language server can find symbols and referencing symbols in the sample Ruby project.