### PR TITLE
fix: add linux-arm64 support for clangd language server

### DIFF
--- a/src/solidlsp/language_servers/clangd_language_server.py
+++ b/src/solidlsp/language_servers/clangd_language_server.py
@@ -51,7 +51,6 @@ class ClangdLanguageServer(SolidLanguageServer):
         """
         Setup runtime dependencies for ClangdLanguageServer and return the command to start the server.
         """
-        import platform
         import shutil
 
         deps = RuntimeDependencyCollection(


### PR DESCRIPTION
This PR is based on https://github.com/oraios/serena/pull/616 by https://github.com/COMEBACKISREAL
I added a commit to address review comments.

### Summary
Fixes missing linux-arm64 runtime dependency for clangd language server, enabling Serena to work on ARM64 Linux systems (aarch64).

### Problem
Serena was failing on ARM64 Linux systems with the error:
RuntimeError: Expected exactly one runtime dependency for linux-arm64, found 0

This occurred because the clangd configuration only had dependencies for linux-x64, win-x64, osx-x64, and osx-arm64, but was missing linux-arm64.

### Solution
Checck for system-installed clangd via shutil.which()
Provides clear installation instructions for major Linux distributions

### Why system-installed clangd?
Unlike macOS which has universal binaries (single file with multiple architectures), Linux requires separate binaries for each architecture. The clangd project currently doesn't provide pre-built ARM64 Linux binaries - this is tracked in issue https://github.com/oraios/serena/issues/514 since 2020.

### Testing

- Tested on ARM64 Linux (Ubuntu on aarch64)
- System clangd detected successfully at /usr/bin/clangd
-  Serena MCP starts without issues on linux-arm64

### Notes
ARM64 Linux users will need to install clangd via their package manager:

- Ubuntu/Debian: `sudo apt-get install clangd`
- Fedora/RHEL: `sudo dnf install clang-tools-extra`
- Arch Linux: `sudo pacman -S clang`