### PR TITLE
Enhanced Ruby LSP progress handler to properly capture completion signals

### DIFF
--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -278,6 +278,9 @@ class RubyLsp(SolidLanguageServer):
                     "workspaceEdit": {"documentChanges": True},
                     "configuration": True,
                 },
+                "window": {
+                    "workDoneProgress": True,
+                },
                 "textDocument": {
                     "documentSymbol": {
                         "hierarchicalDocumentSymbolSupport": True,
@@ -333,28 +336,40 @@ class RubyLsp(SolidLanguageServer):
 
         def progress_handler(params: dict) -> None:
             # ruby-lsp sends progress notifications during indexing
+            self.logger.log(f"LSP: $/progress: {params}", logging.DEBUG)
             if "value" in params:
                 value = params["value"]
                 # Check for completion indicators
-                if value.get("kind") == "end" or value.get("percentage") == 100:
-                    self.logger.log("ruby-lsp indexing complete", logging.INFO)
+                if value.get("kind") == "end":
+                    self.logger.log("ruby-lsp indexing complete ($/progress end)", logging.INFO)
                     self.analysis_complete.set()
                     self.completions_available.set()
-            # Handle alternative progress format
-            elif "token" in params and isinstance(params.get("token"), str):
+                elif value.get("kind") == "begin":
+                    self.logger.log("ruby-lsp indexing started ($/progress begin)", logging.INFO)
+                elif "percentage" in value:
+                    percentage = value.get("percentage", 0)
+                    self.logger.log(f"ruby-lsp indexing progress: {percentage}%", logging.DEBUG)
+            # Handle direct progress format (fallback)
+            elif "token" in params and "value" in params:
                 token = params.get("token")
-                if "indexing" in token.lower():
+                if isinstance(token, str) and "indexing" in token.lower():
                     value = params.get("value", {})
                     if value.get("kind") == "end" or value.get("percentage") == 100:
-                        self.logger.log("ruby-lsp indexing complete", logging.INFO)
+                        self.logger.log("ruby-lsp indexing complete (token progress)", logging.INFO)
                         self.analysis_complete.set()
                         self.completions_available.set()
+
+        def window_work_done_progress_create(params: dict) -> None:
+            """Handle workDoneProgress/create requests from ruby-lsp"""
+            self.logger.log(f"LSP: window/workDoneProgress/create: {params}", logging.DEBUG)
+            return {}
 
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("language/status", lang_status_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", progress_handler)
+        self.server.on_request("window/workDoneProgress/create", window_work_done_progress_create)
         self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
 
         self.logger.log("Starting ruby-lsp server process", logging.INFO)


### PR DESCRIPTION
## Summary

  **Changes:**
  - Add `window.workDoneProgress` support in initialization capabilities
  - Add `window/workDoneProgress/create` request handler
  - Enhanced `$/progress` handler to support multiple completion patterns
  - Support both standard and token-based progress notifications

  **Impact:**
  Significantly reduces timeout warnings during Ruby LSP indexing while maintaining
  functionality.

related https://github.com/oraios/serena/issues/554

## Log example

```
INFO  2025-08-28 09:16:02,297 [LSP-stdout-reader] solidlsp:progress_handler:348 - ruby-lsp indexing started ($/progress begin)
INFO  2025-08-28 09:16:02,297 [LSP-stdout-reader] solidlsp:window_log_message:335 - LSP: window/logMessage: {"type": 4, "message": "Auto detected formatter: rubocop_internal"}
INFO  2025-08-28 09:16:02,298 [SerenaAgentExecutor_0] solidlsp:_start_server:401 - Waiting for ruby-lsp to complete initial indexing...
INFO  2025-08-28 09:16:02,298 [LSP-stdout-reader] solidlsp:window_log_message:335 - LSP: window/logMessage: {"type": 4, "message": "Auto detected linters: rubocop_internal"}
INFO  2025-08-28 09:16:02,298 [LSP-stdout-reader] solidlsp:window_log_message:335 - LSP: window/logMessage: {"type": 4, "message": "Detected test library: rspec"}
INFO  2025-08-28 09:16:02,298 [LSP-stdout-reader] solidlsp:window_log_message:335 - LSP: window/logMessage: {"type": 4, "message": "Finished initializing Ruby LSP!"}
INFO  2025-08-28 09:16:02,505 [LSP-stderr-reader] solidlsp.ls_handler:_read_ls_process_stderr:387 - [RuboCop] Activating RuboCop LSP addon 1.79.2.

INFO  2025-08-28 09:16:02,809 [LSP-stderr-reader] solidlsp.ls_handler:_read_ls_process_stderr:387 - [RuboCop] Initialized RuboCop LSP addon 1.79.2.

INFO  2025-08-28 09:16:17,832 [LSP-stdout-reader] solidlsp:progress_handler:344 - ruby-lsp indexing complete ($/progress end)
INFO  2025-08-28 09:16:17,833 [SerenaAgentExecutor_0] solidlsp:_start_server:403 - ruby-lsp initial indexing complete, server ready
INFO  2025-08-28 09:16:17,833 [SerenaAgentExecutor_0] serena.agent:stop:336 - Language server initialization completed in 16.919 seconds
INFO  2025-08-28 09:16:17,833 [SerenaAgentExecutor_0] serena.agent:stop:336 - Task-1[init_language_server] completed in 16.920 seconds
```