### PR TITLE
Fix: Remove conflict key "creationflags" for windows

### DIFF
--- a/src/serena/util/shell.py
+++ b/src/serena/util/shell.py
@@ -33,7 +33,6 @@ def execute_shell_command(command: str, cwd: str | None = None, capture_stderr: 
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE if capture_stderr else None,
-        creationflags=subprocess.CREATE_NO_WINDOW if is_windows else 0,  # type: ignore
         text=True,
         encoding="utf-8",
         errors="replace",


### PR DESCRIPTION
When using Serena as an MCP server for Claude Code on the Windows platform, this type of exception occurs:
```shell
[SerenaAgentExecutor_0] serena.tools.tools_base:task:275 - Error executing tool:
  subprocess.Popen() got multiple values for keyword argument 'creationflags'
  Traceback (most recent call last):
    File "C:\Users\PC\AppData\Local\uv\cache\archive-v0\0a6WluE8Lzdf6H0f-ebLh\Lib\site-packages\   
  serena\tools\tools_base.py", line 259, in task
      result = apply_fn(**kwargs)
               ^^^^^^^^^^^^^^^^^^
    File "C:\Users\PC\AppData\Local\uv\cache\archive-v0\0a6WluE8Lzdf6H0f-ebLh\Lib\site-packages\   
  serena\tools\cmd_tools.py", line 34, in apply
      result = execute_shell_command(command, cwd=_cwd, capture_stderr=capture_stderr)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\PC\AppData\Local\uv\cache\archive-v0\0a6WluE8Lzdf6H0f-ebLh\Lib\site-packages\   
  serena\util\shell.py", line 30, in execute_shell_command
      process = subprocess.Popen(
                ^^^^^^^^^^^^^^^^^
  TypeError: subprocess.Popen() got multiple values for keyword argument 'creationflags'
```

Problem Analysis：

In `src/serena/util/shell.py`:

1. Directly sets creationflags = subprocess.CREATE_NO_WINDOW

2. Arguments are expanded again using **subprocess_kwargs(), and the subprocess_kwargs() function (in `src/solidlsp/util/subprocess_util.py`) also sets creationflags.

This causes the creationflags parameter to be passed twice, causing a TypeError.

Fix:

Modify `src/serena/util/shell.py` and remove the duplicate creationflags parameter settings: