### PR TITLE
Fix: RenameSymbolTool: WorkspaceEdit was not fully interpreted

### DIFF
--- a/src/solidlsp/ls_types.py
+++ b/src/solidlsp/ls_types.py
@@ -371,28 +371,3 @@ class Diagnostic(TypedDict):
     """ The code of the diagnostic. """
     source: NotRequired[str]
     """ The source of the diagnostic, e.g. the name of the tool that produced it. """
-
-
-def extract_text_edits(workspace_edit: WorkspaceEdit) -> dict[str, list[TextEdit]]:
-    """
-    Extracts the text changes from a WorkspaceEdit object.
-
-    Args:
-        workspace_edit (WorkspaceEdit): The WorkspaceEdit object to extract text changes from.
-
-    Returns:
-        dict[str, list[TextEdit]]: A dictionary mapping document URIs to lists of TextEdit objects.
-
-    """
-    if "changes" in workspace_edit:
-        return workspace_edit["changes"]
-    elif "documentChanges" in workspace_edit:
-        changes = {}
-        for change in workspace_edit["documentChanges"]:
-            if "textDocument" in change and "edits" in change:
-                uri = change["textDocument"]["uri"]
-                edits = change["edits"]
-                changes[uri] = edits
-        return changes
-    else:
-        raise Exception(f"Invalid WorkspaceEdit (expected 'changes' or 'documentChanges' key):\n{workspace_edit}")


### PR DESCRIPTION
In particular, EclipseJDTLS returns both members of WorkspaceEdit, but the processing
  * ignored the second member (documentChanges) if the first member was also present
  * processed contents of the second member only partially in general. 

The handling is now fully reified in `EditOperation` classes.

Fixes #725