### PR TITLE
Resolve eclipse jdtls _request_document_symbols override problem

### DIFF
--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -13,7 +13,7 @@ from pathlib import PurePath
 
 from overrides import override
 
-from solidlsp.ls import GenericDocumentSymbol, SolidLanguageServer
+from solidlsp.ls import GenericDocumentSymbol, LSPFileBuffer, SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_logger import LanguageServerLogger
 from solidlsp.ls_utils import FileUtils, PlatformUtils
@@ -788,8 +788,8 @@ class EclipseJDTLS(SolidLanguageServer):
         # TODO: Add comments about why we wait here, and how this can be optimized
         self.service_ready_event.wait()
 
-    def _request_document_symbols(self, relative_file_path: str) -> list[GenericDocumentSymbol]:
-        result = super()._request_document_symbols(relative_file_path)
+    def _request_document_symbols(self, relative_file_path: str, file_data: LSPFileBuffer | None) -> list[GenericDocumentSymbol]:
+        result = super()._request_document_symbols(relative_file_path, file_data)
 
         # JDTLS sometimes returns symbol names with type information to handle overloads,
         # e.g. "myMethod(int) <T>", but we want overloads to be handled via overload_idx,


### PR DESCRIPTION
Claude Code cannot run the `find_symbol` (or other symbol tools, for that matter) because of a recently-added method having an inconsistent override in the `EclipseJDTLS` lang server definition.

```
serena - find_symbol (MCP)(name_path_pattern: "Enricher/enrich", include_body: true)
  ⎿  {                                                                                                                                     
       "result": "Error executing tool: TypeError - EclipseJDTLS._request_document_symbols() takes 2 positional arguments but 3 were given"
     }

⏺ I'm encountering an error with the Serena MCP symbolic tools:

  Error: TypeError - EclipseJDTLS._request_document_symbols() takes 2 positional arguments but 3 were given

  This error occurs when I try to use:
  - mcp__serena__find_symbol
  - mcp__serena__get_symbols_overview

  It appears to be an internal error in the EclipseJDTLS integration within Serena. The symbolic tools are not working for this project.
  ```

Running `poe test -m "java"` reveals the failure. (By default, `poe test` will not run tests marked with `"java"`, which likely hid this problem.)

```
            else:
                log.debug("No cache hit for document symbols in %s", relative_file_path)
    
            # no cached result: request the root symbols from the language server
>           root_symbols = self._request_document_symbols(relative_file_path, file_data)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           TypeError: EclipseJDTLS._request_document_symbols() takes 2 positional arguments but 3 were given

src/solidlsp/ls.py:1020: TypeError
```