### PR TITLE
Support updating tools from dashboard

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,19 @@
+{
+	"servers": {
+		"serena": {
+			"type": "stdio",
+			"command": "uv",
+			"args": [
+				"run",
+				"--directory",
+				"${workspaceFolder}",
+				"serena",
+				"start-mcp-server",
+				"--context",
+				"ide-assistant",
+				"--project",
+				"${workspaceFolder}"
+			]
+		}
+	}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "tqdm>=4.67.1",
   "tiktoken>=0.9.0",
   "anthropic>=0.54.0",
+  "janus>=2.0.0",
 ]
 
 [[tool.uv.index]]
@@ -165,6 +166,7 @@ select = [
   "YTT",
 ]
 ignore = [
+  "PLW0603", # using global to set a var is fine
   "PLC0415",
   "RUF002",
   "RUF005",

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -203,7 +203,8 @@ class SerenaAgent:
         # may access various parts of the agent
         if self.serena_config.web_dashboard:
             self._dashboard_thread, port = SerenaDashboardAPI(
-                get_memory_log_handler(), tool_names, agent=self, tool_usage_stats=self._tool_usage_stats
+                get_memory_log_handler(), tool_names, agent=self, tool_usage_stats=self._tool_usage_stats,
+                enable_tool_management=self.serena_config.permit_tool_management_in_dashboard,
             ).run_in_thread()
             dashboard_url = f"http://127.0.0.1:{port}/dashboard/index.html"
             log.info("Serena web dashboard started at %s", dashboard_url)

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -55,6 +55,31 @@ class AvailableTools:
                 if isinstance(tool, marker_class):
                     self.tool_marker_names.add(marker_class.__name__)
 
+    def add(self, tool: Tool) -> None:
+        tool_name = tool.get_name()
+        if tool_name in self.tool_names:
+            log.warning(f"Tool '{tool_name}' is already in the available tools list")
+            return
+        self.tools.append(tool)
+        self.tool_names.append(tool_name)
+        for marker_class in iter_subclasses(ToolMarker):
+            if isinstance(tool, marker_class):
+                self.tool_marker_names.add(marker_class.__name__)
+
+    def remove(self, tool: Tool) -> None:
+        tool_name = tool.get_name()
+        if tool_name not in self.tool_names:
+            log.warning(f"Tool '{tool_name}' is not in the available tools list")
+            return
+        self.tools.remove(tool)
+        self.tool_names.remove(tool_name)
+        # Recompute marker names
+        self.tool_marker_names = set()
+        for marker_class in iter_subclasses(ToolMarker):
+            for t in self.tools:
+                if isinstance(t, marker_class):
+                    self.tool_marker_names.add(marker_class.__name__)
+
     def __len__(self) -> int:
         return len(self.tools)
 
@@ -188,6 +213,9 @@ class SerenaAgent:
                 process = multiprocessing.Process(target=self._open_dashboard, args=(dashboard_url,))
                 process.start()
                 process.join(timeout=1)
+
+    def is_for_openai_compatible_context(self) -> bool:
+        return self._context.name in ["chatgpt", "codex", "oaicompat-agent"]
 
     def get_current_tasks(self) -> list[TaskExecutor.TaskInfo]:
         """
@@ -569,6 +597,48 @@ class SerenaAgent:
         :param language: the language to remove
         """
         self.issue_task(lambda: self.get_active_project_or_raise().remove_language(language), name=f"RemoveLanguage:{language.value}")
+
+    def enable_tool(self, tool_name: str) -> None:
+        """
+        Enable a tool that was previously disabled. The tool will be added to both the active
+        tools and the exposed tools.
+
+        :param tool_name: the name of the tool to enable
+        :raises ValueError: if the tool name is invalid or the tool is already enabled
+        """
+        from serena.mcp import update_mcp_server_tool_list
+
+        def do_enable() -> None:
+            tool_class = ToolRegistry().get_tool_class_by_name(tool_name)
+            if tool_class in self._active_tools:
+                log.warning(f"Tool '{tool_name}' is already enabled")
+                return
+            tool_instance = self._all_tools[tool_class]
+            self._active_tools[tool_class] = tool_instance
+            self._exposed_tools.add(tool_instance)
+            update_mcp_server_tool_list(self._exposed_tools.tools, openai_tool_compatible=self.is_for_openai_compatible_context())
+
+        self.execute_task(do_enable, name=f"EnableTool:{tool_name}")
+
+    def disable_tool(self, tool_name: str) -> None:
+        """
+        Disable a tool. The tool will be removed from the active and the exposed tool sets.
+
+        :param tool_name: the name of the tool to disable
+        :raises ValueError: if the tool name is invalid or the tool is already disabled
+        """
+        from serena.mcp import update_mcp_server_tool_list
+
+        def do_disable() -> None:
+            tool_class = ToolRegistry().get_tool_class_by_name(tool_name)
+            if tool_class not in self._active_tools:
+                log.warning(f"Tool '{tool_name}' is already disabled")
+                return
+            tool_instance = self._active_tools.pop(tool_class)
+            self._exposed_tools.remove(tool_instance)
+            update_mcp_server_tool_list(self._exposed_tools.tools, openai_tool_compatible=self.is_for_openai_compatible_context())
+
+        self.execute_task(do_disable, name=f"DisableTool:{tool_name}")
 
     def get_tool(self, tool_class: type[TTool]) -> TTool:
         return self._all_tools[tool_class]  # type: ignore

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -28,7 +28,7 @@ from serena.constants import (
     USER_CONTEXT_YAMLS_DIR,
     USER_MODE_YAMLS_DIR,
 )
-from serena.mcp import SerenaMCPFactory, SerenaMCPFactorySingleProcess
+from serena.mcp import SerenaMCPFactory, SerenaMCPFactorySingleProcess, set_mcp_server_instance
 from serena.project import Project
 from serena.tools import FindReferencingSymbolsTool, FindSymbolTool, GetSymbolsOverviewTool, SearchForPatternTool, ToolRegistry
 from serena.util.logging import MemoryLogHandler
@@ -183,11 +183,15 @@ class TopLevelCommands(AutoRegisteringGroup):
             trace_lsp_communication=trace_lsp_communication,
             tool_timeout=tool_timeout,
         )
+        set_mcp_server_instance(server)
         if project_file_arg:
             log.warning(
                 "Positional project arg is deprecated; use --project instead. Used: %s",
                 project_file,
             )
+
+        # enable communication
+
         log.info("Starting MCP server …")
         server.run(transport=transport)
 

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -134,6 +134,15 @@ class ToolSet:
     def includes_name(self, tool_name: str) -> bool:
         return tool_name in self._tool_names
 
+    def add(self, tool_name: str) -> None:
+        self._tool_names.add(tool_name)
+
+    def remove(self, tool_name: str) -> None:
+        try:
+            self._tool_names.remove(tool_name)
+        except KeyError:
+            log.warning(f"Tool '{tool_name}' not found in tool set, cannot remove it.")
+
 
 @dataclass
 class ToolInclusionDefinition:

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -13,6 +13,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Self, TypeVar
 
+from regex import F
 import yaml
 from ruamel.yaml.comments import CommentedMap
 from sensai.util import logging
@@ -384,6 +385,7 @@ class SerenaConfig(ToolInclusionDefinition, ToStringMixin):
     trace_lsp_communication: bool = False
     web_dashboard: bool = True
     web_dashboard_open_on_launch: bool = True
+    permit_tool_management_in_dashboard: bool = False
     tool_timeout: float = DEFAULT_TOOL_TIMEOUT
     loaded_commented_yaml: CommentedMap | None = None
     config_file_path: str | None = None
@@ -504,6 +506,7 @@ class SerenaConfig(ToolInclusionDefinition, ToStringMixin):
             instance.gui_log_window_enabled = loaded_commented_yaml.get("gui_log_window", False)
         instance.log_level = loaded_commented_yaml.get("log_level", loaded_commented_yaml.get("gui_log_level", logging.INFO))
         instance.web_dashboard = loaded_commented_yaml.get("web_dashboard", True)
+        instance.permit_tool_management_in_dashboard = loaded_commented_yaml.get("permit_tool_management_in_dashboard", False)
         instance.web_dashboard_open_on_launch = loaded_commented_yaml.get("web_dashboard_open_on_launch", True)
         instance.tool_timeout = loaded_commented_yaml.get("tool_timeout", DEFAULT_TOOL_TIMEOUT)
         instance.trace_lsp_communication = loaded_commented_yaml.get("trace_lsp_communication", False)

--- a/src/serena/dashboard.py
+++ b/src/serena/dashboard.py
@@ -54,6 +54,7 @@ class ResponseConfigOverview(BaseModel):
     jetbrains_mode: bool
     languages: list[str]
     encoding: str | None
+    tool_management_enabled: bool
 
 
 class ResponseAvailableLanguages(BaseModel):
@@ -134,6 +135,7 @@ class SerenaDashboardAPI:
         agent: "SerenaAgent",
         shutdown_callback: Callable[[], None] | None = None,
         tool_usage_stats: ToolUsageStats | None = None,
+        enable_tool_management: bool = False,
     ) -> None:
         self._memory_log_handler = memory_log_handler
         self._tool_names = tool_names
@@ -141,6 +143,7 @@ class SerenaDashboardAPI:
         self._shutdown_callback = shutdown_callback
         self._app = Flask(__name__)
         self._tool_usage_stats = tool_usage_stats
+        self._enable_tool_management = enable_tool_management
         self._setup_routes()
 
     @property
@@ -473,6 +476,7 @@ class SerenaDashboardAPI:
             jetbrains_mode=self._agent.serena_config.jetbrains,
             languages=languages,
             encoding=encoding,
+            tool_management_enabled=self._enable_tool_management,
         )
 
     def _shutdown(self) -> None:

--- a/src/serena/resources/dashboard/dashboard.css
+++ b/src/serena/resources/dashboard/dashboard.css
@@ -247,6 +247,7 @@ body {
 }
 
 .tool-item {
+    position: relative;
     background-color: var(--bg-primary);
     padding: 6px 10px;
     border-radius: 3px;
@@ -256,6 +257,66 @@ body {
     text-overflow: ellipsis;
     white-space: nowrap;
     cursor: default;
+}
+
+.tool-item.removable {
+    padding-right: 28px;
+}
+
+.tool-remove {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 18px;
+    height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 68, 68, 0.1);
+    border-radius: 3px;
+    cursor: pointer;
+    color: #ff4444;
+    font-size: 14px;
+    font-weight: bold;
+    line-height: 1;
+    transition: all 0.2s;
+}
+
+.tool-remove:hover {
+    background: rgba(255, 68, 68, 0.2);
+    transform: scale(1.1);
+}
+
+.tool-enable-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    margin: 5px 0;
+    border-radius: 4px;
+    background-color: var(--bg-primary);
+    border: 1px dashed var(--border-color);
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.tool-enable-item:hover {
+    background-color: var(--border-color);
+    border-color: var(--btn-primary);
+    color: var(--btn-primary);
+    border-style: solid;
+}
+
+.tool-enable-icon {
+    font-size: 18px;
+    font-weight: bold;
+    line-height: 1;
+    color: var(--btn-primary);
+}
+
+.tool-enable-name {
+    flex: 1;
+    font-size: 13px;
 }
 
 /* Projects List */

--- a/src/serena/resources/dashboard/dashboard.js
+++ b/src/serena/resources/dashboard/dashboard.js
@@ -461,6 +461,10 @@ class Dashboard {
             html += '<div class="config-label">File Encoding:</div>';
             html += '<div class="config-value">' + (config.encoding || 'N/A') + '</div>';
 
+            // Tool Management Enabled info
+            html += '<div class="config-label">Tool Management Enabled:</div>';
+            html += '<div class="config-value">' + (config.tool_management_enabled ? 'Yes' : 'No') + '</div>';
+
             html += '</div>';
 
             // Active tools - collapsible
@@ -470,10 +474,13 @@ class Dashboard {
             html += '<span class="toggle-icon' + (wasToolsExpanded ? ' expanded' : '') + '">▼</span>';
             html += '</h3>';
             html += '<div class="collapsible-content tools-grid" id="tools-content" style="' + (wasToolsExpanded ? '' : 'display:none;') + ' margin-top: 10px;">';
+            const toolManagementEnabled = config.tool_management_enabled;
             config.active_tools.forEach(function (tool) {
-                html += '<div class="tool-item removable" data-tool="' + tool + '" title="' + tool + '">';
+                html += '<div class="tool-item' + (toolManagementEnabled ? ' removable' : '') + '" data-tool="' + tool + '" title="' + tool + '">';
                 html += tool;
-                html += '<span class="tool-remove" data-tool="' + tool + '">&times;</span>';
+                if (toolManagementEnabled) {
+                    html += '<span class="tool-remove" data-tool="' + tool + '">&times;</span>';
+                }
                 html += '</div>';
             });
             html += '</div>';
@@ -528,13 +535,15 @@ class Dashboard {
                 self.confirmRemoveLanguage(language);
             });
 
-            // Attach event handlers for tool remove buttons (disable tools)
-            $('.tool-remove').click(function (e) {
-                e.preventDefault();
-                e.stopPropagation();
-                const toolName = $(this).data('tool');
-                self.disableTool(toolName);
-            });
+            // Attach event handlers for tool remove buttons (disable tools) - only if tool management is enabled
+            if (config.tool_management_enabled) {
+                $('.tool-remove').click(function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const toolName = $(this).data('tool');
+                    self.disableTool(toolName);
+                });
+            }
 
             // Attach event handlers for memory items
             $('.memory-item').click(function (e) {
@@ -634,21 +643,30 @@ class Dashboard {
         }
 
         const self = this;
+        const toolManagementEnabled = this.configData && this.configData.tool_management_enabled;
         let html = '';
         tools.forEach(function (tool) {
-            html += '<div class="info-item tool-enable-item" data-tool="' + tool.name + '" title="Click to enable ' + tool.name + '">';
-            html += '<span class="tool-enable-icon">+</span>';
-            html += '<span class="tool-enable-name">' + tool.name + '</span>';
-            html += '</div>';
+            if (toolManagementEnabled) {
+                html += '<div class="info-item tool-enable-item" data-tool="' + tool.name + '" title="Click to enable ' + tool.name + '">';
+                html += '<span class="tool-enable-icon">+</span>';
+                html += '<span class="tool-enable-name">' + tool.name + '</span>';
+                html += '</div>';
+            } else {
+                html += '<div class="info-item" title="' + tool.name + '">';
+                html += '<span class="tool-enable-name">' + tool.name + '</span>';
+                html += '</div>';
+            }
         });
 
         this.$availableToolsDisplay.html(html);
 
-        // Attach click handlers to enable tools
-        $('.tool-enable-item').click(function () {
-            const toolName = $(this).data('tool');
-            self.enableTool(toolName);
-        });
+        // Attach click handlers to enable tools - only if tool management is enabled
+        if (toolManagementEnabled) {
+            $('.tool-enable-item').click(function () {
+                const toolName = $(this).data('tool');
+                self.enableTool(toolName);
+            });
+        }
     }
 
     displayAvailableModes(modes) {

--- a/src/serena/resources/serena_config.template.yml
+++ b/src/serena/resources/serena_config.template.yml
@@ -20,6 +20,14 @@ web_dashboard: True
 # shows Serena's current session logs - as an alternative to the GUI log window which
 # is supported on all platforms.
 
+
+permit_tool_management_in_dashboard: False
+# whether to permit enabling and disabling tools from the web dashboard. Some MCP clients
+# (as of November 2025 this includes Claude Desktop and Claude Code) don't support the MCP
+# endpoint for updating the tool list dynamically. Others, such as VSCode and Cursor, do support it.
+# If you are using an MCP client that doesn't support dynamic tool management, you should
+# set this option to False to avoid confusion.
+
 web_dashboard_open_on_launch: True
 # whether to open a browser window with the web dashboard when Serena starts (provided that web_dashboard
 # is enabled). If set to False, you can still open the dashboard manually by navigating to

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.11.*"
 
 [[package]]
@@ -446,6 +446,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "janus"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/7f/69884b6618be4baf6ebcacc716ee8680a842428a19f403db6d1c0bb990aa/janus-2.0.0.tar.gz", hash = "sha256:0970f38e0e725400496c834a368a67ee551dc3b5ad0a257e132f5b46f2e77770", size = 22910, upload-time = "2024-12-13T12:59:08.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/34/65604740edcb20e1bda6a890348ed7d282e7dd23aa00401cbe36fd0edbd9/janus-2.0.0-py3-none-any.whl", hash = "sha256:7e6449d34eab04cd016befbd7d8c0d8acaaaab67cb59e076a69149f9031745f9", size = 12161, upload-time = "2024-12-13T12:59:06.106Z" },
 ]
 
 [[package]]
@@ -1147,6 +1156,7 @@ dependencies = [
     { name = "dotenv" },
     { name = "flask" },
     { name = "fortls" },
+    { name = "janus" },
     { name = "jinja2" },
     { name = "joblib" },
     { name = "mcp" },
@@ -1197,6 +1207,7 @@ requires-dist = [
     { name = "flask", specifier = ">=3.0.0" },
     { name = "fortls", specifier = ">=3.2.2" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.8.0" },
+    { name = "janus", specifier = ">=2.0.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jinja2", marker = "extra == 'dev'" },
     { name = "joblib", specifier = ">=1.5.1" },


### PR DESCRIPTION
Using a dedicated tool _update_tool_list which is added to the server at the very end. Unfortunately, there seems to be no better way to do that, as the session object is not exposed in the mcp sdk in other places than the tool's context

**Doesn't work in Claude Code or Claude Desktop**

Anthropic's products don't follow Anthropic's own specifications...
https://github.com/anthropics/claude-code/issues/4118

We probably shouldn't merge until Anthropic resolves it