### PR TITLE
Use selection range in scala

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,7 +276,6 @@ markers = [
   "dart: language server running for Dart",
   "erlang: language server running for Erlang",
   "scala: language server running for Scala",
-  "scala: language server running for Scala",
   "al: language server running for AL (Microsoft Dynamics 365 Business Central)",
   "rego: language server running for Rego",
   "markdown: language server running for Markdown",

--- a/src/solidlsp/language_servers/scala_language_server.py
+++ b/src/solidlsp/language_servers/scala_language_server.py
@@ -150,13 +150,7 @@ class ScalaLanguageServer(SolidLanguageServer):
                 "copyWorksheetOutputProvider": False,
                 "doctorVisibilityProvider": False,
             },
-            "capabilities": {
-              "textDocument": {
-                  "documentSymbol": {
-                      "hierarchicalDocumentSymbolSupport": True
-                  }
-              }
-            },
+            "capabilities": {"textDocument": {"documentSymbol": {"hierarchicalDocumentSymbolSupport": True}}},
         }
         return initialize_params
 


### PR DESCRIPTION
I resolved an issue where find_referencing_symbol did not work properly in Serena’s Scala support. The images below show it in action.

resolve: https://github.com/oraios/serena/issues/688#issuecomment-3481783775 (It started working once I changed it to return serectionrange.)



<img width="360" height="312" alt="image" src="https://github.com/user-attachments/assets/fcb621a6-8891-4e83-8ff7-cb50a4080c0e" />


<img width="480" height="430" alt="image" src="https://github.com/user-attachments/assets/adf8d276-45ae-444e-a364-57cedfd70b56" />
