### PR TITLE
fix: enhance SearchForPatternTool param description

### DIFF
--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -339,10 +339,10 @@ class SearchForPatternTool(Tool):
         :param substring_pattern: Regular expression for a substring pattern to search for
         :param context_lines_before: Number of lines of context to include before each match
         :param context_lines_after: Number of lines of context to include after each match
-        :param paths_include_glob: optional glob pattern specifying files to include in the search.
+        :param paths_include_glob: optional glob pattern specifying files to include in the search. Only accept no comma-separated string.
             Matches against relative file paths from the project root (e.g., "*.py", "src/**/*.ts").
             Only matches files, not directories. If left empty, all non-ignored files will be included.
-        :param paths_exclude_glob: optional glob pattern specifying files to exclude from the search.
+        :param paths_exclude_glob: optional glob pattern specifying files to exclude from the search. Only accept no comma-separated string.
             Matches against relative file paths from the project root (e.g., "*test*", "**/*_generated.py").
             Takes precedence over paths_include_glob. Only matches files, not directories. If left empty, no files are excluded.
         :param relative_path: only subpaths of this path (relative to the repo root) will be analyzed. If a path to a single


### PR DESCRIPTION
# Description

I setup serena as Claude Code mcp server. 
When I use Claude Code to search code, it will call serena search_for_pattern tool like: 
`search_for_pattern (MCP)(substring_pattern: "Yaml", paths_include_glob: "*.java", restrict_search_to_code_files: true)`

But sometimes Claude Code will set paths_include_glob params as "\*\*/\*.java,\*\*/\*.yaml", which is not satisfied param format rule. So this pr try to enhance tool description to limit Agent behavior.

# Changes

- Add format limit description to `paths_include_glob` param.
- Add format limit description to `paths_exclude_glob` param.