### PR TITLE
[Chore]: Add workflow to automatically mark stale issues and pull requests

### DIFF
--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -1,0 +1,38 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # ---- Issue settings ----
+          days-before-issue-stale: 30  # Issues become stale after 30 days inactive
+          days-before-issue-close: 60 # Close Issues 180 days after stale
+          stale-issue-message: |
+            This issue has been inactive for 30 days and is now marked as stale.
+            It will be automatically closed in 180 days if no further activity occurs.
+          close-issue-message: |
+            Since it has been a long time without updates, the issue has been automatically closed.
+            If you need to continue, please reopen or create a new issue.
+
+          # ---- PR settings ----
+          days-before-pr-stale: 7   # PRs become stale after 7 days inactive
+          days-before-pr-close: 30  # Close PRs 30 days after stale
+          stale-pr-message: |
+            This PR has been inactive for 7 days and is now marked as stale.
+            It will be automatically closed in 30 days if no further activity occurs.
+          close-pr-message: |
+            Since it has been a long time without updates, the PR has been automatically closed.
+            If you need to continue, please reopen or create a new PR.
+          exempt-pr-labels: |
+            pinned
+            WIP

--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -16,10 +16,10 @@ jobs:
 
           # ---- Issue settings ----
           days-before-issue-stale: 30  # Issues become stale after 30 days inactive
-          days-before-issue-close: 60 # Close Issues 180 days after stale
+          days-before-issue-close: 60 # Close Issues 60 days after stale
           stale-issue-message: |
             This issue has been inactive for 30 days and is now marked as stale.
-            It will be automatically closed in 180 days if no further activity occurs.
+            It will be automatically closed in 60 days if no further activity occurs.
           close-issue-message: |
             Since it has been a long time without updates, the issue has been automatically closed.
             If you need to continue, please reopen or create a new issue.


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions workflow (`.github/workflows/stale-issue-pr.yml`) to automatically mark and close inactive issues and pull requests.

## Details
- Uses the `actions/stale` GitHub Action.
- Marks issues as stale after 30 days of inactivity.
- Marks pull requests as stale after 7 days of inactivity.
- Close Issues 60 days after stale.
- Close PRs 30 days after stale.
- Helps keep the repository clean and focused by reducing long-standing inactive discussions.

Currently, inactive issues and PRs remain open indefinitely, making it harder to manage the repository. This workflow will help maintainers keep the backlog clean and prioritize active contributions.
