### PR TITLE
feat: Add CLI tool to download language server dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Status of the `main` branch. Changes prior to the next official version change w
     failed `--project-from-cwd` auto-detection (#1773).
 
 * CLI:
+  - Add `download-ls-dependencies`, which downloads the runtime dependencies of the given language servers
+    (or of all language servers via `--all`) ahead of time, for use in environments with restricted network
+    access #664
   - Fix: `start-mcp-server` help text for `--project-from-cwd` falsely promised a fallback to the CWD, which was 
     removed in v1.0.0 #1773
 

--- a/docs/01-about/020_programming-languages.md
+++ b/docs/01-about/020_programming-languages.md
@@ -174,6 +174,25 @@ Some languages require additional installations or setup steps, as noted.
 Support for further languages can easily be added by providing a shallow adapter for a new language server implementation,
 see Serena's [memory on that](https://github.com/oraios/serena/blob/main/.serena/memories/adding_new_language_support_guide.md).
 
+### Downloading Language Server Dependencies Ahead of Time
+
+Language server dependencies are downloaded on demand, i.e. when a project using the respective language
+is first activated. In environments with restricted network access (e.g. containers which may reach only
+a small set of hosts), the download can instead be carried out ahead of time, e.g. when building the
+container image:
+
+```shell
+serena download-ls-dependencies python typescript
+```
+
+Use `--all` to download the dependencies of all (non-experimental) language servers.
+Note that language servers which require an external toolchain to be present (e.g. Go or Java) can only be
+prepared if that toolchain is installed; the command reports the language servers it could not prepare and
+exits with a non-zero status in that case.
+
+Since the dependencies are specific to the Serena version that downloaded them, the download must be
+repeated whenever Serena is updated.
+
 ## The Serena JetBrains Plugin
 
 The [Serena JetBrains Plugin](https://plugins.jetbrains.com/plugin/28946-serena/) leverages the powerful code analysis capabilities of JetBrains IDEs. 

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from collections.abc import Iterator, Sequence
 from logging import Logger
@@ -123,6 +124,36 @@ def _open_in_editor(path: str) -> None:
         print(f"Failed to open {path}: {e}")
 
 
+def _download_ls_dependencies(ls_id: LanguageServerId, ls_specific_settings: dict, repository_root_path: str) -> None:
+    """
+    Downloads the runtime dependencies of the given language server.
+
+    :param ls_id: the language server whose dependencies to download
+    :param ls_specific_settings: the user-provided language server-specific settings, which can affect which
+        dependencies are required (or whether Serena manages them at all)
+    :param repository_root_path: path of the directory to use as the language server's repository root;
+        since the language server is instantiated but never started, the directory's contents are irrelevant.
+        It also receives the (empty) project-specific data, which is thus discarded along with the directory.
+    :raises Exception: if the dependencies could not be downloaded
+    """
+    from solidlsp import SolidLanguageServer
+    from solidlsp.ls_config import LanguageServerConfig
+    from solidlsp.settings import SolidLSPSettings
+
+    # instantiating the language server already downloads most dependencies (because the launch command
+    # must be constructed), and install_dependencies covers the remaining ones
+    ls = SolidLanguageServer.create(
+        LanguageServerConfig(ls_id=ls_id),
+        repository_root_path,
+        solidlsp_settings=SolidLSPSettings(
+            solidlsp_dir=SerenaPaths().serena_user_home_dir,
+            project_data_path=os.path.join(repository_root_path, ".solidlsp"),
+            ls_specific_settings=ls_specific_settings,
+        ),
+    )
+    ls.install_dependencies()
+
+
 class ProjectType(click.ParamType):
     """ParamType allowing either a project name or a path to a project directory."""
 
@@ -228,6 +259,77 @@ class TopLevelCommands(AutoRegisteringGroup):
         else:
             click.echo(f"\nFailed to set up Serena for {client}.\n")
             raise SystemExit(1)
+
+    @staticmethod
+    @click.command(
+        "download-ls-dependencies",
+        help="Download the dependencies (e.g. binaries) which the given language servers require at runtime, such that "
+        "they need not be downloaded on demand at a later point in time. "
+        "This is intended for environments with restricted network access, allowing the download to be carried out "
+        "ahead of time, e.g. when building a container image.",
+        context_settings={"max_content_width": _MAX_CONTENT_WIDTH},
+    )
+    @click.argument("language_servers", type=str, nargs=-1)
+    @click.option(
+        "--all",
+        "-a",
+        "all_language_servers",
+        is_flag=True,
+        help="Download the dependencies of all language servers instead of the ones given as arguments.",
+    )
+    @click.option(
+        "--include-experimental",
+        is_flag=True,
+        help="Whether to also consider experimental language servers when `--all` is given.",
+    )
+    def download_ls_dependencies(
+        language_servers: tuple[str, ...], all_language_servers: bool = False, include_experimental: bool = False
+    ) -> None:
+        logging.configure(level=logging.INFO)
+
+        # determine the language servers whose dependencies are to be downloaded
+        if all_language_servers:
+            if language_servers:
+                raise click.UsageError("Cannot combine explicitly named language servers with `--all`.")
+            ls_ids = list(LanguageServerId.iter_all(include_experimental=include_experimental))
+        else:
+            if not language_servers:
+                raise click.UsageError("Pass at least one language server name or use `--all`.")
+            if include_experimental:
+                raise click.UsageError("`--include-experimental` is applicable only in conjunction with `--all`.")
+            ls_ids = []
+            for name in language_servers:
+                try:
+                    ls_ids.append(LanguageServerId(name.lower()))
+                except ValueError:
+                    supported = ", ".join(ls_id.value for ls_id in LanguageServerId)
+                    raise click.UsageError(f"Unknown language server '{name}'. Supported: {supported}")
+
+        # take the user's global LS-specific settings into account, as they can affect which dependencies are required
+        try:
+            ls_specific_settings = dict(SerenaConfig.from_config_file(generate_if_missing=False).ls_specific_settings)
+        except FileNotFoundError:
+            ls_specific_settings = {}
+
+        # perform the downloads, collecting failures such that a single unsupported environment
+        # (e.g. a missing toolchain) does not prevent the remaining downloads
+        failures: list[tuple[LanguageServerId, Exception]] = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for i, ls_id in enumerate(ls_ids, start=1):
+                click.echo(f"\n[{i}/{len(ls_ids)}] Downloading dependencies for language server '{ls_id.value}' ...")
+                try:
+                    _download_ls_dependencies(ls_id, ls_specific_settings, temp_dir)
+                except Exception as e:
+                    log.exception(f"Failed to download dependencies for '{ls_id.value}'")
+                    failures.append((ls_id, e))
+
+        # report the result, indicating failure via the exit code (such that container builds fail early)
+        if failures:
+            click.echo(f"\nFailed to download the dependencies of {len(failures)} of {len(ls_ids)} language server(s):", err=True)
+            for ls_id, e in failures:
+                click.echo(f"  {ls_id.value}: {e}", err=True)
+            raise SystemExit(1)
+        click.echo(f"\nSuccessfully downloaded the dependencies of {len(ls_ids)} language server(s).")
 
     @staticmethod
     @click.command("start-mcp-server", help="Starts the Serena MCP server.", context_settings={"max_content_width": _MAX_CONTENT_WIDTH})

--- a/src/solidlsp/dependency_provider.py
+++ b/src/solidlsp/dependency_provider.py
@@ -1,10 +1,12 @@
 import logging
 import os
+import platform
 import shutil
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from solidlsp.settings import SolidLSPSettings
+from solidlsp.util.subprocess_util import subprocess_run
 
 log = logging.getLogger(__name__)
 
@@ -43,6 +45,22 @@ class LanguageServerDependencyProvider(ABC):
         """
         return {}
 
+    def install_dependencies(self) -> None:
+        """
+        Downloads and installs all dependencies that are managed by this provider, such that
+        a subsequent launch of the language server requires no further downloads.
+
+        This is used to prepare environments in which the language server is to be run without
+        (unrestricted) network access later on.
+
+        The default implementation covers the regular case, where the dependencies are installed
+        as part of the launch command's construction; providers which defer the installation
+        beyond that point must override this method.
+
+        :raises Exception: if the dependencies could not be installed
+        """
+        self.create_launch_command()
+
 
 class LanguageServerDependencyProviderBaseCommand(LanguageServerDependencyProvider, ABC):
     """
@@ -77,8 +95,13 @@ class LanguageServerDependencyProviderBaseCommand(LanguageServerDependencyProvid
         :return: the extended command
         """
 
-    def create_launch_command(self) -> list[str]:
-        # obtain base command
+    def _get_custom_base_command(self) -> list[str] | None:
+        """
+        Obtains the base command from the user-provided settings, which bypasses the managed installation
+        of the language server's dependencies.
+
+        :return: the user-provided base command or None if the managed installation applies
+        """
         base_command = self._custom_settings.get("ls_base_cmd", None)
         if base_command is not None and not isinstance(base_command, list):
             log.warning("The 'ls_base_cmd' setting should be a list of strings. Ignoring the provided value: %s", base_command)
@@ -87,9 +110,14 @@ class LanguageServerDependencyProviderBaseCommand(LanguageServerDependencyProvid
             ls_path = self._custom_settings.get("ls_path", None)
             if ls_path is not None:
                 base_command = [ls_path]
-            else:
-                # default case: base command is constructed by the provider implementation
-                base_command = self._create_default_base_command()
+        return base_command
+
+    def create_launch_command(self) -> list[str]:
+        # obtain base command
+        base_command = self._get_custom_base_command()
+        if base_command is None:
+            # default case: base command is constructed by the provider implementation
+            base_command = self._create_default_base_command()
 
         # create launch command from base command
         ls_args = self._custom_settings.get("ls_args")
@@ -233,9 +261,63 @@ class LanguageServerDependencyProviderUvx(LanguageServerDependencyProviderBaseCo
 
         raise RuntimeError("Could not find 'uvx' or 'uv' in PATH. Install uv (https://docs.astral.sh/uv/).")
 
+    @staticmethod
+    def _find_uv_executable() -> str:
+        """
+        :return: the path to the ``uv`` executable
+        :raises RuntimeError: if uv is not installed
+        """
+        uv_path = shutil.which("uv")
+        if uv_path is not None:
+            return uv_path
+
+        # fall back to the 'uv' executable residing alongside 'uvx' (the two are shipped together),
+        # resolving the configured uvx command against the PATH, as it need not be a path
+        uvx_path = os.environ.get("UVX") or "uvx"
+        uvx_path = shutil.which(uvx_path)
+        if uvx_path is not None:
+            candidate = os.path.join(os.path.dirname(uvx_path), "uv.exe" if platform.system() == "Windows" else "uv")
+            if os.path.isfile(candidate):
+                return candidate
+
+        raise RuntimeError("Could not find 'uv' in PATH. Install uv (https://docs.astral.sh/uv/).")
+
+    @classmethod
+    def _build_uv_tool_install_command(cls, package: str, version: str, python_version: str = DEFAULT_UVX_PYTHON_VERSION) -> list[str]:
+        """
+        Builds a command which persistently installs a pinned PyPI package's console script as a uv tool.
+
+        :param package: PyPI package name (e.g. ``"pyright"``).
+        :param version: Pinned package version.
+        :param python_version: Python interpreter version passed via ``-p`` (uv will fetch it if missing).
+        :return: the installation command
+        """
+        return [cls._find_uv_executable(), "tool", "install", "-p", python_version, f"{package}=={version}"]
+
     def _create_default_base_command(self):
         version = self._custom_settings.get(self._version_setting_key, self._default_version)
         return self._build_uvx_base_command(self._package, version, self._entrypoint)
 
     def _create_launch_command_from_base_command(self, base_command: list[str]) -> list[str]:
         return base_command + list(self._extra_args)
+
+    def install_dependencies(self) -> None:
+        # Note that the base class implementation would be insufficient here: constructing the launch command
+        # downloads nothing, because uvx materialises the package's environment only when the command is
+        # actually executed. We therefore install the pinned package as a uv tool, which downloads the package
+        # (and, if necessary, the Python interpreter), such that the subsequent `uvx` invocation can reuse
+        # the existing installation instead of retrieving it from the network.
+
+        # skip if the user bypasses the uv-managed installation via a custom launch command/path
+        # (applying the very same criterion as the launch command construction, such that the two cannot diverge)
+        if self._get_custom_base_command() is not None:
+            log.info("A custom launch command is configured for package '%s'; no dependencies to install", self._package)
+            return
+
+        # perform the installation
+        version = self._custom_settings.get(self._version_setting_key, self._default_version)
+        cmd = self._build_uv_tool_install_command(self._package, version)
+        log.info("Installing %s==%s via %s", self._package, version, cmd)
+        result = subprocess_run(cmd)
+        if result.returncode != 0:
+            raise RuntimeError(f"Installation of {self._package}=={version} failed: {result.stderr or result.stdout}")

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -583,6 +583,24 @@ class SolidLanguageServer(ABC):
             self._dependency_provider = self._create_dependency_provider()
         return self._dependency_provider
 
+    def install_dependencies(self) -> None:
+        """
+        Downloads and installs all runtime dependencies (e.g. language server binaries) that this language
+        server requires, such that it can subsequently be started without any further downloads being
+        necessary.
+
+        Note that instantiating a language server already installs most dependencies, because the launch
+        command must be constructed; this method additionally covers dependencies whose retrieval is
+        deferred until the language server is actually launched.
+
+        :raises Exception: if the dependencies could not be installed
+        """
+        if self._dependency_provider is None:
+            # the launch command was provided externally (deprecated code path), so there are no
+            # dependencies under our control
+            return
+        self._dependency_provider.install_dependencies()
+
     def _create_process_launch_info(self) -> ProcessLaunchInfo:
         dependency_provider = self._get_dependency_provider()
         cmd = dependency_provider.create_launch_command()

--- a/test/serena/test_cli_download_ls_dependencies.py
+++ b/test/serena/test_cli_download_ls_dependencies.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from serena.cli import TopLevelCommands
+from solidlsp.ls_config import LanguageServerId
+
+
+def _patch_config(monkeypatch, ls_specific_settings: dict | None = None) -> None:
+    """Makes the command read a well-defined (empty) global configuration instead of the user's."""
+    monkeypatch.setattr(
+        "serena.cli.SerenaConfig.from_config_file",
+        classmethod(lambda cls, generate_if_missing=True: SimpleNamespace(ls_specific_settings=ls_specific_settings or {})),
+    )
+
+
+def test_download_ls_dependencies_downloads_the_given_language_servers(monkeypatch):
+    downloaded: list[LanguageServerId] = []
+    _patch_config(monkeypatch)
+    monkeypatch.setattr("serena.cli._download_ls_dependencies", lambda ls_id, settings, root: downloaded.append(ls_id))
+
+    result = CliRunner().invoke(TopLevelCommands.download_ls_dependencies, ["python", "LUA"])
+
+    assert result.exit_code == 0, result.output
+    assert downloaded == [LanguageServerId.PYTHON, LanguageServerId.LUA]
+    assert "Successfully downloaded the dependencies of 2 language server(s)." in result.output
+
+
+def test_download_ls_dependencies_all_covers_non_experimental_language_servers(monkeypatch):
+    downloaded: list[LanguageServerId] = []
+    _patch_config(monkeypatch)
+    monkeypatch.setattr("serena.cli._download_ls_dependencies", lambda ls_id, settings, root: downloaded.append(ls_id))
+
+    result = CliRunner().invoke(TopLevelCommands.download_ls_dependencies, ["--all"])
+
+    assert result.exit_code == 0, result.output
+    assert downloaded == list(LanguageServerId.iter_all(include_experimental=False))
+    assert not any(ls_id.is_experimental() for ls_id in downloaded)
+
+
+def test_download_ls_dependencies_all_can_include_experimental_language_servers(monkeypatch):
+    downloaded: list[LanguageServerId] = []
+    _patch_config(monkeypatch)
+    monkeypatch.setattr("serena.cli._download_ls_dependencies", lambda ls_id, settings, root: downloaded.append(ls_id))
+
+    result = CliRunner().invoke(TopLevelCommands.download_ls_dependencies, ["--all", "--include-experimental"])
+
+    assert result.exit_code == 0, result.output
+    assert downloaded == list(LanguageServerId.iter_all(include_experimental=True))
+    assert any(ls_id.is_experimental() for ls_id in downloaded)
+
+
+def test_download_ls_dependencies_continues_after_failure_and_exits_1(monkeypatch):
+    downloaded: list[LanguageServerId] = []
+    _patch_config(monkeypatch)
+
+    def fake_download(ls_id: LanguageServerId, settings: dict, root: str) -> None:
+        if ls_id is LanguageServerId.GO:
+            raise RuntimeError("Go is not installed")
+        downloaded.append(ls_id)
+
+    monkeypatch.setattr("serena.cli._download_ls_dependencies", fake_download)
+
+    result = CliRunner().invoke(TopLevelCommands.download_ls_dependencies, ["go", "python"])
+
+    assert result.exit_code == 1
+    assert downloaded == [LanguageServerId.PYTHON], "the failure must not prevent the remaining downloads"
+    assert "go: Go is not installed" in result.output
+
+
+def test_download_ls_dependencies_rejects_unknown_language_server():
+    result = CliRunner().invoke(TopLevelCommands.download_ls_dependencies, ["pythonn"])
+
+    assert result.exit_code == 2
+    assert "Unknown language server 'pythonn'" in result.output
+
+
+def test_download_ls_dependencies_requires_language_server_or_all():
+    result = CliRunner().invoke(TopLevelCommands.download_ls_dependencies, [])
+
+    assert result.exit_code == 2
+    assert "Pass at least one language server name or use `--all`." in result.output
+
+
+def test_download_ls_dependencies_rejects_all_combined_with_explicit_language_servers():
+    result = CliRunner().invoke(TopLevelCommands.download_ls_dependencies, ["--all", "python"])
+
+    assert result.exit_code == 2
+    assert "Cannot combine explicitly named language servers with `--all`." in result.output
+
+
+def test_download_ls_dependencies_rejects_include_experimental_without_all():
+    result = CliRunner().invoke(TopLevelCommands.download_ls_dependencies, ["--include-experimental", "python"])
+
+    assert result.exit_code == 2
+    assert "`--include-experimental` is applicable only in conjunction with `--all`." in result.output

--- a/test/solidlsp/test_dependency_provider.py
+++ b/test/solidlsp/test_dependency_provider.py
@@ -1,0 +1,74 @@
+import subprocess
+
+import pytest
+
+from solidlsp.dependency_provider import LanguageServerDependencyProviderUvx
+from solidlsp.settings import SolidLSPSettings
+
+
+def _create_provider(settings: dict) -> LanguageServerDependencyProviderUvx:
+    return LanguageServerDependencyProviderUvx(
+        SolidLSPSettings.CustomLSSettings(settings),
+        ls_resources_dir=".",
+        package="somepackage",
+        entrypoint="some-langserver",
+        default_version="1.2.3",
+        version_setting_key="somepackage_version",
+    )
+
+
+@pytest.fixture
+def installation_commands(monkeypatch) -> list[list[str]]:
+    """Captures the commands that would be executed, preventing any actual installation."""
+    commands: list[list[str]] = []
+
+    def fake_subprocess_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+        commands.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("solidlsp.dependency_provider.subprocess_run", fake_subprocess_run)
+    monkeypatch.setattr(LanguageServerDependencyProviderUvx, "_find_uv_executable", staticmethod(lambda: "uv"))
+    return commands
+
+
+def test_install_dependencies_installs_the_pinned_version(installation_commands):
+    _create_provider({}).install_dependencies()
+
+    assert installation_commands == [["uv", "tool", "install", "-p", "3.13", "somepackage==1.2.3"]]
+
+
+def test_install_dependencies_respects_the_configured_version(installation_commands):
+    _create_provider({"somepackage_version": "4.5.6"}).install_dependencies()
+
+    assert installation_commands == [["uv", "tool", "install", "-p", "3.13", "somepackage==4.5.6"]]
+
+
+@pytest.mark.parametrize("settings", [{"ls_path": "/opt/some-langserver"}, {"ls_base_cmd": ["/opt/some-langserver"]}])
+def test_install_dependencies_skips_user_provided_launch_commands(installation_commands, settings):
+    _create_provider(settings).install_dependencies()
+
+    assert installation_commands == []
+
+
+def test_install_dependencies_ignores_malformed_base_command_like_the_launch_command_construction(installation_commands):
+    """
+    A malformed `ls_base_cmd` is ignored when the launch command is constructed, so the managed
+    installation applies and must not be skipped here either.
+    """
+    provider = _create_provider({"ls_base_cmd": "/opt/some-langserver"})
+
+    provider.install_dependencies()
+
+    assert installation_commands == [["uv", "tool", "install", "-p", "3.13", "somepackage==1.2.3"]]
+    assert provider._get_custom_base_command() is None
+
+
+def test_install_dependencies_raises_on_installation_failure(monkeypatch):
+    def failing_subprocess_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="network unreachable")
+
+    monkeypatch.setattr("solidlsp.dependency_provider.subprocess_run", failing_subprocess_run)
+    monkeypatch.setattr(LanguageServerDependencyProviderUvx, "_find_uv_executable", staticmethod(lambda: "uv"))
+
+    with pytest.raises(RuntimeError, match="network unreachable"):
+        _create_provider({}).install_dependencies()


### PR DESCRIPTION
Closes #664

Rebased onto current `main` and reimplemented from scratch — the previous version of this branch predated the `LanguageServerDependencyProvider` refactoring and no longer applied.

## What this PR does

Adds the CLI command

```shell
serena download-ls-dependencies <language server>...   # or --all
```

which downloads the runtime dependencies of the given language servers ahead of time, so that they need not be fetched on demand later on. This is the use case from #664: a container that may only reach a small, unstable-across-versions set of hosts at runtime, but has full network access at build time.

Following @opcode81's suggestion, the download is triggered by *instantiating* the language server (in a temporary directory, since the repository contents are never looked at), which constructs its launch command and thereby installs the dependencies.

## The uvx case

Instantiation alone is not sufficient for language servers run through `LanguageServerDependencyProviderUvx` (e.g. `python`/pyright): constructing the launch command only assembles `uvx --from <pkg>==<version> <entrypoint>`; the package environment is materialised when the command is *executed*. Such a server would report success without anything having been downloaded — precisely the case that then fails inside the offline container.

The dependency provider abstraction therefore gains an explicit part of its interface:

* `LanguageServerDependencyProvider.install_dependencies()`, whose default implementation covers the regular case (dependencies are installed while the launch command is constructed),
* overridden in `LanguageServerDependencyProviderUvx` to install the pinned package as a uv tool, so the subsequent `uvx` invocation reuses the existing installation. A user-provided `ls_path`/`ls_base_cmd` bypasses it, as there is then nothing for Serena to install.
* `SolidLanguageServer.install_dependencies()` exposes this on the language server itself.

## Behaviour

* Failures are collected per language server rather than aborting the run — a missing external toolchain (e.g. Go, Java) must not prevent the remaining downloads — and are reported with a non-zero exit code, so a container build fails early instead of silently producing an image with missing dependencies.
* The global `ls_specific_settings` are taken into account (without generating a config file if none exists), so users who point Serena at an existing installation don't download anything they don't need.

## Verification

* `ruff format` / `ruff check` / `ty check` clean (the pre-existing `ty` diagnostics on `main` are untouched).
* New unit tests in `test/serena/test_cli_download_ls_dependencies.py` covering selection, `--all`, partial failure + exit code, and argument validation.
* Manually verified end-to-end: `python` (uvx path → `uv tool install pyright==1.1.403`), `lua` (binary download), and `go` on a machine without Go (fails with the language server's own error message, exit code 1, remaining downloads unaffected).

Documentation added under "Language Support" and an entry in the CHANGELOG.
