### PR TITLE
Fix ListDirTool FileNotFoundError for non-existent directories

### DIFF
--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -100,6 +100,15 @@ class ListDirTool(Tool):
             required for the task.
         :return: a JSON object with the names of directories and files within the given directory
         """
+        # Check if the directory exists before validation
+        if not self.project.relative_path_exists(relative_path):
+            error_info = {
+                "error": f"Directory not found: {relative_path}",
+                "project_root": self.get_project_root(),
+                "hint": "Check if the path is correct relative to the project root",
+            }
+            return json.dumps(error_info)
+
         self.project.validate_relative_path(relative_path)
 
         dirs, files = scan_directory(


### PR DESCRIPTION
 Now when LLMs try to access non-existent paths, they get clear feedback about what went wrong and where they are in the filesystem.


Similar to fix in commit 8464f25 for CreateTextFileTool