### PR TITLE
feat(solidlsp): add ruby-lsp language server support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
   "tqdm>=4.67.1",
   "tiktoken>=0.9.0",
   "anthropic>=0.54.0",
+  "typing-extensions>=4.14.1",
+  "lsprotocol>=2025.0.0",
 ]
 
 [[tool.uv.index]]
@@ -270,5 +272,11 @@ markers = [
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git*,*.svg,*.lock,*.min.*'
 check-hidden = true
-# ignore-regex = ''
-# ignore-words-list = ''
+
+[dependency-groups]
+dev = [
+    "black>=25.1.0",
+    "mypy>=1.17.0",
+    "ruff>=0.12.5",
+    "types-requests>=2.32.4.20250809",
+]

--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -1,0 +1,334 @@
+import json
+import logging
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import threading
+
+from typing_extensions import override
+
+from solidlsp.ls import SolidLanguageServer
+from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_logger import LanguageServerLogger
+from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
+from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
+
+
+class RubyLSP(SolidLanguageServer):
+    """
+    Provides Ruby specific instantiation of the LanguageServer class using ruby-lsp.
+    Contains various configurations and settings specific to Ruby.
+    """
+
+    def __init__(
+        self, config: LanguageServerConfig, logger: LanguageServerLogger, repository_root_path: str, solidlsp_settings: SolidLSPSettings
+    ):
+        """
+        Creates a RubyLSP instance. This class is not meant to be instantiated directly.
+        Use LanguageServer.create() instead.
+        """
+        ruby_lsp_executable_path = self._setup_runtime_dependencies(logger, config, repository_root_path)
+        super().__init__(
+            config,
+            logger,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=f"{ruby_lsp_executable_path}", cwd=repository_root_path),
+            "ruby",
+            solidlsp_settings,
+        )
+        self.analysis_complete = threading.Event()
+        self.service_ready_event = threading.Event()
+
+        # Set timeout for ruby-lsp requests
+        self.set_request_timeout(60.0)  # 60 seconds for initialization and requests
+
+    @override
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        ruby_ignored_dirs = [
+            "vendor",  # Ruby vendor directory
+            ".bundle",  # Bundler cache
+            "tmp",  # Temporary files
+            "log",  # Log files
+            "coverage",  # Test coverage reports
+            ".yardoc",  # YARD documentation cache
+            "doc",  # Generated documentation
+            "node_modules",  # Node modules (for Rails with JS)
+            "storage",  # Active Storage files (Rails)
+        ]
+        return super().is_ignored_dirname(dirname) or dirname in ruby_ignored_dirs
+
+    @staticmethod
+    def _setup_runtime_dependencies(logger: LanguageServerLogger, config: LanguageServerConfig, repository_root_path: str) -> str:
+        """
+        Setup runtime dependencies for ruby-lsp and return the command to start the server.
+        """
+        # Check if Ruby is installed
+        try:
+            result = subprocess.run(["ruby", "--version"], check=True, capture_output=True, cwd=repository_root_path, text=True)
+            ruby_version = result.stdout.strip()
+            logger.log(f"Ruby version: {ruby_version}", logging.INFO)
+
+            # Extract version number for compatibility checks
+            version_match = re.search(r"ruby (\d+)\.(\d+)\.(\d+)", ruby_version)
+            if version_match:
+                major, minor, patch = map(int, version_match.groups())
+                if major < 3 or (major == 3 and minor < 0):
+                    logger.log(f"Warning: Ruby {major}.{minor}.{patch} detected. ruby-lsp works best with Ruby 3.0+", logging.WARNING)
+
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr.decode() if e.stderr else "Unknown error"
+            raise RuntimeError(
+                f"Error checking Ruby installation: {error_msg}. Please ensure Ruby is properly installed and in PATH."
+            ) from e
+        except FileNotFoundError as e:
+            raise RuntimeError(
+                "Ruby is not installed or not found in PATH. Please install Ruby using one of these methods:\n"
+                "  - Using rbenv: rbenv install 3.2.0 && rbenv global 3.2.0\n"
+                "  - Using RVM: rvm install 3.2.0 && rvm use 3.2.0 --default\n"
+                "  - Using asdf: asdf install ruby 3.2.0 && asdf global ruby 3.2.0\n"
+                "  - System package manager (brew install ruby, apt install ruby, etc.)"
+            ) from e
+
+        # Check for Bundler project (Gemfile exists)
+        gemfile_path = os.path.join(repository_root_path, "Gemfile")
+        gemfile_lock_path = os.path.join(repository_root_path, "Gemfile.lock")
+        is_bundler_project = os.path.exists(gemfile_path)
+
+        if is_bundler_project:
+            logger.log("Detected Bundler project (Gemfile found)", logging.INFO)
+
+            # Check if bundle command is available
+            bundle_path = shutil.which("bundle")
+            if not bundle_path:
+                # Try common bundle executables
+                for bundle_cmd in ["bin/bundle", "bundle"]:
+                    bundle_full_path = (
+                        os.path.join(repository_root_path, bundle_cmd) if bundle_cmd.startswith("bin/") else shutil.which(bundle_cmd)
+                    )
+                    if bundle_full_path and os.path.exists(bundle_full_path):
+                        bundle_path = bundle_full_path if bundle_cmd.startswith("bin/") else bundle_cmd
+                        break
+
+            if not bundle_path:
+                raise RuntimeError(
+                    "Bundler project detected but 'bundle' command not found. Please install Bundler:\n"
+                    "  - gem install bundler\n"
+                    "  - Or use your Ruby version manager's bundler installation\n"
+                    "  - Ensure the bundle command is in your PATH"
+                )
+
+            # Check if ruby-lsp is in Gemfile.lock
+            ruby_lsp_in_bundle = False
+            if os.path.exists(gemfile_lock_path):
+                try:
+                    with open(gemfile_lock_path) as f:
+                        content = f.read()
+                        ruby_lsp_in_bundle = "ruby-lsp" in content.lower()
+                except Exception as e:
+                    logger.log(f"Warning: Could not read Gemfile.lock: {e}", logging.WARNING)
+
+            if ruby_lsp_in_bundle:
+                logger.log("Found ruby-lsp in Gemfile.lock", logging.INFO)
+                return f"{bundle_path} exec ruby-lsp"
+            else:
+                logger.log(
+                    "ruby-lsp not found in Gemfile.lock. Please add 'gem \"ruby-lsp\"' to your Gemfile and run 'bundle install'",
+                    logging.WARNING,
+                )
+                # Fall through to global installation check
+
+        # Check if ruby-lsp is installed globally
+        # First, try to find ruby-lsp in PATH (includes asdf shims)
+        ruby_lsp_path = shutil.which("ruby-lsp")
+        if ruby_lsp_path:
+            logger.log(f"Found ruby-lsp at: {ruby_lsp_path}", logging.INFO)
+            return ruby_lsp_path
+
+        # Fallback to gem exec (for non-Bundler projects or when global ruby-lsp not found)
+        if not is_bundler_project:
+            dependency = {
+                "url": "https://rubygems.org/downloads/ruby-lsp-0.17.17.gem",
+                "installCommand": "gem install ruby-lsp -v 0.17.17",
+                "binaryName": "ruby-lsp",
+                "archiveType": "gem",
+            }
+
+            try:
+                result = subprocess.run(
+                    ["gem", "list", "^ruby-lsp$", "-i"], check=False, capture_output=True, text=True, cwd=repository_root_path
+                )
+                if result.stdout.strip() == "false":
+                    logger.log("Installing ruby-lsp...", logging.INFO)
+                    subprocess.run(dependency["installCommand"].split(), check=True, capture_output=True, cwd=repository_root_path)
+
+                return "gem exec ruby-lsp"
+            except subprocess.CalledProcessError as e:
+                error_msg = e.stderr.decode() if e.stderr else str(e)
+                raise RuntimeError(
+                    f"Failed to check or install ruby-lsp: {error_msg}\nPlease try installing manually: gem install ruby-lsp"
+                ) from e
+        else:
+            raise RuntimeError(
+                "This appears to be a Bundler project, but ruby-lsp is not available. "
+                "Please add 'gem \"ruby-lsp\"' to your Gemfile and run 'bundle install'."
+            )
+
+    @staticmethod
+    def _detect_rails_project(repository_root_path: str) -> bool:
+        """
+        Detect if this is a Rails project by checking for Rails-specific files.
+        """
+        rails_indicators = [
+            "config/application.rb",
+            "config/environment.rb",
+            "app/controllers/application_controller.rb",
+            "Rakefile",
+        ]
+
+        for indicator in rails_indicators:
+            if os.path.exists(os.path.join(repository_root_path, indicator)):
+                return True
+
+        # Check for Rails in Gemfile
+        gemfile_path = os.path.join(repository_root_path, "Gemfile")
+        if os.path.exists(gemfile_path):
+            try:
+                with open(gemfile_path) as f:
+                    content = f.read().lower()
+                    if "gem 'rails'" in content or 'gem "rails"' in content:
+                        return True
+            except Exception:
+                pass
+
+        return False
+
+    @staticmethod
+    def _get_ruby_exclude_patterns(repository_root_path: str) -> list[str]:
+        """
+        Get Ruby and Rails-specific exclude patterns for better performance.
+        """
+        base_patterns = [
+            "**/vendor/**",  # Ruby vendor directory (similar to node_modules)
+            "**/.bundle/**",  # Bundler cache
+            "**/tmp/**",  # Temporary files
+            "**/log/**",  # Log files
+            "**/coverage/**",  # Test coverage reports
+            "**/.yardoc/**",  # YARD documentation cache
+            "**/doc/**",  # Generated documentation
+            "**/.git/**",  # Git directory
+            "**/node_modules/**",  # Node modules (for Rails with JS)
+            "**/public/assets/**",  # Rails compiled assets
+        ]
+
+        # Add Rails-specific patterns if this is a Rails project
+        if RubyLSP._detect_rails_project(repository_root_path):
+            rails_patterns = [
+                "**/public/packs/**",  # Webpacker output
+                "**/public/webpack/**",  # Webpack output
+                "**/storage/**",  # Active Storage files
+                "**/tmp/cache/**",  # Rails cache
+                "**/tmp/pids/**",  # Process IDs
+                "**/tmp/sessions/**",  # Session files
+                "**/tmp/sockets/**",  # Socket files
+                "**/db/*.sqlite3",  # SQLite databases
+            ]
+            base_patterns.extend(rails_patterns)
+
+        return base_patterns
+
+    @staticmethod
+    def _get_initialize_params(repository_absolute_path: str) -> InitializeParams:
+        """
+        Returns the initialize params for the ruby-lsp Language Server.
+        """
+        root_uri = pathlib.Path(repository_absolute_path).as_uri()
+
+        initialize_params: InitializeParams = {  # type: ignore
+            "processId": os.getpid(),
+            "rootPath": repository_absolute_path,
+            "rootUri": root_uri,
+            "initializationOptions": {
+                "enabledFeatures": {
+                    "diagnostics": True,
+                    "documentSymbols": True,
+                    "foldingRanges": True,
+                    "selectionRanges": True,
+                    "semanticHighlighting": True,
+                    "formatting": True,
+                    "codeActions": True,
+                },
+                "featuresConfiguration": {
+                    "inlayHint": {"enableAll": True},
+                },
+            },
+            "capabilities": {
+                "workspace": {
+                    "workspaceEdit": {"documentChanges": True},
+                },
+                "textDocument": {
+                    "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": True,
+                        "symbolKind": {"valueSet": list(range(1, 27))},
+                    },
+                },
+            },
+            "trace": "verbose",
+            "workspaceFolders": [
+                {
+                    "uri": root_uri,
+                    "name": os.path.basename(repository_absolute_path),
+                }
+            ],
+        }
+        return initialize_params
+
+    def _start_server(self):
+        """
+        Starts the ruby-lsp Language Server for Ruby
+        """
+
+        def window_log_message(msg):
+            self.logger.log(f"LSP: window/logMessage: {msg}", logging.INFO)
+
+        def do_nothing(params):
+            return
+
+        self.server.on_notification("window/logMessage", window_log_message)
+        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+
+        self.logger.log("Starting ruby-lsp server process", logging.INFO)
+        self.server.start()
+        initialize_params = self._get_initialize_params(self.repository_root_path)
+
+        self.logger.log(
+            "Sending initialize request from LSP client to LSP server and awaiting response",
+            logging.INFO,
+        )
+        self.logger.log(f"Sending init params: {json.dumps(initialize_params, indent=4)}", logging.INFO)
+        init_response = self.server.send.initialize(initialize_params)
+        self.logger.log(f"Received init response: {init_response}", logging.INFO)
+
+        # ruby-lsp may use different sync modes
+        text_sync = init_response["capabilities"].get("textDocumentSync")
+        self.logger.log(f"ruby-lsp textDocumentSync mode: {text_sync}", logging.INFO)
+
+        # Accept various sync modes (incremental=2, full=1, none=0)
+        if isinstance(text_sync, dict):
+            # Some servers return an object instead of just a number
+            sync_change = text_sync.get("change", 0)
+            assert sync_change in [0, 1, 2], f"Unexpected textDocumentSync change mode: {sync_change}"
+        else:
+            assert text_sync in [0, 1, 2], f"Unexpected textDocumentSync mode: {text_sync}"
+
+        assert "completionProvider" in init_response["capabilities"]
+
+        self.server.notify.initialized({})
+
+        # ruby-lsp doesn't require special analysis completion waiting like solargraph
+        self.logger.log("ruby-lsp server ready", logging.INFO)
+        self.analysis_complete.set()
+        self.completions_available.set()

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -193,9 +193,17 @@ class SolidLanguageServer(ABC):
             ls = Gopls(config, logger, repository_root_path, solidlsp_settings=solidlsp_settings)
 
         elif config.code_language == Language.RUBY:
-            from solidlsp.language_servers.solargraph import Solargraph
+            # Choose Ruby LSP based on environment variable
+            ruby_lsp_type = os.environ.get("SOLIDLSP_RUBY_LSP", "solargraph").lower()
 
-            ls = Solargraph(config, logger, repository_root_path, solidlsp_settings=solidlsp_settings)
+            if ruby_lsp_type == "ruby-lsp" or ruby_lsp_type == "ruby_lsp":
+                from solidlsp.language_servers.ruby_lsp import RubyLSP
+
+                ls = RubyLSP(config, logger, repository_root_path, solidlsp_settings=solidlsp_settings)
+            else:  # default to solargraph
+                from solidlsp.language_servers.solargraph import Solargraph
+
+                ls = Solargraph(config, logger, repository_root_path, solidlsp_settings=solidlsp_settings)
 
         elif config.code_language == Language.DART:
             from solidlsp.language_servers.dart_language_server import DartLanguageServer

--- a/test/solidlsp/ruby/test_ruby_lsp_basic.py
+++ b/test/solidlsp/ruby/test_ruby_lsp_basic.py
@@ -1,0 +1,44 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+from solidlsp.ls_utils import SymbolUtils
+
+
+@pytest.mark.ruby
+class TestRubyLSPLanguageServer:
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    def test_find_symbol(self, language_server: SolidLanguageServer) -> None:
+        symbols = language_server.request_full_symbol_tree()
+        assert SymbolUtils.symbol_tree_contains_name(symbols, "DemoClass"), "DemoClass not found in symbol tree"
+        assert SymbolUtils.symbol_tree_contains_name(symbols, "helper_function"), "helper_function not found in symbol tree"
+        assert SymbolUtils.symbol_tree_contains_name(symbols, "print_value"), "print_value not found in symbol tree"
+
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    def test_find_referencing_symbols(self, language_server: SolidLanguageServer) -> None:
+        file_path = os.path.join("main.rb")
+        symbols = language_server.request_document_symbols(file_path)
+        helper_symbol = None
+        for sym in symbols[0]:
+            if sym.get("name") == "helper_function":
+                helper_symbol = sym
+                break
+        print(helper_symbol)
+        assert helper_symbol is not None, "Could not find 'helper_function' symbol in main.rb"
+
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.RUBY], indirect=True)
+    def test_find_definition_across_files(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        # Test finding Calculator.add method definition from line 17: Calculator.new.add(demo.value, 10)
+        definition_location_list = language_server.request_definition(
+            str(repo_path / "main.rb"), 16, 17
+        )  # add method at line 17 (0-indexed 16), position 17
+
+        assert len(definition_location_list) == 1
+        definition_location = definition_location_list[0]
+        print(f"Found definition: {definition_location}")
+        assert definition_location["uri"].endswith("lib.rb")
+        assert definition_location["range"]["start"]["line"] == 1  # add method on line 2 (0-indexed 1)

--- a/test/solidlsp/ruby/test_ruby_lsp_symbol_retrieval.py
+++ b/test/solidlsp/ruby/test_ruby_lsp_symbol_retrieval.py
@@ -1,0 +1,138 @@
+import os
+
+import pytest
+from lsprotocol.types import SymbolKind
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+
+pytestmark = [pytest.mark.ruby]
+
+
+class TestRubyLSPLanguageServerSymbols:
+    """Test the ruby-lsp language server's symbol-related functionality."""
+
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    def test_request_containing_symbol_method(self, language_server: SolidLanguageServer) -> None:
+        """Test request_containing_symbol for a method."""
+        # Test for a position inside the create_user method
+        file_path = os.path.join("services.rb")
+        # Look for a position inside the create_user method body
+        containing_symbol = language_server.request_containing_symbol(file_path, 11, 10, include_body=True)
+
+        # Verify that we found the containing symbol
+        assert containing_symbol is not None, "Should find containing symbol for method position"
+        assert containing_symbol["name"] == "create_user", f"Expected 'create_user', got '{containing_symbol['name']}'"
+        assert (
+            containing_symbol["kind"] == SymbolKind.Method.value
+        ), f"Expected Method kind ({SymbolKind.Method.value}), got {containing_symbol['kind']}"
+
+        # Verify location information
+        assert "location" in containing_symbol, "Containing symbol should have location information"
+        location = containing_symbol["location"]
+        assert "range" in location, "Location should contain range information"
+        assert "start" in location["range"], "Range should have start position"
+        assert "end" in location["range"], "Range should have end position"
+
+        # Verify container information
+        if "containerName" in containing_symbol:
+            assert containing_symbol["containerName"] in [
+                "Services::UserService",
+                "UserService",
+            ], f"Expected UserService container, got '{containing_symbol['containerName']}'"
+
+        # Verify body content if available
+        if "body" in containing_symbol:
+            body = containing_symbol["body"]
+            assert "def create_user" in body, "Method body should contain method definition"
+            assert len(body.strip()) > 0, "Method body should not be empty"
+
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    def test_request_containing_symbol_class(self, language_server: SolidLanguageServer) -> None:
+        """Test request_containing_symbol for a class."""
+        # Test for a position inside the UserService class but outside any method
+        file_path = os.path.join("services.rb")
+        # Line around the class definition
+        containing_symbol = language_server.request_containing_symbol(file_path, 5, 5)
+
+        # Verify that we found the containing symbol
+        assert containing_symbol is not None, "Should find containing symbol for class position"
+        assert containing_symbol["name"] == "UserService", f"Expected 'UserService', got '{containing_symbol['name']}'"
+        assert (
+            containing_symbol["kind"] == SymbolKind.Class.value
+        ), f"Expected Class kind ({SymbolKind.Class.value}), got {containing_symbol['kind']}"
+
+        # Verify location information exists
+        assert "location" in containing_symbol, "Class symbol should have location information"
+        location = containing_symbol["location"]
+        assert "range" in location, "Location should contain range"
+        assert "start" in location["range"] and "end" in location["range"], "Range should have start and end positions"
+
+        # Verify the class is properly nested in the Services module
+        if "containerName" in containing_symbol:
+            assert (
+                containing_symbol["containerName"] == "Services"
+            ), f"Expected 'Services' as container, got '{containing_symbol['containerName']}'"
+
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    def test_document_symbols_detailed(self, language_server: SolidLanguageServer) -> None:
+        """Test document symbols for detailed Ruby file structure."""
+        file_path = os.path.join("models.rb")
+        symbols, roots = language_server.request_document_symbols(file_path)
+
+        # Verify we have symbols
+        assert len(symbols) > 0 or len(roots) > 0
+
+        # Look for expected class names
+        symbol_names = set()
+        all_symbols = symbols if symbols else roots
+
+        for symbol in all_symbols:
+            symbol_names.add(symbol.get("name"))
+            # Add children names too
+            if "children" in symbol:
+                for child in symbol["children"]:
+                    symbol_names.add(child.get("name"))
+
+        # We should find at least some of our defined classes/methods
+        expected_symbols = {"User", "Item", "Order", "ItemHelpers"}
+        found_symbols = symbol_names.intersection(expected_symbols)
+        assert len(found_symbols) > 0, f"Expected symbols not found. Found: {symbol_names}"
+
+    @pytest.mark.parametrize("language_server", [Language.RUBY], indirect=True)
+    def test_request_dir_overview(self, language_server: SolidLanguageServer) -> None:
+        """Test that request_dir_overview returns correct symbol information for files in a directory."""
+        # Get overview of the test repo directory
+        overview = language_server.request_dir_overview(".")
+
+        # Verify that we have entries for our main files
+        expected_files = ["services.rb", "models.rb", "variables.rb", "nested.rb"]
+        found_files = []
+
+        for file_path in overview.keys():
+            for expected in expected_files:
+                if expected in file_path:
+                    found_files.append(expected)
+                    break
+
+        assert len(found_files) >= 2, f"Should find at least 2 expected files, found: {found_files}"
+
+        # Test specific symbols from services.rb if it exists
+        services_file_key = None
+        for file_path in overview.keys():
+            if "services.rb" in file_path:
+                services_file_key = file_path
+                break
+
+        if services_file_key:
+            services_symbols = overview[services_file_key]
+            assert len(services_symbols) > 0, "services.rb should have symbols"
+
+            # Check for expected symbols with detailed verification
+            symbol_names = [s[0] for s in services_symbols if isinstance(s, tuple) and len(s) > 0]
+            if not symbol_names:  # If not tuples, try different format
+                symbol_names = [s.get("name") for s in services_symbols if hasattr(s, "get")]
+
+            expected_symbols = ["Services", "UserService", "ItemService"]
+            found_expected = [name for name in expected_symbols if name in symbol_names]
+            assert len(found_expected) >= 1, f"Should find at least one expected symbol, found: {found_expected} in {symbol_names}"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.11.*"
 
 [[package]]
@@ -126,6 +126,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "25.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/2b/561d78f488dcc303da4639e02021311728fb7fda8006dd2835550cddd9ed/cattrs-25.1.1.tar.gz", hash = "sha256:c914b734e0f2d59e5b720d145ee010f1fd9a13ee93900922a2f3f9d593b8382c", size = 435016, upload-time = "2025-06-04T20:27:15.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/b0/215274ef0d835bbc1056392a367646648b6084e39d489099959aefcca2af/cattrs-25.1.1-py3-none-any.whl", hash = "sha256:1b40b2d3402af7be79a7e7e097a9b4cd16d4c06e6d526644b0b26a063a1cc064", size = 69386, upload-time = "2025-06-04T20:27:13.969Z" },
 ]
 
 [[package]]
@@ -512,6 +525,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513, upload-time = "2025-04-23T12:34:07.418Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437, upload-time = "2025-04-23T12:34:05.422Z" },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
 ]
 
 [[package]]
@@ -1125,6 +1151,7 @@ dependencies = [
     { name = "flask" },
     { name = "jinja2" },
     { name = "joblib" },
+    { name = "lsprotocol" },
     { name = "mcp" },
     { name = "overrides" },
     { name = "pathspec" },
@@ -1139,6 +1166,7 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tqdm" },
     { name = "types-pyyaml" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -1162,6 +1190,14 @@ google = [
     { name = "google-genai" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "black" },
+    { name = "mypy" },
+    { name = "ruff" },
+    { name = "types-requests" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "agno", marker = "extra == 'agno'", specifier = ">=1.2.6" },
@@ -1174,6 +1210,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jinja2", marker = "extra == 'dev'" },
     { name = "joblib", specifier = ">=1.5.1" },
+    { name = "lsprotocol", specifier = ">=2025.0.0" },
     { name = "mcp", specifier = "==1.12.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.16.1" },
     { name = "overrides", specifier = ">=7.7.0,<8" },
@@ -1197,8 +1234,17 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20241230" },
+    { name = "typing-extensions", specifier = ">=4.14.1" },
 ]
 provides-extras = ["dev", "agno", "google"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "black", specifier = ">=25.1.0" },
+    { name = "mypy", specifier = ">=1.17.0" },
+    { name = "ruff", specifier = ">=0.12.5" },
+    { name = "types-requests", specifier = ">=2.32.4.20250809" },
+]
 
 [[package]]
 name = "shellingham"
@@ -1418,6 +1464,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload-time = "2025-05-16T03:08:04.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530", size = 20312, upload-time = "2025-05-16T03:08:04.019Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20250809"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/b0/9355adb86ec84d057fea765e4c49cce592aaf3d5117ce5609a95a7fc3dac/types_requests-2.32.4.20250809.tar.gz", hash = "sha256:d8060de1c8ee599311f56ff58010fb4902f462a1470802cf9f6ed27bc46c4df3", size = 23027, upload-time = "2025-08-09T03:17:10.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/6f/ec0012be842b1d888d46884ac5558fd62aeae1f0ec4f7a581433d890d4b5/types_requests-2.32.4.20250809-py3-none-any.whl", hash = "sha256:f73d1832fb519ece02c85b1f09d5f0dd3108938e7d47e7f94bbfa18a6782b163", size = 20644, upload-time = "2025-08-09T03:17:09.716Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add new RubyLSP class with comprehensive Ruby environment detection and configuration
- Implement ruby-lsp and Solargraph selection via SOLIDLSP_RUBY_LSP environment variable
- Support Bundler projects, gem installations, and various Ruby version managers
- Add Ruby-specific directory exclusions and Rails project detection
- Include comprehensive test suite for ruby-lsp language server functionality
- Add lsprotocol dependency for LSP type support

🤖 Generated with [Claude Code](https://claude.ai/code)