### PR TITLE
Fix 'Failed to deserialize config field at /cargo/cfgs' error from rust analyzer

### DIFF
--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -406,7 +406,7 @@ class RustAnalyzer(SolidLanguageServer):
                         "overrideCommand": None,
                         "useRustcWrapper": True,
                     },
-                    "cfgs": {},
+                    "cfgs": [],
                     "extraArgs": [],
                     "extraEnv": {},
                     "features": [],


### PR DESCRIPTION
Reference to this [issue](https://github.com/oraios/serena/issues/657).
Fix 'Failed to deserialize config field at /cargo/cfgs' error by rust analyzer by this [issue](https://github.com/rust-lang/rust-analyzer/issues/19658)

Reproduce steps:
```shell
root in /home
❯ cargo new serena-testing
    Creating binary (application) `serena-testing` package
note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

root in /home
❯ cd serena-testing/

root in serena-testing
❯ uvx --from git+https://github.com/oraios/serena@8abfe58 serena project index
Installed 55 packages in 923ms
Indexing symbols in project /home/serena-testing…
ERROR 2025-10-15 11:28:18,268 solidlsp.ls_handler:_read_ls_process_stderr:387 - 2025-10-15T11:28:18.268611501+08:00  WARN Failed to deserialize config field at /cargo/cfgs: Error("invalid type: map, expected a sequence", line: 0, column: 0)

Indexing: 100%|████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 165.44it/s]
Symbols saved to /home/serena-testing/.serena/cache/rust/document_symbols_cache_v23-06-25.pkl
```

After fix:
```shell
❯ uvx --from git+https://github.com/Anivie/serena@fix_rust_analyzer serena project index
Indexing symbols in project /home/serena-testing…
Indexing: 100%|████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 701.74it/s]
Symbols saved to /home/serena-testing/.serena/cache/rust/document_symbols_cache_v23-06-25.pkl
```