### PR TITLE
Fix broken import in test_tool_parameter_types.py

### DIFF
--- a/test/serena/test_tool_parameter_types.py
+++ b/test/serena/test_tool_parameter_types.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from serena.config.serena_config import SerenaConfig
-from serena.mcp import SerenaMCPFactorySingleProcess
+from serena.mcp import SerenaMCPFactory
 from serena.tools.tools_base import ToolRegistry
 
 
@@ -16,9 +16,9 @@ def test_all_tool_parameters_have_type(context):
     cfg = SerenaConfig(gui_log_window_enabled=False, web_dashboard=False, log_level=logging.ERROR)
     registry = ToolRegistry()
     cfg.included_optional_tools = tuple(registry.get_tool_names_optional())
-    factory = SerenaMCPFactorySingleProcess(context=context)
+    factory = SerenaMCPFactory(context=context)
     # Initialize the agent so that the tools are available
-    factory._instantiate_agent(cfg, [])
+    factory.agent = factory._create_serena_agent(cfg, [])
     tools = list(factory._iter_tools())
 
     for tool in tools:


### PR DESCRIPTION
## Summary

Fixes the broken CI pipeline by updating `test_tool_parameter_types.py` to use the current MCP factory API.

## Problem

The test was importing `SerenaMCPFactorySingleProcess` and calling `_instantiate_agent()`, both of which were removed when process isolation was removed from the codebase (commit 49515d6).

This caused all CI test runs to fail with:
```
ImportError: cannot import name 'SerenaMCPFactorySingleProcess' from 'serena.mcp'
```

## Solution

- Changed import from `SerenaMCPFactorySingleProcess` to `SerenaMCPFactory`
- Changed `factory._instantiate_agent(cfg, [])` to `factory.agent = factory._create_serena_agent(cfg, [])`

## Test Plan

- [x] `test_tool_parameter_types.py` passes all 3 test cases (chatgpt, codex, oaicompat-agent)
- [x] Format check passes
- [x] Type check passes