### PR TITLE
Fix AttributeError when starting MCP server

### DIFF
--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -185,7 +185,10 @@ class SerenaMCPFactory:
 
         # Mount the tool description as a combination of the docstring description and
         # the return value description, if it exists.
-        overridden_description = tool.agent.get_context().tool_description_overrides.get(func_name, None)
+        # overridden_description = tool.agent.get_context().tool_description_overrides.get(func_name, None)
+        context = tool.agent.get_context()
+        tool_desc_overrides = getattr(context, 'tool_description_overrides', None) if context else None
+        overridden_description = tool_desc_overrides.get(func_name, None) if tool_desc_overrides else None
 
         if overridden_description is not None:
             func_doc = overridden_description


### PR DESCRIPTION
### Problem
The MCP server crashes during startup with `AttributeError: 'NoneType' object has no attribute 'get'` when `context.tool_description_overrides` is `None`.

**Error location**: `src/serena/mcp.py`, line 190

**Error message**:
```
AttributeError: 'NoneType' object has no attribute 'get'
```

This occurs in various scenarios:
- Starting server without specifying a project
- Starting with an invalid project path
- In certain context configurations where `tool_description_overrides` is not initialized

### Root Cause
The code assumes `context.tool_description_overrides` is always a dictionary, but it can be `None` in some cases. The existing null check only verified that `context` itself is not `None`, but didn't check if the `tool_description_overrides` attribute exists or is `None`.

### Solution
Added proper null-safety checks before accessing the `tool_description_overrides` dictionary:
```python
# Before
overridden_description = context.tool_description_overrides.get(func_name, None) if context else None

# After
context = tool.agent.get_context()
tool_desc_overrides = getattr(context, 'tool_description_overrides', None) if context else None
overridden_description = tool_desc_overrides.get(func_name, None) if tool_desc_overrides else None
```

### Testing
Tested on Windows 10/11 with Serena v0.1.4:
- ✅ Server starts successfully with valid project
- ✅ Server starts successfully without project specification
- ✅ Server handles invalid project paths gracefully
- ✅ All contexts (test, ide-assistant, etc.) work correctly

### Environment
- OS: Windows 10/11
- Python: 3.11.13, 3.13.5
- Serena version: 0.1.4-600080c6-dirty