### PR TITLE
test: skip Go tests when gopls is not installed

### DIFF
--- a/test/solidlsp/go/__init__.py
+++ b/test/solidlsp/go/__init__.py
@@ -1,0 +1,28 @@
+"""Go test utilities for checking gopls availability."""
+
+import subprocess
+
+
+def _get_gopls_version():
+    """Get the installed gopls version or None if not found."""
+    try:
+        result = subprocess.run(["gopls", "version"], capture_output=True, text=True, check=False)
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except FileNotFoundError:
+        return None
+    return None
+
+
+def check_gopls_available():
+    """Check if gopls is available and return a tuple (is_unavailable, reason)."""
+    try:
+        gopls_version = _get_gopls_version()
+        if not gopls_version:
+            return True, "gopls is not installed"
+        return False, ""
+    except Exception as e:
+        return True, f"Error checking gopls: {e}"
+
+
+GOPLS_UNAVAILABLE, GOPLS_UNAVAILABLE_REASON = check_gopls_available()

--- a/test/solidlsp/go/test_go_basic.py
+++ b/test/solidlsp/go/test_go_basic.py
@@ -5,9 +5,11 @@ import pytest
 from solidlsp import SolidLanguageServer
 from solidlsp.ls_config import Language
 from solidlsp.ls_utils import SymbolUtils
+from test.solidlsp.go import GOPLS_UNAVAILABLE, GOPLS_UNAVAILABLE_REASON
 
 
 @pytest.mark.go
+@pytest.mark.skipif(GOPLS_UNAVAILABLE, reason=f"gopls not available: {GOPLS_UNAVAILABLE_REASON}")
 class TestGoLanguageServer:
     @pytest.mark.parametrize("language_server", [Language.GO], indirect=True)
     def test_find_symbol(self, language_server: SolidLanguageServer) -> None:
@@ -28,6 +30,6 @@ class TestGoLanguageServer:
         assert helper_symbol is not None, "Could not find 'Helper' function symbol in main.go"
         sel_start = helper_symbol["selectionRange"]["start"]
         refs = language_server.request_references(file_path, sel_start["line"], sel_start["character"])
-        assert any(
-            "main.go" in ref.get("relativePath", "") for ref in refs
-        ), "main.go should reference Helper (tried all positions in selectionRange)"
+        assert any("main.go" in ref.get("relativePath", "") for ref in refs), (
+            "main.go should reference Helper (tried all positions in selectionRange)"
+        )


### PR DESCRIPTION
## Summary
- Add gopls availability check utility to detect when gopls is not installed
- Update Go tests to skip gracefully when gopls is unavailable instead of failing
- Follow the same pattern used by other language tests (Elixir, Erlang, Clojure)

## Problem
Go tests were failing when gopls (Go language server) was not installed, causing CI/test failures for developers who don't have Go development tools set up.

## Solution
Added a skipif condition that checks for gopls availability before running Go-specific tests. This matches the pattern already established in the codebase for other language servers.

## Test Plan
- [x] Tests skip correctly when gopls is not installed
- [x] Tests run normally when gopls is installed
- [x] Other language tests continue to work as expected