### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -215,7 +215,16 @@ class SerenaMCPFactory:
         def execute_fn(**kwargs) -> str:  # type: ignore
             return tool.apply_ex(log_call=True, catch_exceptions=True, **kwargs)
 
-        annotations = ToolAnnotations(readOnlyHint=not tool.can_edit())
+        # Generate human-readable title from snake_case tool name
+        tool_title = " ".join(word.capitalize() for word in func_name.split("_"))
+
+        # Create annotations with appropriate hints based on tool capabilities
+        can_edit = tool.can_edit()
+        annotations = ToolAnnotations(
+            title=tool_title,
+            readOnlyHint=not can_edit,
+            destructiveHint=can_edit,
+        )
 
         return MCPTool(
             fn=execute_fn,
@@ -226,7 +235,7 @@ class SerenaMCPFactory:
             is_async=is_async,
             context_kwarg=None,
             annotations=annotations,
-            title=None,
+            title=tool_title,
         )
 
     @abstractmethod

--- a/src/serena/tools/memory_tools.py
+++ b/src/serena/tools/memory_tools.py
@@ -1,9 +1,9 @@
 from typing import Literal
 
-from serena.tools import ReplaceContentTool, Tool
+from serena.tools import ReplaceContentTool, Tool, ToolMarkerCanEdit
 
 
-class WriteMemoryTool(Tool):
+class WriteMemoryTool(Tool, ToolMarkerCanEdit):
     """
     Writes a named memory (for future reference) to Serena's project-specific memory store.
     """
@@ -52,7 +52,7 @@ class ListMemoriesTool(Tool):
         return self._to_json(self.memories_manager.list_memories())
 
 
-class DeleteMemoryTool(Tool):
+class DeleteMemoryTool(Tool, ToolMarkerCanEdit):
     """
     Deletes a memory from Serena's project-specific memory store.
     """
@@ -66,7 +66,7 @@ class DeleteMemoryTool(Tool):
         return self.memories_manager.delete_memory(memory_file_name)
 
 
-class EditMemoryTool(Tool):
+class EditMemoryTool(Tool, ToolMarkerCanEdit):
     def apply(
         self,
         memory_file_name: str,


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

### Enhanced Annotation Generation (`src/serena/mcp.py`)
- Added `destructiveHint: true` to tools that can modify data (those inheriting `ToolMarkerCanEdit`)
- Added `title` annotations with human-readable display names (e.g., `find_symbol` → "Find Symbol")
- Set `readOnlyHint: true` for read-only tools, `destructiveHint: true` for edit tools

### Fixed Memory Tools (`src/serena/tools/memory_tools.py`)
- `WriteMemoryTool`, `DeleteMemoryTool`, and `EditMemoryTool` now correctly inherit `ToolMarkerCanEdit`
- This ensures these tools properly receive `destructiveHint: true` instead of incorrectly being marked as read-only

## Why This Matters

- **Safety**: LLMs can distinguish read-only from destructive operations before execution
- **Better Tool Selection**: Helps LLMs prioritize read-only tools for information gathering
- **Human Readability**: Title annotations provide clear display names for tool interfaces

## Before/After

**Before:**
```python
annotations = ToolAnnotations(readOnlyHint=not tool.can_edit())
# WriteMemoryTool incorrectly marked as readOnlyHint=True
```

**After:**
```python
annotations = ToolAnnotations(
    title=tool_title,
    readOnlyHint=not can_edit,
    destructiveHint=can_edit,
)
# WriteMemoryTool correctly marked as destructiveHint=True
```

## Testing

- [x] Server builds successfully (`uv sync`)
- [x] Type checker passes (`pyright`)
- [x] Linter passes (`ruff check`)
- [x] Memory tool inheritance verified:
  - `WriteMemoryTool.can_edit()` → `True`
  - `DeleteMemoryTool.can_edit()` → `True`
  - `EditMemoryTool.can_edit()` → `True`
  - `ReadMemoryTool.can_edit()` → `False`
  - `ListMemoriesTool.can_edit()` → `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)