### PR TITLE
Scala language server: stop requiring old coursier

### DIFF
--- a/src/solidlsp/language_servers/scala_language_server.py
+++ b/src/solidlsp/language_servers/scala_language_server.py
@@ -66,6 +66,7 @@ class ScalaLanguageServer(SolidLanguageServer):
 
         if not os.path.exists(metals_executable):
             if not cs_command_path:
+                assert coursier_command_path is not None
                 log.info("'cs' command not found. Trying to install it using 'coursier'.")
                 try:
                     log.info("Running 'coursier setup --yes' to install 'cs'...")


### PR DESCRIPTION
You run coursier with "cs" command nowadays.
Users of the new coursier no longer have the old
"coursier" command around.
Yet, the assertion required its presence.
That caused the project creation command to break.

After this change:
- the assertion passes if "cs" or "coursier" is there

("coursier" was only used to install the new "cs" if it was missing)