### PR TITLE
refactor: use rustup-managed rust-analyzer instead of bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # latest
 Status of the `main` branch. Changes prior to the next official version change will appear here.
 
+## Breaking Changes
+
+* **Rust support now requires rustup**: The rust-analyzer is no longer bundled with Serena. Instead, it uses the rust-analyzer from your Rust toolchain managed by rustup. This ensures compatibility with your Rust version and eliminates outdated bundled binaries. If you don't have rustup installed, you'll need to install it from https://rustup.rs/
+
 # 0.1.4
 
 ## Summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Test Markers:**
 Available pytest markers for selective testing:
-- `python`, `go`, `java`, `rust`, `typescript`, `php`, `csharp`, `elixir`, `terraform`, `clojure`
+- `python`, `go`, `java`, `rust`, `typescript`, `php`, `csharp`, `elixir`, `terraform`, `clojure`, `swift`, `bash`, `ruby`
 - `snapshot` - for symbolic editing operation tests
 
 **Project Management:**
@@ -100,7 +100,7 @@ Configuration is loaded from (in order of precedence):
 - **Symbol-based editing** - Uses LSP for precise code manipulation
 - **Caching strategy** - Reduces language server overhead
 - **Error recovery** - Automatic language server restart on crashes
-- **Multi-language support** - 13+ languages with LSP integration
+- **Multi-language support** - 16+ languages with LSP integration
 - **MCP protocol** - Exposes tools to AI agents via Model Context Protocol
 - **Async operation** - Non-blocking language server interactions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,15 @@ ENV PATH="${PATH}:/root/.local/bin"
 # Install the latest version of uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
+# Install Rust and rustup for rust-analyzer support (minimal profile)
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    --default-toolchain stable \
+    --profile minimal \
+    && rustup component add rust-analyzer
+
 # Set the working directory
 WORKDIR /workspaces/serena
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ With Serena, we provide
   * TypeScript/Javascript
   * PHP (uses Intelephense LSP; set `INTELEPHENSE_LICENSE_KEY` environment variable for premium features)
   * Go (requires installation of gopls)
-  * Rust
+  * Rust (requires [rustup](https://rustup.rs/) - uses rust-analyzer from your toolchain)
   * C#
   * Ruby
   * Swift


### PR DESCRIPTION
BREAKING CHANGE: rust-analyzer now requires rustup to be installed

## Motivation

The previous implementation bundled rust-analyzer binaries that quickly became outdated and required manual updates to Serena's codebase. This caused version mismatches between the bundled rust-analyzer and users' actual Rust toolchain versions.

## Changes

- Remove RuntimeDependency-based binary bundling for rust-analyzer
- Use rustup-managed rust-analyzer from the user's toolchain
- Add automatic installation of rust-analyzer component if missing
- Install rustup with minimal profile in Docker images

## Rationale

Rust development universally relies on rustup for toolchain management. Unlike some other languages where system packages or bundled binaries make sense, Rust developers already have rustup installed and expect tools to use their toolchain's versions.

This approach ensures:
- rust-analyzer always matches the user's Rust version
- No outdated binaries shipped with Serena
- Automatic updates via `rustup update`
- Consistency with Rust ecosystem expectations

The LSP API of rust-analyzer is stable enough that version differences are not a concern. If users don't have rustup, they'll get a clear error message - this is acceptable since you cannot meaningfully develop Rust without rustup.

## Docker Support

Added rustup installation to Docker images to ensure Rust support works in containerized environments. Uses minimal profile to reduce image size while still providing full rust-analyzer functionality.