### PR TITLE
feat: Add TOML and TOON language support via Taplo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Status of the `main` branch. Changes prior to the next official version change w
   * **Add support for Lua** via lua-language-server
   * **Add support for Nix** requires nixd installation (Windows not supported)
   * **Add experimental support for YAML** via yaml-language-server with LSP integration for .yaml and .yml files
+  * **Add support for TOML** via Taplo language server with automatic binary download, validation, formatting, and schema support for .toml files
+  * **Add experimental support for TOON** (Token-Oriented Object Notation) format via Taplo, a compact JSON alternative for LLM prompts (.toon files)
   * **Dart now officially supported**: Dart was always working, but now tests were added, and it is promoted to "officially supported"
   * **Rust now uses already installed rustup**: The rust-analyzer is no longer bundled with Serena. Instead, it uses the rust-analyzer from your Rust toolchain managed by rustup. This ensures compatibility with your Rust version and eliminates outdated bundled binaries.
   * **Kotlin now officially supported**: We now use the official Kotlin LS, tests run through and performance is good, even though the LS is in an early development stage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,6 +299,8 @@ markers = [
   "fortran: language server running for Fortran",
   "haskell: Haskell language server tests",
   "yaml: language server running for YAML",
+  "toml: language server running for TOML",
+  "toon: language server running for TOON (experimental)",
 ]
 
 [tool.codespell]

--- a/src/solidlsp/language_servers/taplo_server.py
+++ b/src/solidlsp/language_servers/taplo_server.py
@@ -1,0 +1,275 @@
+"""
+Provides TOML specific instantiation of the LanguageServer class using Taplo.
+Contains various configurations and settings specific to TOML files.
+"""
+
+import gzip
+import logging
+import os
+import platform
+import shutil
+import stat
+import threading
+import urllib.request
+from typing import Any
+
+from solidlsp.ls import SolidLanguageServer
+from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
+from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
+from solidlsp.utils.path_utils import PathUtils
+
+log = logging.getLogger(__name__)
+
+# Taplo release version and download URLs
+TAPLO_VERSION = "0.10.0"
+TAPLO_DOWNLOAD_BASE = f"https://github.com/tamasfe/taplo/releases/download/{TAPLO_VERSION}"
+
+
+def _get_taplo_download_url() -> tuple[str, str]:
+    """
+    Get the appropriate Taplo download URL for the current platform.
+
+    Returns:
+        Tuple of (download_url, executable_name)
+
+    """
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    # Map machine architecture to Taplo naming convention
+    arch_map = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "x86": "x86",
+        "i386": "x86",
+        "i686": "x86",
+        "aarch64": "aarch64",
+        "arm64": "aarch64",
+        "armv7l": "armv7",
+    }
+
+    arch = arch_map.get(machine, "x86_64")  # Default to x86_64
+
+    if system == "windows":
+        filename = f"taplo-windows-{arch}.zip"
+        executable = "taplo.exe"
+    elif system == "darwin":
+        filename = f"taplo-darwin-{arch}.gz"
+        executable = "taplo"
+    else:  # Linux and others
+        filename = f"taplo-linux-{arch}.gz"
+        executable = "taplo"
+
+    return f"{TAPLO_DOWNLOAD_BASE}/{filename}", executable
+
+
+class TaploServer(SolidLanguageServer):
+    """
+    Provides TOML specific instantiation of the LanguageServer class using Taplo.
+    Taplo is a TOML toolkit with LSP support for validation, formatting, and schema support.
+    """
+
+    @staticmethod
+    def _determine_log_level(line: str) -> int:
+        """Classify Taplo stderr output to avoid false-positive errors."""
+        line_lower = line.lower()
+
+        # Known informational messages from Taplo
+        if any(
+            [
+                "schema" in line_lower and "not found" in line_lower,
+                "warning" in line_lower,
+            ]
+        ):
+            return logging.DEBUG
+
+        return SolidLanguageServer._determine_log_level(line)
+
+    def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
+        """
+        Creates a TaploServer instance. This class is not meant to be instantiated directly.
+        Use LanguageServer.create() instead.
+        """
+        taplo_executable_path = self._setup_runtime_dependencies(solidlsp_settings)
+        super().__init__(
+            config,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=f"{taplo_executable_path} lsp stdio", cwd=repository_root_path),
+            "toml",
+            solidlsp_settings,
+        )
+        self.server_ready = threading.Event()
+
+    @classmethod
+    def _setup_runtime_dependencies(cls, solidlsp_settings: SolidLSPSettings) -> str:
+        """
+        Setup runtime dependencies for Taplo and return the command to start the server.
+        """
+        # First check if taplo is already installed system-wide
+        system_taplo = shutil.which("taplo")
+        if system_taplo:
+            log.info(f"Using system-installed Taplo at: {system_taplo}")
+            return system_taplo
+
+        # Setup local installation directory
+        taplo_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "taplo")
+        os.makedirs(taplo_dir, exist_ok=True)
+
+        _, executable_name = _get_taplo_download_url()
+        taplo_executable = os.path.join(taplo_dir, executable_name)
+
+        if os.path.exists(taplo_executable) and os.access(taplo_executable, os.X_OK):
+            log.info(f"Using cached Taplo at: {taplo_executable}")
+            return taplo_executable
+
+        # Download and install Taplo
+        log.info(f"Taplo not found. Downloading version {TAPLO_VERSION}...")
+        cls._download_taplo(taplo_dir, taplo_executable)
+
+        if not os.path.exists(taplo_executable):
+            raise FileNotFoundError(
+                f"Taplo executable not found at {taplo_executable}. "
+                "Installation may have failed. Try installing manually: cargo install taplo-cli --locked"
+            )
+
+        return taplo_executable
+
+    @classmethod
+    def _download_taplo(cls, install_dir: str, executable_path: str) -> None:
+        """Download and extract Taplo binary."""
+        download_url, _ = _get_taplo_download_url()
+
+        try:
+            log.info(f"Downloading Taplo from: {download_url}")
+            archive_path = os.path.join(install_dir, os.path.basename(download_url))
+
+            # Download the archive
+            urllib.request.urlretrieve(download_url, archive_path)
+
+            # Extract based on format
+            if archive_path.endswith(".gz") and not archive_path.endswith(".tar.gz"):
+                # Single file gzip
+                with gzip.open(archive_path, "rb") as f_in:
+                    with open(executable_path, "wb") as f_out:
+                        f_out.write(f_in.read())
+            elif archive_path.endswith(".zip"):
+                import zipfile
+
+                with zipfile.ZipFile(archive_path, "r") as zip_ref:
+                    # Extract all and find the executable
+                    zip_ref.extractall(install_dir)
+
+            # Make executable on Unix systems
+            if os.name != "nt":
+                os.chmod(executable_path, os.stat(executable_path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+            # Clean up archive
+            os.remove(archive_path)
+            log.info(f"Taplo installed successfully at: {executable_path}")
+
+        except Exception as e:
+            log.error(f"Failed to download Taplo: {e}")
+            raise RuntimeError(
+                f"Failed to download Taplo from {download_url}. Try installing manually: cargo install taplo-cli --locked"
+            ) from e
+
+    @staticmethod
+    def _get_initialize_params(repository_absolute_path: str) -> InitializeParams:
+        """
+        Returns the initialize params for the Taplo Language Server.
+        """
+        root_uri = PathUtils.path_to_uri(repository_absolute_path)
+        initialize_params = {
+            "locale": "en",
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {"didSave": True, "dynamicRegistration": True},
+                    "completion": {"dynamicRegistration": True, "completionItem": {"snippetSupport": True}},
+                    "definition": {"dynamicRegistration": True},
+                    "references": {"dynamicRegistration": True},
+                    "documentSymbol": {
+                        "dynamicRegistration": True,
+                        "hierarchicalDocumentSymbolSupport": True,
+                        "symbolKind": {"valueSet": list(range(1, 27))},
+                    },
+                    "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "codeAction": {"dynamicRegistration": True},
+                    "formatting": {"dynamicRegistration": True},
+                    "semanticTokens": {"dynamicRegistration": True},
+                },
+                "workspace": {
+                    "workspaceFolders": True,
+                    "didChangeConfiguration": {"dynamicRegistration": True},
+                    "symbol": {"dynamicRegistration": True},
+                    "configuration": True,
+                },
+            },
+            "processId": os.getpid(),
+            "rootPath": repository_absolute_path,
+            "rootUri": root_uri,
+            "workspaceFolders": [
+                {
+                    "uri": root_uri,
+                    "name": os.path.basename(repository_absolute_path),
+                }
+            ],
+            "initializationOptions": {
+                "configuration": {
+                    "evenBetterToml": {
+                        "schema": {
+                            "enabled": True,
+                            "repositoryEnabled": True,
+                            "repositoryUrl": "https://taplo.tamasfe.dev/schema_index.json",
+                        },
+                        "formatter": {"alignEntries": False, "alignComments": True, "arrayTrailingComma": True},
+                    }
+                }
+            },
+        }
+        return initialize_params  # type: ignore
+
+    def _start_server(self) -> None:
+        """
+        Starts the Taplo Language Server and initializes it.
+        """
+
+        def register_capability_handler(params: Any) -> None:
+            return
+
+        def do_nothing(params: Any) -> None:
+            return
+
+        def window_log_message(msg: dict) -> None:
+            log.info(f"LSP: window/logMessage: {msg}")
+
+        self.server.on_request("client/registerCapability", register_capability_handler)
+        self.server.on_notification("window/logMessage", window_log_message)
+        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+
+        log.info("Starting Taplo server process")
+        self.server.start()
+        initialize_params = self._get_initialize_params(self.repository_root_path)
+
+        log.info("Sending initialize request to Taplo server")
+        init_response = self.server.send.initialize(initialize_params)
+        log.debug(f"Received initialize response from Taplo: {init_response}")
+
+        # Verify document symbol support
+        capabilities = init_response.get("capabilities", {})
+        if capabilities.get("documentSymbolProvider"):
+            log.info("Taplo server supports document symbols")
+        else:
+            log.warning("Taplo server may have limited document symbol support")
+
+        self.server.notify.initialized({})
+
+        log.info("Taplo server initialization complete")
+        self.server_ready.set()
+        self.completions_available.set()
+
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        """Define TOML-specific directories to ignore."""
+        return super().is_ignored_dirname(dirname) or dirname in ["target", ".cargo", "node_modules"]

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -82,6 +82,14 @@ class Language(str, Enum):
     """YAML language server (experimental).
     Must be explicitly specified as the main language, not auto-detected.
     """
+    TOML = "toml"
+    """TOML language server using Taplo.
+    Supports TOML validation, formatting, and schema support.
+    """
+    TOON = "toon"
+    """TOON (Token-Oriented Object Notation) format support (experimental).
+    Uses Taplo server for basic validation. TOON is a compact JSON alternative for LLM prompts.
+    """
 
     @classmethod
     def iter_all(cls, include_experimental: bool = False) -> Iterable[Self]:
@@ -93,7 +101,15 @@ class Language(str, Enum):
         """
         Check if the language server is experimental or deprecated.
         """
-        return self in {self.TYPESCRIPT_VTS, self.PYTHON_JEDI, self.CSHARP_OMNISHARP, self.RUBY_SOLARGRAPH, self.MARKDOWN, self.YAML}
+        return self in {
+            self.TYPESCRIPT_VTS,
+            self.PYTHON_JEDI,
+            self.CSHARP_OMNISHARP,
+            self.RUBY_SOLARGRAPH,
+            self.MARKDOWN,
+            self.YAML,
+            self.TOON,
+        }
 
     def __str__(self) -> str:
         return self.value
@@ -148,6 +164,10 @@ class Language(str, Enum):
                 return FilenameMatcher("*.sh", "*.bash")
             case self.YAML:
                 return FilenameMatcher("*.yaml", "*.yml")
+            case self.TOML:
+                return FilenameMatcher("*.toml")
+            case self.TOON:
+                return FilenameMatcher("*.toon")
             case self.ZIG:
                 return FilenameMatcher("*.zig", "*.zon")
             case self.LUA:
@@ -269,6 +289,10 @@ class Language(str, Enum):
                 from solidlsp.language_servers.yaml_language_server import YamlLanguageServer
 
                 return YamlLanguageServer
+            case self.TOML | self.TOON:
+                from solidlsp.language_servers.taplo_server import TaploServer
+
+                return TaploServer
             case self.ZIG:
                 from solidlsp.language_servers.zls import ZigLanguageServer
 

--- a/test/resources/repos/toml/test_repo/Cargo.toml
+++ b/test/resources/repos/toml/test_repo/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "test_project"
+version = "0.1.0"
+edition = "2021"
+description = "A test TOML file for Serena TOML language support"
+authors = ["Test Author <test@example.com>"]
+license = "MIT"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.0", features = ["full"] }
+
+[dev-dependencies]
+proptest = "1.0"
+
+[features]
+default = ["feature1"]
+feature1 = []
+feature2 = ["feature1"]
+
+[profile.release]
+lto = true
+opt-level = 3
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[workspace]
+members = ["crates/*"]

--- a/test/resources/repos/toml/test_repo/pyproject.toml
+++ b/test/resources/repos/toml/test_repo/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "test-project"
+version = "0.1.0"
+description = "A test Python project for TOML support"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "Test Author", email = "test@example.com"}
+]
+dependencies = [
+    "pydantic>=2.0",
+    "httpx>=0.24",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "ruff>=0.1",
+    "mypy>=1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+select = ["E", "F", "I", "N", "W", "B", "S"]
+
+[tool.ruff.isort]
+known-first-party = ["test_project"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_unreachable = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-v --cov=src"

--- a/test/solidlsp/toml/test_toml_basic.py
+++ b/test/solidlsp/toml/test_toml_basic.py
@@ -1,0 +1,54 @@
+"""
+Basic integration tests for the TOML language server functionality.
+
+These tests validate the functionality of the Taplo language server APIs
+like request_document_symbols using the TOML test repository.
+"""
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+
+
+@pytest.mark.toml
+class TestTomlLanguageServerBasics:
+    """Test basic functionality of the TOML language server (Taplo)."""
+
+    @pytest.mark.parametrize("language_server", [Language.TOML], indirect=True)
+    def test_toml_language_server_initialization(self, language_server: SolidLanguageServer) -> None:
+        """Test that TOML language server can be initialized successfully."""
+        assert language_server is not None
+        assert language_server.language == Language.TOML
+
+    @pytest.mark.parametrize("language_server", [Language.TOML], indirect=True)
+    def test_toml_request_document_symbols_cargo(self, language_server: SolidLanguageServer) -> None:
+        """Test request_document_symbols for Cargo.toml files."""
+        all_symbols, _root_symbols = language_server.request_document_symbols("Cargo.toml").get_all_symbols_and_roots()
+
+        # Extract symbol names - Taplo should detect tables and keys
+        symbol_names = [symbol["name"] for symbol in all_symbols]
+
+        # Should detect at least some standard Cargo.toml sections
+        # Taplo typically detects tables like [package], [dependencies], etc.
+        assert len(all_symbols) > 0, f"Should find symbols in Cargo.toml, found: {symbol_names}"
+
+    @pytest.mark.parametrize("language_server", [Language.TOML], indirect=True)
+    def test_toml_request_document_symbols_pyproject(self, language_server: SolidLanguageServer) -> None:
+        """Test request_document_symbols for pyproject.toml files."""
+        all_symbols, _root_symbols = language_server.request_document_symbols("pyproject.toml").get_all_symbols_and_roots()
+
+        # Extract symbol names
+        symbol_names = [symbol["name"] for symbol in all_symbols]
+
+        # Should detect at least some standard pyproject.toml sections
+        assert len(all_symbols) > 0, f"Should find symbols in pyproject.toml, found: {symbol_names}"
+
+    @pytest.mark.parametrize("language_server", [Language.TOML], indirect=True)
+    def test_toml_request_document_symbols_with_body(self, language_server: SolidLanguageServer) -> None:
+        """Test request_document_symbols with body extraction."""
+        all_symbols, _root_symbols = language_server.request_document_symbols("Cargo.toml").get_all_symbols_and_roots()
+
+        # Should have found some symbols
+        assert len(all_symbols) > 0, "Should find symbols in Cargo.toml"
+        assert all_symbols is not None, "Should return symbols"


### PR DESCRIPTION
## Summary

This PR adds support for **TOML** and **TOON** (Token-Oriented Object Notation) languages to Serena via the Taplo language server.

### Features

- **TOML Language Support** via [Taplo](https://taplo.tamasfe.dev/) LSP:
  - Automatic binary download from GitHub releases (v0.10.0)
  - Cross-platform support: Windows (x86_64), macOS (x86_64/arm64), Linux (x86_64/aarch64)
  - Full LSP capabilities: validation, formatting, schema support
  - Falls back to system-installed `taplo` if available
  - Ignored directories: `target/`, `.cargo/`, `node_modules/`

- **TOON Format Support** (experimental):
  - Uses Taplo server for basic validation
  - [TOON specification](https://github.com/toon-format/spec) - A compact JSON alternative optimized for LLM prompts
  - Marked as experimental since no dedicated TOON LSP exists yet

### Files Changed

| File | Description |
|------|-------------|
| `src/solidlsp/language_servers/taplo_server.py` | New TaploServer implementation with auto-download |
| `src/solidlsp/ls_config.py` | Added TOML and TOON to Language enum |
| `test/solidlsp/toml/test_toml_basic.py` | Basic test suite |
| `test/resources/repos/toml/test_repo/` | Test TOML files (Cargo.toml, pyproject.toml) |
| `CHANGELOG.md` | Documented new language support |
| `pyproject.toml` | Added pytest markers for toml/toon |

### Motivation

This addresses user need for TOML support when working with Rust (Cargo.toml), Python (pyproject.toml), and other TOML-based configuration files. The addition of TOON support enables working with the emerging LLM-optimized format.

### Test Plan

- [x] Code passes `ruff check` and `black` formatting
- [x] Test files created following existing patterns (see test_toml_basic.py)
- [ ] Manual testing of Taplo download on Linux/macOS (tested on Windows)
- [ ] CI/CD validation (pytest markers added)

### Breaking Changes

None. This is a purely additive change.