### PR TITLE
More flexible GetSymbolOverviewTool, allowing depth to be specified

### DIFF
--- a/src/serena/tools/symbol_tools.py
+++ b/src/serena/tools/symbol_tools.py
@@ -2,7 +2,6 @@
 Language server-related tools
 """
 
-import dataclasses
 import os
 from collections.abc import Sequence
 from copy import copy
@@ -50,13 +49,15 @@ class GetSymbolsOverviewTool(Tool, ToolMarkerSymbolicRead):
     Gets an overview of the top-level symbols defined in a given file.
     """
 
-    def apply(self, relative_path: str, max_answer_chars: int = -1) -> str:
+    def apply(self, relative_path: str, depth: int = 0, max_answer_chars: int = -1) -> str:
         """
         Use this tool to get a high-level understanding of the code symbols in a file.
         This should be the first tool to call when you want to understand a new file, unless you already know
         what you are looking for.
 
         :param relative_path: the relative path to the file to get the overview of
+        :param depth: depth up to which descendants of top-level symbols shall be retrieved
+            (e.g. 1 retrieves immediate children). Default 0.
         :param max_answer_chars: if the overview is longer than this number of characters,
             no content will be returned. -1 means the default value from the config will be used.
             Don't adjust unless there is really no other way to get the content required for the task.
@@ -71,8 +72,8 @@ class GetSymbolsOverviewTool(Tool, ToolMarkerSymbolicRead):
             raise FileNotFoundError(f"File or directory {relative_path} does not exist in the project.")
         if os.path.isdir(file_path):
             raise ValueError(f"Expected a file path, but got a directory path: {relative_path}. ")
-        result = symbol_retriever.get_symbol_overview(relative_path)[relative_path]
-        result_json_str = self._to_json([dataclasses.asdict(i) for i in result])
+        result = symbol_retriever.get_symbol_overview(relative_path, depth=depth)[relative_path]
+        result_json_str = self._to_json(result)
         return self._limit_length(result_json_str, max_answer_chars)
 
 


### PR DESCRIPTION
Simply use the dictionary conversion to generate overview elements, adding the new option to specify a predicate for filtering children (thus allowing low-level symbols like variables to be filtered out)