### PR TITLE
tools: safer cmd execution with preflight + timeout summaries

### DIFF
--- a/src/serena/tools/cmd_tools.py
+++ b/src/serena/tools/cmd_tools.py
@@ -2,6 +2,9 @@
 Tools supporting the execution of (external) commands
 """
 
+import shlex
+import shutil
+
 from serena.tools import TOOL_DEFAULT_MAX_ANSWER_LENGTH, Tool, ToolMarkerCanEdit
 from serena.util.shell import execute_shell_command
 
@@ -17,6 +20,9 @@ class ExecuteShellCommandTool(Tool, ToolMarkerCanEdit):
         cwd: str | None = None,
         capture_stderr: bool = True,
         max_answer_chars: int = TOOL_DEFAULT_MAX_ANSWER_LENGTH,
+        timeout: float | None = None,
+        preflight: bool = True,
+        preflight_cmds: list[str] | None = None,
     ) -> str:
         """
         Execute a shell command and return its output. If there is a memory about suggested commands, read that first.
@@ -31,6 +37,59 @@ class ExecuteShellCommandTool(Tool, ToolMarkerCanEdit):
         :return: a JSON object containing the command's stdout and optionally stderr output
         """
         _cwd = cwd or self.get_project_root()
-        result = execute_shell_command(command, cwd=_cwd, capture_stderr=capture_stderr)
-        result = result.json()
-        return self._limit_length(result, max_answer_chars)
+
+        # Lightweight, generic preflight (tool-agnostic)
+        # 1) Ensure the target binary exists in PATH
+        if preflight:
+            try:
+                parts = shlex.split(command)
+                exe = parts[0] if parts else None
+            except Exception:
+                exe = None
+            if exe and shutil.which(exe) is None:
+                return self._limit_length(
+                    '{"error":"executable not found in PATH","exe":"' + exe + '","hint":"Install it or adjust PATH"}',
+                    max_answer_chars,
+                )
+            # 2) Optional caller-provided preflight checks (fast, tool-agnostic)
+            if preflight_cmds:
+                for check in preflight_cmds:
+                    probe = execute_shell_command(check, cwd=_cwd, capture_stderr=True, timeout=5)
+                    if probe.return_code != 0:
+                        import json as _json
+
+                        payload = {
+                            "error": "preflight check failed",
+                            "check": check,
+                            "summary": {
+                                "exit_code": probe.return_code,
+                                "stderr_tail": (probe.stderr or "")[-512:],
+                                "stdout_tail": (probe.stdout or "")[-512:],
+                                "cwd": probe.cwd,
+                            },
+                        }
+                        return self._limit_length(_json.dumps(payload), max_answer_chars)
+
+        result = execute_shell_command(command, cwd=_cwd, capture_stderr=capture_stderr, timeout=timeout)
+        payload = result.model_dump()  # dict
+
+        # Add a concise summary for non-zero exit or timeout to improve downstream logs
+        if result.return_code != 0:
+            stderr_tail = (result.stderr or "")[-1024:]
+            stdout_tail = (result.stdout or "")[-1024:]
+            summary = {
+                "summary": {
+                    "exit_code": result.return_code,
+                    "stderr_tail": stderr_tail,
+                    "stdout_tail": stdout_tail,
+                    "cwd": result.cwd,
+                }
+            }
+            try:
+                payload.update(summary)
+            except Exception:
+                pass
+
+        import json
+
+        return self._limit_length(json.dumps(payload), max_answer_chars)


### PR DESCRIPTION
Summary
- Add lightweight, tool-agnostic preflight to ExecuteShellCommandTool (PATH executable check; optional caller-specified probes)
- Capture timeout safely in util.shell.execute_shell_command: return code 124, include best-effort stdout/stderr tails
- Enrich non-zero exit payloads with concise summary tails to improve downstream logs/UX
- Improve Tool.apply_ex error reporting with explicit timeout hint

Motivation
- Reduce silent stalls and provide actionable failure context without dumping large outputs
- Keep design tool-agnostic and portable (no Docker/OS-specific logic)

Details
- serena/util/shell.py: add TimeoutExpired handling, return ShellCommandResult with cwd/stdout/stderr/return_code
- serena/tools/cmd_tools.py: preflight checks (PATH; optional preflight_cmds), structured JSON payload with summary for non-zero exit/timeout
- serena/tools/tools_base.py: clearer timeout error hinting in tool wrapper

Tests
- Ran unit tests locally with dev deps
  206 passed, 1 skipped, 188 deselected (language-server-heavy suites not required for this change)

Compatibility
- Backward compatible JSON shape extension (adds fields but preserves existing keys); preflight is opt-out via preflight=False

Sign-off: Xopoko <devnull@example.com>
