### PR TITLE
Upgrade gradle to 8.14.2 and disable gradle wrapper for java 21 compatibility

### DIFF
--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -167,7 +167,7 @@ class EclipseJDTLS(SolidLanguageServer):
         runtime_dependencies = {
             "gradle": {
                 "platform-agnostic": {
-                    "url": "https://services.gradle.org/distributions/gradle-7.3.3-bin.zip",
+                    "url": "https://services.gradle.org/distributions/gradle-8.14.2-bin.zip",
                     "archiveType": "zip",
                     "relative_extraction_path": ".",
                 }
@@ -244,7 +244,7 @@ class EclipseJDTLS(SolidLanguageServer):
         gradle_path = str(
             PurePath(
                 cls.ls_resources_dir(solidlsp_settings),
-                "gradle-7.3.3",
+                "gradle-8.14.2",
             )
         )
 
@@ -531,7 +531,7 @@ class EclipseJDTLS(SolidLanguageServer):
                             },
                             "gradle": {
                                 "enabled": True,
-                                "wrapper": {"enabled": True},
+                                "wrapper": {"enabled": False},
                                 "version": None,
                                 "home": "abs(static/gradle-7.3.3)",
                                 "java": {"home": "abs(static/launch_jres/21.0.7-linux-x86_64)"},


### PR DESCRIPTION
### This change request updates the build configuration to improve compatibility with Java 21:

1. Upgrade Gradle version
- Default Gradle version is updated from 7.3.3 to 8.14.2.
- Gradle 7.x does not support Java 21 (class file major version 65), while Gradle 8.14.2 provides full compatibility.
2. Disable Gradle Wrapper
- Previously, the Gradle version depended on each project’s wrapper configuration.
- Older projects using outdated Gradle wrappers caused compilation errors with Java 21.
- By disabling the wrapper, Serena will consistently use the configured Gradle version (8.14.2) for all builds.

### Impact:
- Ensures Serena compiles projects correctly under Java 21.
- Prevents build failures caused by mismatched or outdated Gradle wrapper versions.