### PR TITLE
fix: remove incorrect description of supporting directories from `get_symbols_overview` docs

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -33,7 +33,7 @@ read_only: false
 #  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
 #  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
 #  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file or directory.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
 #  * `initial_instructions`: Gets the initial instructions for the current project.
 #     Should only be used in settings where the system prompt cannot be set,
 #     e.g. in clients you have no control over, like Claude Desktop.

--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ Here is the list of Serena's default tools with a short description (output of `
  * `find_file`: Finds files in the given relative paths
  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
- * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file or directory.
+ * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).

--- a/src/serena/resources/config/modes/editing.yml
+++ b/src/serena/resources/config/modes/editing.yml
@@ -16,8 +16,8 @@ prompt: |
   Let us first discuss the symbol-based approach.
   Symbols are identified by their name path and relative file path, see the description of the `find_symbol` tool for more details
   on how the `name_path` matches symbols.
-  You can get information about available symbols by using the `get_symbols_overview` tool for finding top-level symbols in a file
-  or directory, or by using `find_symbol` if you already know the symbol's name path. You generally try to read as little code as possible
+  You can get information about available symbols by using the `get_symbols_overview` tool for finding top-level symbols in a file,
+  or by using `find_symbol` if you already know the symbol's name path. You generally try to read as little code as possible
   while still solving your task, meaning you only read the bodies when you need to, and after you have found the symbol you want to edit.
   Before calling symbolic reading tools, you should have a basic understanding of the repository structure that you can get from memories
   or by using the `list_dir` and `find_file` tools (or similar).

--- a/src/serena/resources/config/prompt_templates/system_prompt.yml
+++ b/src/serena/resources/config/prompt_templates/system_prompt.yml
@@ -38,8 +38,8 @@ prompts:
     {% if 'ToolMarkerSymbolicRead' in available_markers %}
     Symbols are identified by their `name_path and `relative_path`, see the description of the `find_symbol` tool for more details
     on how the `name_path` matches symbols.
-    You can get information about available symbols by using the `get_symbols_overview` tool for finding top-level symbols in a file
-    or directory, or by using `find_symbol` if you already know the symbol's name path. You generally try to read as little code as possible
+    You can get information about available symbols by using the `get_symbols_overview` tool for finding top-level symbols in a file,
+    or by using `find_symbol` if you already know the symbol's name path. You generally try to read as little code as possible
     while still solving your task, meaning you only read the bodies when you need to, and after you have found the symbol you want to edit.
     For example, if you are working with python code and already know that you need to read the body of the constructor of the class Foo, you can directly
     use `find_symbol` with the name path `Foo/__init__` and `include_body=True`. If you don't know yet which methods in `Foo` you need to read or edit,

--- a/src/serena/resources/project.template.yml
+++ b/src/serena/resources/project.template.yml
@@ -35,7 +35,7 @@ read_only: false
 #  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
 #  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
 #  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file or directory.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
 #  * `initial_instructions`: Gets the initial instructions for the current project.
 #     Should only be used in settings where the system prompt cannot be set,
 #     e.g. in clients you have no control over, like Claude Desktop.

--- a/src/serena/tools/symbol_tools.py
+++ b/src/serena/tools/symbol_tools.py
@@ -48,7 +48,7 @@ class RestartLanguageServerTool(Tool):
 
 class GetSymbolsOverviewTool(Tool, ToolMarkerSymbolicRead):
     """
-    Gets an overview of the top-level symbols defined in a given file or directory.
+    Gets an overview of the top-level symbols defined in a given file.
     """
 
     def apply(self, relative_path: str, max_answer_chars: int = TOOL_DEFAULT_MAX_ANSWER_LENGTH) -> str:
@@ -57,11 +57,10 @@ class GetSymbolsOverviewTool(Tool, ToolMarkerSymbolicRead):
         This should be the first tool to call when you want to understand a new file, unless you already know
         what you are looking for.
 
-        :param relative_path: the relative path to the file or directory to get the overview of
+        :param relative_path: the relative path to the file to get the overview of
         :param max_answer_chars: if the overview is longer than this number of characters,
             no content will be returned. Don't adjust unless there is really no other way to get the content
-            required for the task. If the overview is too long, you should use a smaller directory instead,
-            (e.g. a subdirectory).
+            required for the task.
         :return: a JSON object containing info about top-level symbols in the file
         """
         symbol_retriever = self.create_language_server_symbol_retriever()


### PR DESCRIPTION
I noticed that models often use `get_symbols_overview` on a directory only to get an error because the tool does not support directories. The issue was that the description and usage instructions for the tool incorrectly mentioned support for directories.