### PR TITLE
feat: CWD-based project detection for MCP with CLI-based agents

### DIFF
--- a/docs/02-usage/020_running.md
+++ b/docs/02-usage/020_running.md
@@ -150,7 +150,7 @@ to get a list of all available options.
 Some useful options include:
 
   * `--project <path|name>`: specify the project to work on by name or path.
-  * `--project-from-cwd`: auto-detect project from current working directory (searches up for `.serena` or `.git`). Intended only for CLI-based agents like Claude Code, Gemini and Codex.
+  * `--project-from-cwd`: auto-detect project from current working directory (searches up for `.serena/project.yml` or `.git`, falls back to CWD). Intended only for CLI-based agents like Claude Code, Gemini and Codex.
   * `--context <context>`: specify the operation [context](contexts) in which Serena shall operate
   * `--mode <mode>`: specify one or more [modes](modes) to enable (can be passed several times)
   * `--enable-web-dashboard <true|false>`: enable or disable the web dashboard (enabled by default)

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -94,8 +94,9 @@ Alternatively, use `--project-from-cwd` for user-level configuration that works 
 claude mcp add --scope user serena -- <serena> start-mcp-server --context=claude-code --project-from-cwd
 ```
 
-This searches up from the current directory for `.serena` or `.git` markers, making it suitable
-for a single global MCP configuration. The `--project-from-cwd` option is intended for CLI-based agents
+This searches up from the current directory for `.serena/project.yml` or `.git` markers,
+falling back to the current directory if neither is found. This makes it suitable for a
+single global MCP configuration. The `--project-from-cwd` option is intended for CLI-based agents
 (like Claude Code, Gemina or Codex) that invoke Serena from within project directories.
 
 Be sure to use at least `v1.0.52` of Claude Code (as earlier versions do not read MCP server system prompts upon startup). 


### PR DESCRIPTION
Adds a new `--auto-project` flag to `start-mcp-server` that automatically detects and activates a project based on the current working directory.

## Motivation

Enables user-level MCP configuration (e.g., in Claude Code's global settings) without requiring per-context activation or explicit `--project="$(pwd)"`:

```
claude mcp add --scope=user serena -- <serena> start-mcp-server --context=claude-code --auto-project
```

## Detection logic

  1. Searches up from CWD for `.serena/` directory (explicit Serena project)
  2. Falls back to `.git/` if no `.serena` found
  3. Returns `None` if neither marker exists (server starts without active project)