### PR TITLE
fix: improve file encoding support and error handling during indexing

### DIFF
--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -464,7 +464,7 @@ class ProjectCommands(AutoRegisteringGroup):
                 try:
                     ls.request_document_symbols(f, include_body=False)
                     ls.request_document_symbols(f, include_body=True)
-                except TimeoutError as e:
+                except Exception as e:
                     log.error(f"Failed to index {f}, continuing.")
                     collected_exceptions.append(e)
                     files_failed.append(f)


### PR DESCRIPTION
- Add multi-encoding fallback support (utf-8, utf-8-sig, latin-1, cp1252) to FileUtils.read_file()
- Change indexing error handling from TimeoutError to Exception to catch encoding failures
- Files with unsupported encodings now skip gracefully instead of crashing indexing

Fixes issues with indexing projects containing non-UTF-8 encoded files (e.g., legacy Windows files with special characters).
