### PR TITLE
Remove 'read_file' from excluded tools list

### DIFF
--- a/src/serena/resources/config/contexts/ide-assistant.yml
+++ b/src/serena/resources/config/contexts/ide-assistant.yml
@@ -18,7 +18,6 @@ prompt: |
 
 excluded_tools:
   - create_text_file
-  - read_file
   - execute_shell_command
   - prepare_for_new_conversation
   - replace_regex


### PR DESCRIPTION
Inconsistent instruction and excluded tools: " The call of the read_file tool on an entire source code file should only happen in exceptional cases, usually you should first explore the file (by itself or as part of exploring the directory containing it) using the symbol_overview tool, and then make targeted reads using find_symbol and other symbolic tools."