### PR TITLE
feat(find_symbol): add include_documentation parameter for hover-based docs

### DIFF
--- a/src/serena/symbol.py
+++ b/src/serena/symbol.py
@@ -283,19 +283,27 @@ class LanguageServerSymbol(Symbol, ToStringMixin):
         """
         :return: the line in which the symbol identifier is defined.
         """
+        # Try selectionRange first (DocumentSymbol format)
         if "selectionRange" in self.symbol_root:
             return self.symbol_root["selectionRange"]["start"]["line"]
-        else:
-            # line is expected to be undefined for some types of symbols (e.g. SymbolKind.File)
-            return None
+        # Fallback to location.range (SymbolInformation format, used by pasls)
+        start_pos = self.body_start_position
+        if start_pos:
+            return start_pos["line"]
+        # line is expected to be undefined for some types of symbols (e.g. SymbolKind.File)
+        return None
 
     @property
     def column(self) -> int | None:
+        # Try selectionRange first (DocumentSymbol format)
         if "selectionRange" in self.symbol_root:
             return self.symbol_root["selectionRange"]["start"]["character"]
-        else:
-            # precise location is expected to be undefined for some types of symbols (e.g. SymbolKind.File)
-            return None
+        # Fallback to location.range (SymbolInformation format, used by pasls)
+        start_pos = self.body_start_position
+        if start_pos:
+            return start_pos["character"]
+        # precise location is expected to be undefined for some types of symbols (e.g. SymbolKind.File)
+        return None
 
     @property
     def body(self) -> str | None:


### PR DESCRIPTION
## Summary

- Add `include_documentation` parameter to `FindSymbolTool` (default: `True`)
- Fetch documentation comments via LSP hover request for each symbol
- Fix `LanguageServerSymbol.line/column` to support SymbolInformation format
- Add test case for documentation retrieval

## Background

LSP defines two symbol formats:
- **DocumentSymbol**: Has `selectionRange` for identifier position (used by Pylsp, tsserver)
- **SymbolInformation**: Only has `location.range` (used by pasls)

The original code only checked `selectionRange`, causing `line`/`column` to return `None` for SymbolInformation format, which prevented hover requests.

## Changes

| File | Change |
|------|--------|
| `src/serena/symbol.py` | Add fallback to `location.range.start` when `selectionRange` is absent |
| `src/serena/tools/symbol_tools.py` | Add `include_documentation` param, fetch docs via hover |
| `test/serena/test_serena_agent.py` | Add `test_find_symbol_with_documentation` test case |

## Test Plan

- [x] `uv run poe test -m python -k test_find_symbol_with_documentation` passes
- [x] Verified Pascal symbols (TDocValue) return documentation via MCP
- [x] `uv run poe format` and `uv run poe type-check` pass