### PR TITLE
Fix: Extend Nix symbol ranges to include trailing semicolons

### DIFF
--- a/test/resources/repos/nix/test_repo/default.nix
+++ b/test/resources/repos/nix/test_repo/default.nix
@@ -1,56 +1,56 @@
 # default.nix - Traditional Nix expression for backwards compatibility
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 let
   # Import library functions
   lib = pkgs.lib;
   stdenv = pkgs.stdenv;
-  
+
   # Import our custom utilities
   utils = import ./lib/utils.nix { inherit lib; };
-  
+
   # Custom function to create a greeting
   makeGreeting = name: "Hello, ${name}!";
-  
+
   # List manipulation functions (using imported utils)
   listUtils = {
     double = list: map (x: x * 2) list;
     sum = list: lib.foldl' (acc: x: acc + x) 0 list;
-    average = list: 
-      if list == [] 
-      then 0 
+    average = list:
+      if list == [ ]
+      then 0
       else (listUtils.sum list) / (builtins.length list);
     # Use function from imported utils
     unique = utils.lists.unique;
   };
-  
+
   # String utilities
   stringUtils = rec {
-    capitalize = str: 
+    capitalize = str:
       let
         first = lib.substring 0 1 str;
         rest = lib.substring 1 (-1) str;
       in
-        (lib.toUpper first) + rest;
-    
+      (lib.toUpper first) + rest;
+
     repeat = n: str: lib.concatStrings (lib.genList (_: str) n);
-    
+
     padLeft = width: char: str:
       let
         len = lib.stringLength str;
         padding = if len >= width then 0 else width - len;
       in
-        (repeat padding char) + str;
+      (repeat padding char) + str;
   };
-  
+
   # Package builder helper
   buildSimplePackage = { name, version, script }:
     stdenv.mkDerivation {
       pname = name;
       inherit version;
-      
+
       phases = [ "installPhase" ];
-      
+
       installPhase = ''
         mkdir -p $out/bin
         cat > $out/bin/${name} << EOF
@@ -61,13 +61,14 @@ let
       '';
     };
 
-in rec {
+in
+rec {
   # Export utilities
   inherit listUtils stringUtils makeGreeting;
-  
+
   # Export imported utilities directly
   inherit (utils) math strings;
-  
+
   # Example packages
   hello = buildSimplePackage {
     name = "hello";
@@ -76,7 +77,7 @@ in rec {
       echo "${makeGreeting "World"}"
     '';
   };
-  
+
   calculator = buildSimplePackage {
     name = "calculator";
     version = "0.1";
@@ -95,7 +96,7 @@ in rec {
       esac
     '';
   };
-  
+
   # Environment with multiple packages
   devEnv = pkgs.buildEnv {
     name = "dev-environment";
@@ -107,7 +108,7 @@ in rec {
       calculator
     ];
   };
-  
+
   # Shell derivation
   shell = pkgs.mkShell {
     buildInputs = with pkgs; [
@@ -117,20 +118,20 @@ in rec {
       gnugrep
       gnused
     ];
-    
+
     shellHook = ''
       echo "Entering Nix shell environment"
       echo "Available custom functions: makeGreeting, listUtils, stringUtils"
     '';
   };
-  
+
   # Configuration example
   config = {
     system = {
       stateVersion = "23.11";
       enable = true;
     };
-    
+
     services = {
       nginx = {
         enable = false;
@@ -144,7 +145,7 @@ in rec {
         };
       };
     };
-    
+
     users = {
       testUser = {
         name = "test";
@@ -154,7 +155,7 @@ in rec {
       };
     };
   };
-  
+
   # Recursive attribute set example
   tree = {
     root = {
@@ -170,13 +171,13 @@ in rec {
         right = { value = 7; };
       };
     };
-    
+
     # Tree traversal function
     traverse = node:
       if node ? left && node ? right
       then [ node.value ] ++ (tree.traverse node.left) ++ (tree.traverse node.right)
       else if node ? value
       then [ node.value ]
-      else [];
+      else [ ];
   };
 }

--- a/test/serena/__snapshots__/test_symbol_editing.ambr
+++ b/test/serena/__snapshots__/test_symbol_editing.ambr
@@ -800,6 +800,189 @@
   
   '''
 # ---
+# name: test_nix_symbol_replacement_no_double_semicolon
+  '''
+  # default.nix - Traditional Nix expression for backwards compatibility
+  { pkgs ? import <nixpkgs> { } }:
+  
+  let
+    # Import library functions
+    lib = pkgs.lib;
+    stdenv = pkgs.stdenv;
+  
+    # Import our custom utilities
+    utils = import ./lib/utils.nix { inherit lib; };
+  
+    # Custom function to create a greeting
+    makeGreeting = name: "Hello, ${name}!";
+  
+    # List manipulation functions (using imported utils)
+    listUtils = {
+      double = list: map (x: x * 2) list;
+      sum = list: lib.foldl' (acc: x: acc + x) 0 list;
+      average = list:
+        if list == [ ]
+        then 0
+        else (listUtils.sum list) / (builtins.length list);
+      # Use function from imported utils
+      unique = utils.lists.unique;
+    };
+  
+    # String utilities
+    stringUtils = rec {
+      capitalize = str:
+        let
+          first = lib.substring 0 1 str;
+          rest = lib.substring 1 (-1) str;
+        in
+        (lib.toUpper first) + rest;
+  
+      repeat = n: str: lib.concatStrings (lib.genList (_: str) n);
+  
+      padLeft = width: char: str:
+        let
+          len = lib.stringLength str;
+          padding = if len >= width then 0 else width - len;
+        in
+        (repeat padding char) + str;
+    };
+  
+    # Package builder helper
+    buildSimplePackage = { name, version, script }:
+      stdenv.mkDerivation {
+        pname = name;
+        inherit version;
+  
+        phases = [ "installPhase" ];
+  
+        installPhase = ''
+          mkdir -p $out/bin
+          cat > $out/bin/${name} << EOF
+          #!/usr/bin/env bash
+          ${script}
+          EOF
+          chmod +x $out/bin/${name}
+        '';
+      };
+  
+  in
+  rec {
+    # Export utilities
+    inherit listUtils stringUtils makeGreeting;
+  
+    # Export imported utilities directly
+    inherit (utils) math strings;
+  
+    # Example packages
+    hello = buildSimplePackage {
+      name = "hello";
+      version = "1.0";
+      script = ''
+        echo "${makeGreeting "World"}"
+      '';
+    };
+  
+    calculator = buildSimplePackage {
+      name = "calculator";
+      version = "0.1";
+      script = ''
+        if [ $# -ne 3 ]; then
+          echo "Usage: calculator <num1> <op> <num2>"
+          exit 1
+        fi
+        
+        case $2 in
+          +) echo $(($1 + $3)) ;;
+          -) echo $(($1 - $3)) ;;
+          x) echo $(($1 * $3)) ;;
+          /) echo $(($1 / $3)) ;;
+          *) echo "Unknown operator: $2" ;;
+        esac
+      '';
+    };
+  
+    # Environment with multiple packages
+    devEnv = pkgs.buildEnv {
+      name = "dev-environment";
+      paths = with pkgs; [
+        git
+        vim
+        bash
+        hello
+        calculator
+      ];
+    };
+  
+    # Shell derivation
+    shell = pkgs.mkShell {
+      buildInputs = with pkgs; [
+        bash
+        coreutils
+        findutils
+        gnugrep
+        gnused
+      ];
+  
+      shellHook = ''
+        echo "Entering Nix shell environment"
+        echo "Available custom functions: makeGreeting, listUtils, stringUtils"
+      '';
+    };
+  
+    # Configuration example
+    config = {
+      system = {
+        stateVersion = "23.11";
+        enable = true;
+      };
+  
+      services = {
+        nginx = {
+          enable = false;
+          virtualHosts = {
+            "example.com" = {
+              root = "/var/www/example";
+              locations."/" = {
+                index = "index.html";
+              };
+            };
+          };
+        };
+      };
+  
+      users = {
+        c = 3;
+      };
+    };
+  
+    # Recursive attribute set example
+    tree = {
+      root = {
+        value = 1;
+        left = {
+          value = 2;
+          left = { value = 4; };
+          right = { value = 5; };
+        };
+        right = {
+          value = 3;
+          left = { value = 6; };
+          right = { value = 7; };
+        };
+      };
+  
+      # Tree traversal function
+      traverse = node:
+        if node ? left && node ? right
+        then [ node.value ] ++ (tree.traverse node.left) ++ (tree.traverse node.right)
+        else if node ? value
+        then [ node.value ]
+        else [ ];
+    };
+  }
+  
+  '''
+# ---
 # name: test_replace_body[test_case0]
   '''
   """

--- a/test/solidlsp/nix/test_nix_basic.py
+++ b/test/solidlsp/nix/test_nix_basic.py
@@ -106,14 +106,14 @@ class TestNixLanguageServer:
 
         assert refs is not None
         assert isinstance(refs, list)
-        # nixd finds at least the inherit statement (line 66)
+        # nixd finds at least the inherit statement (line 67)
         assert len(refs) >= 1, f"Should find at least 1 reference to makeGreeting, found {len(refs)}"
 
         # Verify makeGreeting is referenced at expected locations
         if refs:
             ref_lines = sorted([ref["range"]["start"]["line"] for ref in refs])
-            # Check if we found the inherit (line 66, 0-indexed: 65)
-            assert 65 in ref_lines, f"Should find makeGreeting inherit at line 66, found at lines {[l+1 for l in ref_lines]}"
+            # Check if we found the inherit (line 67, 0-indexed: 66)
+            assert 66 in ref_lines, f"Should find makeGreeting inherit at line 67, found at lines {[l+1 for l in ref_lines]}"
 
     @pytest.mark.parametrize("language_server", [Language.NIX], indirect=True)
     def test_hover_information(self, language_server: SolidLanguageServer) -> None:


### PR DESCRIPTION
This fixes the double semicolon issue in replace_symbol_body when replacing Nix attributes with content that includes semicolons.

Root cause: nixd provides expression-level ranges (excluding semicolons) but serena expects statement-level ranges (including semicolons).

Solution: Override request_document_symbols() in NixLanguageServer to detect and include trailing semicolons in symbol ranges.