### PR TITLE
feat: Set MCP ToolAnnotations.readOnlyHint from Tool.can_edit()

### DIFF
--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -215,8 +215,6 @@ class SerenaMCPFactory:
             return tool.apply_ex(log_call=True, catch_exceptions=True, **kwargs)
 
         annotations = ToolAnnotations(readOnlyHint=not tool.can_edit())
-        if annotations.readOnlyHint:
-            annotations.destructiveHint = False
 
         return MCPTool(
             fn=execute_fn,


### PR DESCRIPTION
Serena constructs MCP tools with `annotations=None`, so under the MCP spec `ToolAnnotations.readOnlyHint` defaults to `false` ("may modify the environment").

In my setup, Serena runs as an MCP server behind [`mcp-auth-proxy`](https://github.com/sigbit/mcp-auth-proxy) and is connected to ChatGPT Developer Mode via a custom Connector. In this configuration, ChatGPT treats every tool as potentially write-capable and shows an approval dialog for every call, including tools that only read data, for example reading files.

To address this, `SerenaMCPFactory.make_mcp_tool` now creates a `ToolAnnotations` object and passes it to `MCPTool`, setting `readOnlyHint = not tool.can_edit()`, and for read-only tools explicitly setting `destructiveHint = false`.

MCP clients can now distinguish read-only Serena tools from tools that can edit state, so read-only operations no longer trigger write-operation approval prompts while editable tools keep their existing behavior.

<img width="510" height="600" alt="PixPin_2025-12-07_14-36-55" src="https://github.com/user-attachments/assets/269b2edb-f6f1-4f94-969f-84c926f7d2ba" />

<img width="685" height="815" alt="PixPin_2025-12-07_14-45-53" src="https://github.com/user-attachments/assets/6912135b-6b50-49ce-bd08-14a28cc89711" />