### PR TITLE
Bugfix: Remove spurious arg from log call

### DIFF
--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -318,7 +318,7 @@ class SolidLanguageServer(ABC):
             # Normalize separators (pathspec expects forward slashes)
             pattern = pattern.replace(os.path.sep, "/")
             processed_patterns.append(pattern)
-        log.debug(f"Processing {len(processed_patterns)} ignored paths from the config", logging.DEBUG)
+        log.debug(f"Processing {len(processed_patterns)} ignored paths from the config")
 
         # Create a pathspec matcher from the processed patterns
         self._ignore_spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, processed_patterns)


### PR DESCRIPTION
I am not sure how this can work for anyone, but for me, a spurious argument to a `log.debug` call broke LSP initialization. This PR just removes it.

This is the log with the error when trying to initialize:
```
(...)
vINFO  2025-11-27 11:06:31,140 [StartLS:rust] sensai.util.logging:start:329 - Language server startup (language=rust) starting ...
INFO  2025-11-27 11:06:31,140 [StartLS:rust] serena.ls_manager:create_language_server:40 - Creating language server instance for /home/miguel/devel/transit-rs, language=rust.
INFO  2025-11-27 11:06:31,189 [StartLS:rust] solidlsp.language_servers.rust_analyzer:__init__:104 - Using rust-analyzer at: /home/miguel/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rust-analyzer
DEBUG 2025-11-27 11:06:31,198 [StartLS:rust] solidlsp.ls:__init__:265 - Custom config (LS-specific settings) for rust: SolidLSPSettings.CustomLSSettings[settings={}]
DEBUG 2025-11-27 11:06:31,198 [StartLS:rust] solidlsp.ls:__init__:268 - Creating language server instance for repository_root_path='/home/miguel/devel/transit-rs' with language_id='rust' and process launch info: ProcessLaunchInfo(cmd='/home/miguel/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rust-analyzer', env={}, cwd='/home/miguel/devel/transit-rs')
DEBUG 2025-11-27 11:06:31,198 [StartLS:rust] solidlsp.ls:__init__:305 - Creating language server instance with language_id='rust' and process launch info: ProcessLaunchInfo(cmd='/home/miguel/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rust-analyzer', env={}, cwd='/home/miguel/devel/transit-rs')
ERROR 2025-11-27 11:06:31,198 [StartLS:rust] sensai.util.logging:__exit__:342 - Language server startup (language=rust) failed after 0.059 seconds
ERROR 2025-11-27 11:06:31,199 [StartLS:rust] serena.ls_manager:start_language_server:100 - Error starting language server for language rust: not all arguments converted during string formatting
Traceback (most recent call last):
  File "/home/miguel/devel/serena/src/serena/ls_manager.py", line 93, in start_language_server
    language_server = factory.create_language_server(language)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/miguel/devel/serena/src/serena/ls_manager.py", line 41, in create_language_server
    return SolidLanguageServer.create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/miguel/devel/serena/src/solidlsp/ls.py", line 234, in create
    ls = ls_class(config, repository_root_path, solidlsp_settings)  # type: ignore
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/miguel/devel/serena/src/solidlsp/language_servers/rust_analyzer.py", line 106, in __init__
    super().__init__(
  File "/home/miguel/devel/serena/src/solidlsp/ls.py", line 321, in __init__
    log.debug(f"Processing {len(processed_patterns)} ignored paths from the config", logging.DEBUG)
  File "/home/miguel/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 1477, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/home/miguel/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 1634, in _log
    self.handle(record)
  File "/home/miguel/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 1644, in handle
    self.callHandlers(record)
  File "/home/miguel/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 1706, in callHandlers
    hdlr.handle(record)
  File "/home/miguel/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 978, in handle
    self.emit(record)
  File "/home/miguel/devel/serena/src/serena/util/logging.py", line 34, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/miguel/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/home/miguel/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/home/miguel/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
ERROR 2025-11-27 11:06:31,201 [Task-2:init_language_server_manager] serena.agent:__exit__:342 - Language server initialization failed after 0.062 seconds
ERROR 2025-11-27 11:06:31,202 [Task-2:init_language_server_manager] serena.task_executor:__exit__:342 - Task-2:init_language_server_manager failed after 0.063 seconds
ERROR 2025-11-27 11:06:31,202 [Task-2:init_language_server_manager] serena.task_executor:run_task:62 - Error during execution of Task-2:init_language_server_manager: Failed to start language servers:
rust: not all arguments converted during string formatting
Traceback (most recent call last):
  File "/home/miguel/devel/serena/src/serena/task_executor.py", line 57, in run_task
    result = self._function()
             ^^^^^^^^^^^^^^^^
  File "/home/miguel/devel/serena/src/serena/agent.py", line 521, in init_language_server_manager
    self.reset_language_server_manager()
  File "/home/miguel/devel/serena/src/serena/agent.py", line 645, in reset_language_server_manager
    self.get_active_project_or_raise().create_language_server_manager(
  File "/home/miguel/devel/serena/src/serena/project.py", line 393, in create_language_server_manager
    self.language_server_manager = LanguageServerManager.from_languages(self.project_config.languages, factory)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/miguel/devel/serena/src/serena/ls_manager.py", line 117, in from_languages
    raise Exception(f"Failed to start language servers:\n{failure_messages}")
Exception: Failed to start language servers:
rust: not all arguments converted during string formatting
DEBUG 2025-11-27 11:06:45,761 [MainThread] mcp.server.lowlevel.server:run:588 - Received message: <mcp.shared.session.RequestResponder object at 0x762363f10650>
INFO  2025-11-27 11:06:45,762 [MainThread] mcp.server.lowlevel.server:_handle_request:625 - Processing request of type CallToolRequest
DEBUG 2025-11-27 11:06:45,762 [MainThread] mcp.server.lowlevel.server:_handle_request:627 - Dispatching request of type CallToolRequest
INFO  2025-11-27 11:06:45,762 [MainThread] serena.task_executor:issue_task:192 - Scheduling Task-3:CheckOnboardingPerformedTool
(...)
```