### PR TITLE
fix: correct typos in variable names, constants, and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Serena is under active development. We are just discovering what it can do and where the limitations lie.
 
-Feel free to share your learnings by opening open new issues, feature requests and extensions.
+Feel free to share your learnings by opening new issues, feature requests and extensions.
 
 ## Developer Environment Setup
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * :free: Serena is **free & open-source**, enhancing the capabilities of LLMs you already have access to free of charge.
 
 You can think of Serena as an IDE for a coding agent. With it, the agent no longer needs to read entire
-files, perform grep-like searches or string replacements to find and and edit the right code. Instead, it can use code centered tools like `find_symbol`, `find_referencing_symbols` and `insert_after_symbol`.
+files, perform grep-like searches or string replacements to find and edit the right code. Instead, it can use code centered tools like `find_symbol`, `find_referencing_symbols` and `insert_after_symbol`.
 
 ### Users' Feedback
 

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -599,9 +599,9 @@ class SerenaAgent:
     def print_tool_overview(self) -> None:
         ToolRegistry().print_tool_overview(self._active_tools.values())
 
-    def mark_file_modified(self, relativ_path: str) -> None:
+    def mark_file_modified(self, relative_path: str) -> None:
         assert self.lines_read is not None
-        self.lines_read.invalidate_lines_read(relativ_path)
+        self.lines_read.invalidate_lines_read(relative_path)
 
     def __del__(self) -> None:
         """

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -22,7 +22,7 @@ from serena.constants import (
     DEFAULT_ENCODING,
     PROJECT_TEMPLATE_FILE,
     REPO_ROOT,
-    SELENA_CONFIG_TEMPLATE_FILE,
+    SERENA_CONFIG_TEMPLATE_FILE,
     SERENA_MANAGED_DIR_IN_HOME,
     SERENA_MANAGED_DIR_NAME,
 )
@@ -365,7 +365,7 @@ class SerenaConfig(ToolInclusionDefinition, ToStringMixin):
         :param config_file_path: the path where the configuration file should be generated
         """
         log.info(f"Auto-generating Serena configuration file in {config_file_path}")
-        loaded_commented_yaml = load_yaml(SELENA_CONFIG_TEMPLATE_FILE, preserve_comments=True)
+        loaded_commented_yaml = load_yaml(SERENA_CONFIG_TEMPLATE_FILE, preserve_comments=True)
         save_yaml(config_file_path, loaded_commented_yaml, preserve_comments=True)
 
     @classmethod

--- a/src/serena/constants.py
+++ b/src/serena/constants.py
@@ -30,6 +30,6 @@ DEFAULT_CONTEXT = "desktop-app"
 DEFAULT_MODES = ("interactive", "editing")
 
 PROJECT_TEMPLATE_FILE = str(_serena_pkg_path / "resources" / "project.template.yml")
-SELENA_CONFIG_TEMPLATE_FILE = str(_serena_pkg_path / "resources" / "serena_config.template.yml")
+SERENA_CONFIG_TEMPLATE_FILE = str(_serena_pkg_path / "resources" / "serena_config.template.yml")
 
 SERENA_LOG_FORMAT = "%(levelname)-5s %(asctime)-15s [%(threadName)s] %(name)s:%(funcName)s:%(lineno)d - %(message)s"

--- a/src/serena/resources/project.template.yml
+++ b/src/serena/resources/project.template.yml
@@ -11,7 +11,7 @@ ignore_all_files_in_gitignore: true
 # list of additional paths to ignore
 # same syntax as gitignore, so you can use * and **
 # Was previously called `ignored_dirs`, please update your config if you are using that.
-# Added (renamed)on 2025-04-07
+# Added (renamed) on 2025-04-07
 ignored_paths: []
 
 # whether the project is in read-only mode


### PR DESCRIPTION
- Fix parameter name `relativ_path` to `relative_path` in agent.py
- Fix constant `SELENA_CONFIG_TEMPLATE_FILE` to `SERENA_CONFIG_TEMPLATE_FILE`
- Remove duplicate words "and and" -> "and" in README.md
- Remove duplicate words "open" in CONTRIBUTING.md
- Add missing space in project.template.yml comment