### PR TITLE
Fix: Use {} instead of null in params field when None in JSON-RPC requests/notifications

### DIFF
--- a/src/solidlsp/lsp_protocol_handler/server.py
+++ b/src/solidlsp/lsp_protocol_handler/server.py
@@ -92,11 +92,15 @@ def make_error_response(request_id: Any, err: LSPError) -> StringDict:
 
 
 def make_notification(method: str, params: PayloadLike) -> StringDict:
-    return {"jsonrpc": "2.0", "method": method, "params": params}
+    # JSON-RPC 2.0: params must be object or array if present, cannot be null
+    # Some language servers require params to be present, so we send empty object instead of omitting
+    return {"jsonrpc": "2.0", "method": method, "params": params if params is not None else {}}
 
 
 def make_request(method: str, request_id: Any, params: PayloadLike) -> StringDict:
-    return {"jsonrpc": "2.0", "method": method, "id": request_id, "params": params}
+    # JSON-RPC 2.0: params must be object or array if present, cannot be null
+    # Some language servers require params to be present, so we send empty object instead of omitting
+    return {"jsonrpc": "2.0", "method": method, "id": request_id, "params": params if params is not None else {}}
 
 
 class StopLoopException(Exception):


### PR DESCRIPTION
According to JSON-RPC 2.0 specification, the params field must be a structured value (object or array) if present. Sending "params": null violates the spec and causes strict implementations to reject the request.

This fix modifies make_request() and make_notification() to use an empty dictionary ({}) when params is None, instead of including it as null.