### PR TITLE
Exclude 'search_for_pattern' in ide-assistant context

### DIFF
--- a/src/serena/resources/config/contexts/ide-assistant.yml
+++ b/src/serena/resources/config/contexts/ide-assistant.yml
@@ -22,6 +22,7 @@ excluded_tools:
   - execute_shell_command
   - prepare_for_new_conversation
   - replace_regex
+  - search_for_pattern
 
 tool_description_overrides: {}
 


### PR DESCRIPTION
Claude Code and most other ide assistants have capable pattern searching tools. Ours has quite a long description, cluttering the context, and I see times and times again that claude fails to write non-greedy regexes, leading to long matches. I think we should disable it by default in this context