### PR TITLE
"Companion language server" abstraction

### DIFF
--- a/src/solidlsp/companion_ls.py
+++ b/src/solidlsp/companion_ls.py
@@ -1,0 +1,387 @@
+"""Language server base class for frameworks requiring companion servers (Vue, Svelte, Astro)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from abc import abstractmethod
+from fnmatch import fnmatch
+from pathlib import Path
+from time import sleep
+
+from overrides import override
+
+from solidlsp import ls_types
+from solidlsp.embedded_language_config import EmbeddedLanguageConfig
+from solidlsp.ls import LSPFileBuffer, SolidLanguageServer
+from solidlsp.ls_exceptions import SolidLSPException
+from solidlsp.ls_utils import PathUtils
+
+log = logging.getLogger(__name__)
+
+
+class CompanionLanguageServer(SolidLanguageServer):
+    """
+    Abstract base class for language servers coordinating with companion servers.
+
+    Manages companion server lifecycle, delegates LSP operations, and handles cross-file indexing.
+    Subclasses must implement _get_domain_file_extension(), _get_embedded_language_configs(),
+    and _create_companion_server().
+    """
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(*args, **kwargs)
+        self._companions: dict[str, SolidLanguageServer] = {}
+        self._companion_configs: dict[str, EmbeddedLanguageConfig] = {}
+        self._domain_files_indexed: bool = False
+        self._indexed_file_uris: list[str] = []
+
+    @abstractmethod
+    def _get_domain_file_extension(self) -> str:
+        pass
+
+    @abstractmethod
+    def _get_embedded_language_configs(self) -> list[EmbeddedLanguageConfig]:
+        pass
+
+    @abstractmethod
+    def _create_companion_server(self, config: EmbeddedLanguageConfig) -> SolidLanguageServer:
+        """
+        Create companion server for given configuration. Server must not be started.
+
+        :param config: Configuration for the embedded language
+        :return: Configured but not yet started SolidLanguageServer instance
+        """
+
+    def _get_domain_specific_references(self, relative_file_path: str) -> list[ls_types.Location]:
+        """
+        Override to add domain-specific reference finding.
+
+        :param relative_file_path: Path to file relative to repository root
+        :return: List of domain-specific references
+        """
+        return []
+
+    def _setup_domain_protocol_handlers(self) -> None:
+        """Override to register domain-specific LSP handlers."""
+
+    def _on_companions_ready(self) -> None:
+        """Hook called after all companion servers are started."""
+
+    def _merge_references(
+        self,
+        companion_refs: list[ls_types.Location],
+        domain_refs: list[ls_types.Location],
+    ) -> list[ls_types.Location]:
+        """
+        Merge and deduplicate references from companion and domain sources.
+
+        :param companion_refs: References from companion language servers
+        :param domain_refs: References from domain-specific sources
+        :return: Deduplicated list of all references
+        """
+        seen: set[tuple[str, int, int]] = set()
+        result: list[ls_types.Location] = []
+
+        for ref in companion_refs + domain_refs:
+            key = (
+                ref["uri"],
+                ref["range"]["start"]["line"],
+                ref["range"]["start"]["character"],
+            )
+            if key not in seen:
+                result.append(ref)
+                seen.add(key)
+
+        return result
+
+    def _find_companion_for_operation(self, operation: str) -> SolidLanguageServer | None:
+        """
+        Find highest-priority companion server for the given operation.
+
+        :param operation: Operation name (e.g., "definitions", "references", "rename")
+        :return: Companion server with highest priority for operation, or None if none found
+        """
+        candidates: list[tuple[int, str]] = []
+
+        for lang_id, config in self._companion_configs.items():
+            handles_attr = f"handles_{operation}"
+            if getattr(config, handles_attr, False):
+                candidates.append((config.priority, lang_id))
+
+        if not candidates:
+            return None
+
+        candidates.sort(reverse=True)
+        return self._companions.get(candidates[0][1])
+
+    def _find_all_domain_files(self) -> list[str]:
+        """
+        Find all domain files in repository, excluding ignored directories.
+
+        :return: List of relative paths to domain files
+        """
+        ext = self._get_domain_file_extension()
+        domain_files: list[str] = []
+        repo_path = self.repository_root_path
+
+        for dirpath, dirnames, filenames in os.walk(repo_path):
+            dirnames[:] = [d for d in dirnames if not self.is_ignored_dirname(d)]
+
+            for filename in filenames:
+                if filename.endswith(ext):
+                    abs_path = os.path.join(dirpath, filename)
+                    relative_path = os.path.relpath(abs_path, repo_path)
+
+                    try:
+                        if not self.is_ignored_path(relative_path, ignore_unsupported_files=False):
+                            domain_files.append(relative_path)
+                    except Exception as e:
+                        log.debug(f"Error checking if {relative_path} is ignored: {e}")
+
+        return domain_files
+
+    def _ensure_domain_files_indexed(self) -> None:
+        """
+        Index domain files on companion servers for cross-file references.
+
+        Opens all domain files matching companion patterns on respective servers
+        to enable cross-file symbol resolution.
+        """
+        if self._domain_files_indexed:
+            return
+
+        domain_files = self._find_all_domain_files()
+        log.debug(f"Indexing {len(domain_files)} domain files on companion servers")
+
+        for lang_id, config in self._companion_configs.items():
+            companion = self._companions.get(lang_id)
+            if companion is None:
+                continue
+
+            for domain_file in domain_files:
+                matches = any(fnmatch(domain_file, pattern) for pattern in config.file_patterns)
+                if not matches:
+                    continue
+
+                try:
+                    absolute_file_path = os.path.join(companion.repository_root_path, domain_file)
+                    uri = PathUtils.path_to_uri(absolute_file_path)
+
+                    if uri in companion.open_file_buffers:
+                        companion.open_file_buffers[uri].ref_count += 1
+                    else:
+                        with open(absolute_file_path, encoding=companion._encoding) as f:
+                            contents = f.read()
+                        language_id = companion._get_language_id_for_file(domain_file)
+                        file_buffer = LSPFileBuffer(uri, contents, 0, language_id, 1)
+                        companion.open_file_buffers[uri] = file_buffer
+
+                        companion.server.notify.did_open_text_document(
+                            {
+                                "textDocument": {
+                                    "uri": uri,
+                                    "languageId": language_id,
+                                    "version": 0,
+                                    "text": contents,
+                                }
+                            }
+                        )
+                        self._indexed_file_uris.append(uri)
+                except Exception as e:
+                    log.debug(f"Failed to index {domain_file} on {lang_id} server: {e}")
+
+        self._domain_files_indexed = True
+        log.debug("Domain file indexing complete")
+
+    def _cleanup_indexed_files(self) -> None:
+        """
+        Clean up indexed files on companion servers.
+
+        Closes files that were opened for cross-file indexing and removes them
+        from companion server buffers.
+        """
+        if not self._indexed_file_uris:
+            return
+
+        log.debug(f"Cleaning up {len(self._indexed_file_uris)} indexed files")
+
+        failed_cleanups: list[tuple[str, str]] = []
+        for uri in set(self._indexed_file_uris):
+            for companion in self._companions.values():
+                try:
+                    if uri in companion.open_file_buffers:
+                        file_buffer = companion.open_file_buffers[uri]
+                        file_buffer.ref_count -= 1
+
+                        if file_buffer.ref_count == 0:
+                            companion.server.notify.did_close_text_document({"textDocument": {"uri": uri}})
+                            del companion.open_file_buffers[uri]
+                except Exception as e:
+                    log.error(f"Error cleaning up indexed file {uri}: {e}")
+                    failed_cleanups.append((uri, str(e)))
+
+        if failed_cleanups:
+            log.warning(f"Failed to cleanup {len(failed_cleanups)} indexed files - potential resource leak")
+
+        self._indexed_file_uris.clear()
+
+    def _send_companion_references_request(
+        self,
+        companion: SolidLanguageServer,
+        relative_file_path: str,
+        line: int,
+        column: int,
+    ) -> list[ls_types.Location]:
+        """
+        Send references request to companion, filtering to repository files.
+
+        :param companion: Companion language server to query
+        :param relative_file_path: Path to file relative to repository root
+        :param line: Line number of symbol
+        :param column: Column number of symbol
+        :return: List of references within repository
+        """
+        uri = PathUtils.path_to_uri(os.path.join(self.repository_root_path, relative_file_path))
+        request_params = {
+            "textDocument": {"uri": uri},
+            "position": {"line": line, "character": column},
+            "context": {"includeDeclaration": True},
+        }
+
+        with companion.open_file(relative_file_path):
+            response = companion.handler.send.references(request_params)  # type: ignore[arg-type]
+
+        result: list[ls_types.Location] = []
+        if response is None:
+            return result
+
+        for item in response:
+            abs_path = PathUtils.uri_to_path(item["uri"])
+            if not Path(abs_path).is_relative_to(self.repository_root_path):
+                log.debug(f"Skipping reference outside repository: {abs_path}")
+                continue
+
+            rel_path = Path(abs_path).relative_to(self.repository_root_path)
+            if self.is_ignored_path(str(rel_path)):
+                log.debug(f"Skipping ignored reference: {rel_path}")
+                continue
+
+            new_item: dict = dict(item)  # type: ignore[arg-type]
+            new_item["absolutePath"] = str(abs_path)
+            new_item["relativePath"] = str(rel_path)
+            result.append(ls_types.Location(**new_item))  # type: ignore[typeddict-item]
+
+        return result
+
+    @override
+    def request_definition(
+        self,
+        relative_file_path: str,
+        line: int,
+        column: int,
+    ) -> list[ls_types.Location]:
+        if not self.server_started:
+            log.error("request_definition called before language server started")
+            raise SolidLSPException("Language Server not started")
+
+        companion = self._find_companion_for_operation("definitions")
+        if companion:
+            with companion.open_file(relative_file_path):
+                definitions = companion.request_definition(relative_file_path, line, column)
+
+            if len(definitions) > 1:
+                preferred = self._get_preferred_definition(definitions)
+                return [preferred]
+
+            return definitions
+
+        return super().request_definition(relative_file_path, line, column)
+
+    @override
+    def request_references(
+        self,
+        relative_file_path: str,
+        line: int,
+        column: int,
+    ) -> list[ls_types.Location]:
+        if not self.server_started:
+            log.error("request_references called before language server started")
+            raise SolidLSPException("Language Server not started")
+
+        if not self._has_waited_for_cross_file_references:
+            sleep(self._get_wait_time_for_cross_file_referencing())
+            self._has_waited_for_cross_file_references = True
+
+        self._ensure_domain_files_indexed()
+
+        companion_refs: list[ls_types.Location] = []
+        companion = self._find_companion_for_operation("references")
+        if companion:
+            companion_refs = self._send_companion_references_request(companion, relative_file_path, line, column)
+
+        domain_refs = self._get_domain_specific_references(relative_file_path)
+
+        return self._merge_references(companion_refs, domain_refs)
+
+    @override
+    def request_rename_symbol_edit(
+        self,
+        relative_file_path: str,
+        line: int,
+        column: int,
+        new_name: str,
+    ) -> ls_types.WorkspaceEdit | None:
+        if not self.server_started:
+            log.error("request_rename_symbol_edit called before language server started")
+            raise SolidLSPException("Language Server not started")
+
+        companion = self._find_companion_for_operation("rename")
+        if companion:
+            with companion.open_file(relative_file_path):
+                return companion.request_rename_symbol_edit(relative_file_path, line, column, new_name)
+
+        return super().request_rename_symbol_edit(relative_file_path, line, column, new_name)
+
+    def _start_companions(self) -> None:
+        """
+        Start all companion language servers.
+
+        Creates and starts each companion server defined by embedded language configs.
+        """
+        for config in self._get_embedded_language_configs():
+            log.info(f"Creating companion server for {config.language_id}")
+            companion = self._create_companion_server(config)
+
+            log.info(f"Starting companion server for {config.language_id}")
+            companion.start()
+
+            self._companions[config.language_id] = companion
+            self._companion_configs[config.language_id] = config
+            log.info(f"Companion server for {config.language_id} ready")
+
+        self._on_companions_ready()
+        self._setup_domain_protocol_handlers()
+
+    @override
+    def stop(self, shutdown_timeout: float = 2.0) -> None:
+        self._cleanup_indexed_files()
+
+        failed_companions: list[str] = []
+        for lang_id, companion in list(self._companions.items()):
+            try:
+                log.info(f"Stopping companion server for {lang_id}")
+                companion.stop()
+                del self._companions[lang_id]
+                if lang_id in self._companion_configs:
+                    del self._companion_configs[lang_id]
+            except Exception as e:
+                log.error(f"Error stopping companion server {lang_id}: {e}")
+                failed_companions.append(lang_id)
+
+        if failed_companions:
+            log.error(f"Failed to stop companion servers: {', '.join(failed_companions)}")
+
+        self._domain_files_indexed = False
+
+        super().stop(shutdown_timeout)

--- a/src/solidlsp/embedded_language_config.py
+++ b/src/solidlsp/embedded_language_config.py
@@ -1,0 +1,25 @@
+"""
+Configuration for embedded languages handled by companion servers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EmbeddedLanguageConfig:
+    """
+    Configuration for an embedded language handled by a companion language server.
+
+    Specifies which LSP operations the companion handles and which files to index.
+    """
+
+    language_id: str
+    file_patterns: list[str]
+    handles_definitions: bool = False
+    handles_references: bool = False
+    handles_rename: bool = False
+    handles_completions: bool = False
+    handles_diagnostics: bool = False
+    priority: int = 0

--- a/src/solidlsp/typescript_companion.py
+++ b/src/solidlsp/typescript_companion.py
@@ -1,0 +1,57 @@
+"""Helpers for configuring TypeScript as a companion language server."""
+
+from __future__ import annotations
+
+from solidlsp import ls_types
+from solidlsp.embedded_language_config import EmbeddedLanguageConfig
+
+
+def create_typescript_companion_config(
+    file_patterns: list[str],
+    handles_definitions: bool = True,
+    handles_references: bool = True,
+    handles_rename: bool = True,
+    handles_completions: bool = False,
+    handles_diagnostics: bool = False,
+    priority: int = 100,
+) -> EmbeddedLanguageConfig:
+    """
+    Create standard TypeScript embedded language configuration.
+
+    :param file_patterns: Glob patterns for files to index (e.g., ["*.vue"])
+    :param handles_definitions: Handle go-to-definition requests
+    :param handles_references: Handle find-references requests
+    :param handles_rename: Handle rename requests
+    :param handles_completions: Handle completion requests
+    :param handles_diagnostics: Handle diagnostic requests
+    :param priority: Priority when multiple companions could handle an operation
+    :return: Configured EmbeddedLanguageConfig for TypeScript
+    """
+    return EmbeddedLanguageConfig(
+        language_id="typescript",
+        file_patterns=file_patterns,
+        handles_definitions=handles_definitions,
+        handles_references=handles_references,
+        handles_rename=handles_rename,
+        handles_completions=handles_completions,
+        handles_diagnostics=handles_diagnostics,
+        priority=priority,
+    )
+
+
+def prefer_non_node_modules_definition(
+    definitions: list[ls_types.Location],
+) -> ls_types.Location:
+    """
+    Select preferred definition, favoring source files over node_modules.
+
+    :param definitions: Non-empty list of definition locations
+    :return: Preferred definition location (first non-node_modules, or first if all in node_modules)
+    """
+    if not definitions:
+        raise ValueError("definitions list cannot be empty")
+    for d in definitions:
+        rel_path = d.get("relativePath", "")
+        if rel_path and "node_modules" not in rel_path:
+            return d
+    return definitions[0]

--- a/test/solidlsp/vue/test_vue_basic.py
+++ b/test/solidlsp/vue/test_vue_basic.py
@@ -1,3 +1,10 @@
+"""
+Basic Vue language server tests.
+
+Tests core functionality including symbol tree parsing, cross-file references,
+and TypeScript coordination through the dual LSP architecture.
+"""
+
 import os
 
 import pytest
@@ -9,6 +16,8 @@ from solidlsp.ls_utils import SymbolUtils
 
 @pytest.mark.vue
 class TestVueLanguageServer:
+    """Tests for basic Vue language server operations."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_vue_files_in_symbol_tree(self, language_server: SolidLanguageServer) -> None:
         symbols = language_server.request_full_symbol_tree()
@@ -45,6 +54,8 @@ class TestVueLanguageServer:
 
 @pytest.mark.vue
 class TestVueDualLspArchitecture:
+    """Tests for Vue + TypeScript dual language server coordination."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_typescript_server_coordination(self, language_server: SolidLanguageServer) -> None:
         ts_file = os.path.join("src", "stores", "calculator.ts")
@@ -180,6 +191,8 @@ class TestVueDualLspArchitecture:
 
 @pytest.mark.vue
 class TestVueEdgeCases:
+    """Tests for edge cases in Vue symbol handling."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_symbol_tree_structure(self, language_server: SolidLanguageServer) -> None:
         full_tree = language_server.request_full_symbol_tree()

--- a/test/solidlsp/vue/test_vue_error_cases.py
+++ b/test/solidlsp/vue/test_vue_error_cases.py
@@ -1,3 +1,10 @@
+"""
+Vue language server error case tests.
+
+Tests error handling for invalid positions, non-existent files,
+undefined symbols, and other edge cases.
+"""
+
 import os
 import sys
 
@@ -28,6 +35,8 @@ class TypeScriptServerBehavior:
 
 
 class TestVueInvalidPositions:
+    """Tests for handling invalid positions in Vue files."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_negative_line_number(self, language_server: SolidLanguageServer) -> None:
         file_path = os.path.join("src", "components", "CalculatorInput.vue")

--- a/test/solidlsp/vue/test_vue_rename.py
+++ b/test/solidlsp/vue/test_vue_rename.py
@@ -1,3 +1,10 @@
+"""
+Vue language server rename tests.
+
+Tests symbol renaming functionality including single-file and
+cross-file rename operations for Vue components and TypeScript files.
+"""
+
 import os
 
 import pytest
@@ -9,6 +16,8 @@ pytestmark = pytest.mark.vue
 
 
 class TestVueRename:
+    """Tests for Vue symbol rename operations."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_rename_function_within_single_file(self, language_server: SolidLanguageServer) -> None:
         file_path = os.path.join("src", "components", "CalculatorInput.vue")

--- a/test/solidlsp/vue/test_vue_symbol_retrieval.py
+++ b/test/solidlsp/vue/test_vue_symbol_retrieval.py
@@ -1,3 +1,10 @@
+"""
+Vue language server symbol retrieval tests.
+
+Tests symbol lookup functionality including containing symbols,
+referencing symbols, cross-component references, and import resolution.
+"""
+
 import os
 
 import pytest
@@ -10,6 +17,8 @@ pytestmark = pytest.mark.vue
 
 
 class TestVueSymbolRetrieval:
+    """Tests for Vue symbol retrieval operations."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_request_containing_symbol_script_setup_function(self, language_server: SolidLanguageServer) -> None:
         file_path = os.path.join("src", "components", "CalculatorInput.vue")


### PR DESCRIPTION
Based on the work of @tylersatre, we can now implement svelte support in a similar way and using the same abstractions as done for vue. Implementing svelte support will also give a practical test for how well the abstractions work (I expect them to work well for this).

Several attempts at supporting svelte were already done in the past, including #339 and #504 .

We can likely reuse a lot of the code there, and combine it with the companion server abstraction introduced on this branch.

I am creating the PR as a place for further discussion and also as a good way for @opcode81 and me to review the companion abstraction.

Thank you @tylersatre for the great work on this, highly appreciated!