### PR TITLE
Add Astro Language Server Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Language support:
 
+  * **Add support for Astro** via @astrojs/language-server with companion TypeScript LS for code intelligence.
+    Uses dual-server architecture where Astro LS handles `.astro` file parsing and document symbols,
+    while a companion TypeScript server (configured with `@astrojs/ts-plugin`) handles go-to-definition,
+    find references, and rename operations. Supports frontmatter TypeScript/JavaScript extraction,
+    cross-file symbol resolution, and Props interface detection. Runtime dependencies auto-install on first use.
+  * **Add `CompanionLanguageServer` abstraction** for language servers requiring companion servers (Vue, Astro, future Svelte).
+    Manages companion lifecycle, LSP operation delegation with priority-based routing, cross-file domain file indexing
+    with ref-count tracking, and reference merging/deduplication. Extracted shared TypeScript companion configuration
+    to `typescript_companion.py` for reuse across framework implementations.
+  * **Refactored Vue language server** to use `CompanionLanguageServer` base class, reducing code by ~160 lines
+    while maintaining full functionality and improving maintainability.
   * **Add support for Fortran** via fortls language server (requires `pip install fortls`)
   * **Add partial support for Groovy** requires user-provided Groovy language server JAR (see [setup guide](docs/03-special-guides/groovy_setup_guide_for_serena.md))
   * **Add support for Julia** via LanguageServer.jl

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ that implement the language server protocol (LSP).
 The underlying language servers are typically open-source projects (like Serena) or at least freely available for use.
 
 With Serena's LSP library, we provide **support for over 30 programming languages**, including
-AL, Bash, C#, C/C++, Clojure, Dart, Elixir, Elm, Erlang, Fortran, Go, Groovy (partial support), Haskell, Java, Javascript, Julia, Kotlin, Lua, Markdown, Nix, Perl, PHP, PowerShell, Python, R, Ruby, Rust, Scala, Swift, TOML, TypeScript, YAML, and Zig.
+AL, Astro, Bash, C#, C/C++, Clojure, Dart, Elixir, Elm, Erlang, Fortran, Go, Groovy (partial support), Haskell, Java, Javascript, Julia, Kotlin, Lua, Markdown, Nix, Perl, PHP, PowerShell, Python, R, Ruby, Rust, Scala, Swift, TOML, TypeScript, Vue, YAML, and Zig.
 
 > [!IMPORTANT]
 > Some language servers require additional dependencies to be installed; see the [Language Support](https://oraios.github.io/serena/01-about/020_programming-languages.html) page for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,7 @@ markers = [
   "rust: language server running for Rust",
   "typescript: language server running for TypeScript",
   "vue: language server running for Vue (uses TypeScript LSP)",
+  "astro: language server running for Astro (uses TypeScript LSP)",
   "php: language server running for PHP",
   "perl: language server running for Perl",
   "csharp: language server running for C#",

--- a/src/solidlsp/companion_ls.py
+++ b/src/solidlsp/companion_ls.py
@@ -170,6 +170,8 @@ class CompanionLanguageServer(SolidLanguageServer):
 
                     if uri in companion.open_file_buffers:
                         companion.open_file_buffers[uri].ref_count += 1
+                        # Track URI so cleanup can decrement the ref-count we just added
+                        self._indexed_file_uris.append(uri)
                     else:
                         with open(absolute_file_path, encoding=companion._encoding) as f:
                             contents = f.read()

--- a/src/solidlsp/companion_ls.py
+++ b/src/solidlsp/companion_ls.py
@@ -1,0 +1,387 @@
+"""Language server base class for frameworks requiring companion servers (Vue, Svelte, Astro)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from abc import abstractmethod
+from fnmatch import fnmatch
+from pathlib import Path
+from time import sleep
+
+from overrides import override
+
+from solidlsp import ls_types
+from solidlsp.embedded_language_config import EmbeddedLanguageConfig
+from solidlsp.ls import LSPFileBuffer, SolidLanguageServer
+from solidlsp.ls_exceptions import SolidLSPException
+from solidlsp.ls_utils import PathUtils
+
+log = logging.getLogger(__name__)
+
+
+class CompanionLanguageServer(SolidLanguageServer):
+    """
+    Abstract base class for language servers coordinating with companion servers.
+
+    Manages companion server lifecycle, delegates LSP operations, and handles cross-file indexing.
+    Subclasses must implement _get_domain_file_extension(), _get_embedded_language_configs(),
+    and _create_companion_server().
+    """
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(*args, **kwargs)
+        self._companions: dict[str, SolidLanguageServer] = {}
+        self._companion_configs: dict[str, EmbeddedLanguageConfig] = {}
+        self._domain_files_indexed: bool = False
+        self._indexed_file_uris: list[str] = []
+
+    @abstractmethod
+    def _get_domain_file_extension(self) -> str:
+        pass
+
+    @abstractmethod
+    def _get_embedded_language_configs(self) -> list[EmbeddedLanguageConfig]:
+        pass
+
+    @abstractmethod
+    def _create_companion_server(self, config: EmbeddedLanguageConfig) -> SolidLanguageServer:
+        """
+        Create companion server for given configuration. Server must not be started.
+
+        :param config: Configuration for the embedded language
+        :return: Configured but not yet started SolidLanguageServer instance
+        """
+
+    def _get_domain_specific_references(self, relative_file_path: str) -> list[ls_types.Location]:
+        """
+        Override to add domain-specific reference finding.
+
+        :param relative_file_path: Path to file relative to repository root
+        :return: List of domain-specific references
+        """
+        return []
+
+    def _setup_domain_protocol_handlers(self) -> None:
+        """Override to register domain-specific LSP handlers."""
+
+    def _on_companions_ready(self) -> None:
+        """Hook called after all companion servers are started."""
+
+    def _merge_references(
+        self,
+        companion_refs: list[ls_types.Location],
+        domain_refs: list[ls_types.Location],
+    ) -> list[ls_types.Location]:
+        """
+        Merge and deduplicate references from companion and domain sources.
+
+        :param companion_refs: References from companion language servers
+        :param domain_refs: References from domain-specific sources
+        :return: Deduplicated list of all references
+        """
+        seen: set[tuple[str, int, int]] = set()
+        result: list[ls_types.Location] = []
+
+        for ref in companion_refs + domain_refs:
+            key = (
+                ref["uri"],
+                ref["range"]["start"]["line"],
+                ref["range"]["start"]["character"],
+            )
+            if key not in seen:
+                result.append(ref)
+                seen.add(key)
+
+        return result
+
+    def _find_companion_for_operation(self, operation: str) -> SolidLanguageServer | None:
+        """
+        Find highest-priority companion server for the given operation.
+
+        :param operation: Operation name (e.g., "definitions", "references", "rename")
+        :return: Companion server with highest priority for operation, or None if none found
+        """
+        candidates: list[tuple[int, str]] = []
+
+        for lang_id, config in self._companion_configs.items():
+            handles_attr = f"handles_{operation}"
+            if getattr(config, handles_attr, False):
+                candidates.append((config.priority, lang_id))
+
+        if not candidates:
+            return None
+
+        candidates.sort(reverse=True)
+        return self._companions.get(candidates[0][1])
+
+    def _find_all_domain_files(self) -> list[str]:
+        """
+        Find all domain files in repository, excluding ignored directories.
+
+        :return: List of relative paths to domain files
+        """
+        ext = self._get_domain_file_extension()
+        domain_files: list[str] = []
+        repo_path = self.repository_root_path
+
+        for dirpath, dirnames, filenames in os.walk(repo_path):
+            dirnames[:] = [d for d in dirnames if not self.is_ignored_dirname(d)]
+
+            for filename in filenames:
+                if filename.endswith(ext):
+                    abs_path = os.path.join(dirpath, filename)
+                    relative_path = os.path.relpath(abs_path, repo_path)
+
+                    try:
+                        if not self.is_ignored_path(relative_path, ignore_unsupported_files=False):
+                            domain_files.append(relative_path)
+                    except Exception as e:
+                        log.debug(f"Error checking if {relative_path} is ignored: {e}")
+
+        return domain_files
+
+    def _ensure_domain_files_indexed(self) -> None:
+        """
+        Index domain files on companion servers for cross-file references.
+
+        Opens all domain files matching companion patterns on respective servers
+        to enable cross-file symbol resolution.
+        """
+        if self._domain_files_indexed:
+            return
+
+        domain_files = self._find_all_domain_files()
+        log.debug(f"Indexing {len(domain_files)} domain files on companion servers")
+
+        for lang_id, config in self._companion_configs.items():
+            companion = self._companions.get(lang_id)
+            if companion is None:
+                continue
+
+            for domain_file in domain_files:
+                matches = any(fnmatch(domain_file, pattern) for pattern in config.file_patterns)
+                if not matches:
+                    continue
+
+                try:
+                    absolute_file_path = os.path.join(companion.repository_root_path, domain_file)
+                    uri = PathUtils.path_to_uri(absolute_file_path)
+
+                    if uri in companion.open_file_buffers:
+                        companion.open_file_buffers[uri].ref_count += 1
+                    else:
+                        with open(absolute_file_path, encoding=companion._encoding) as f:
+                            contents = f.read()
+                        language_id = companion._get_language_id_for_file(domain_file)
+                        file_buffer = LSPFileBuffer(uri, contents, 0, language_id, 1)
+                        companion.open_file_buffers[uri] = file_buffer
+
+                        companion.server.notify.did_open_text_document(
+                            {
+                                "textDocument": {
+                                    "uri": uri,
+                                    "languageId": language_id,
+                                    "version": 0,
+                                    "text": contents,
+                                }
+                            }
+                        )
+                        self._indexed_file_uris.append(uri)
+                except Exception as e:
+                    log.debug(f"Failed to index {domain_file} on {lang_id} server: {e}")
+
+        self._domain_files_indexed = True
+        log.debug("Domain file indexing complete")
+
+    def _cleanup_indexed_files(self) -> None:
+        """
+        Clean up indexed files on companion servers.
+
+        Closes files that were opened for cross-file indexing and removes them
+        from companion server buffers.
+        """
+        if not self._indexed_file_uris:
+            return
+
+        log.debug(f"Cleaning up {len(self._indexed_file_uris)} indexed files")
+
+        failed_cleanups: list[tuple[str, str]] = []
+        for uri in set(self._indexed_file_uris):
+            for companion in self._companions.values():
+                try:
+                    if uri in companion.open_file_buffers:
+                        file_buffer = companion.open_file_buffers[uri]
+                        file_buffer.ref_count -= 1
+
+                        if file_buffer.ref_count == 0:
+                            companion.server.notify.did_close_text_document({"textDocument": {"uri": uri}})
+                            del companion.open_file_buffers[uri]
+                except Exception as e:
+                    log.error(f"Error cleaning up indexed file {uri}: {e}")
+                    failed_cleanups.append((uri, str(e)))
+
+        if failed_cleanups:
+            log.warning(f"Failed to cleanup {len(failed_cleanups)} indexed files - potential resource leak")
+
+        self._indexed_file_uris.clear()
+
+    def _send_companion_references_request(
+        self,
+        companion: SolidLanguageServer,
+        relative_file_path: str,
+        line: int,
+        column: int,
+    ) -> list[ls_types.Location]:
+        """
+        Send references request to companion, filtering to repository files.
+
+        :param companion: Companion language server to query
+        :param relative_file_path: Path to file relative to repository root
+        :param line: Line number of symbol
+        :param column: Column number of symbol
+        :return: List of references within repository
+        """
+        uri = PathUtils.path_to_uri(os.path.join(self.repository_root_path, relative_file_path))
+        request_params = {
+            "textDocument": {"uri": uri},
+            "position": {"line": line, "character": column},
+            "context": {"includeDeclaration": True},
+        }
+
+        with companion.open_file(relative_file_path):
+            response = companion.handler.send.references(request_params)  # type: ignore[arg-type]
+
+        result: list[ls_types.Location] = []
+        if response is None:
+            return result
+
+        for item in response:
+            abs_path = PathUtils.uri_to_path(item["uri"])
+            if not Path(abs_path).is_relative_to(self.repository_root_path):
+                log.debug(f"Skipping reference outside repository: {abs_path}")
+                continue
+
+            rel_path = Path(abs_path).relative_to(self.repository_root_path)
+            if self.is_ignored_path(str(rel_path)):
+                log.debug(f"Skipping ignored reference: {rel_path}")
+                continue
+
+            new_item: dict = dict(item)  # type: ignore[arg-type]
+            new_item["absolutePath"] = str(abs_path)
+            new_item["relativePath"] = str(rel_path)
+            result.append(ls_types.Location(**new_item))  # type: ignore[typeddict-item]
+
+        return result
+
+    @override
+    def request_definition(
+        self,
+        relative_file_path: str,
+        line: int,
+        column: int,
+    ) -> list[ls_types.Location]:
+        if not self.server_started:
+            log.error("request_definition called before language server started")
+            raise SolidLSPException("Language Server not started")
+
+        companion = self._find_companion_for_operation("definitions")
+        if companion:
+            with companion.open_file(relative_file_path):
+                definitions = companion.request_definition(relative_file_path, line, column)
+
+            if len(definitions) > 1:
+                preferred = self._get_preferred_definition(definitions)
+                return [preferred]
+
+            return definitions
+
+        return super().request_definition(relative_file_path, line, column)
+
+    @override
+    def request_references(
+        self,
+        relative_file_path: str,
+        line: int,
+        column: int,
+    ) -> list[ls_types.Location]:
+        if not self.server_started:
+            log.error("request_references called before language server started")
+            raise SolidLSPException("Language Server not started")
+
+        if not self._has_waited_for_cross_file_references:
+            sleep(self._get_wait_time_for_cross_file_referencing())
+            self._has_waited_for_cross_file_references = True
+
+        self._ensure_domain_files_indexed()
+
+        companion_refs: list[ls_types.Location] = []
+        companion = self._find_companion_for_operation("references")
+        if companion:
+            companion_refs = self._send_companion_references_request(companion, relative_file_path, line, column)
+
+        domain_refs = self._get_domain_specific_references(relative_file_path)
+
+        return self._merge_references(companion_refs, domain_refs)
+
+    @override
+    def request_rename_symbol_edit(
+        self,
+        relative_file_path: str,
+        line: int,
+        column: int,
+        new_name: str,
+    ) -> ls_types.WorkspaceEdit | None:
+        if not self.server_started:
+            log.error("request_rename_symbol_edit called before language server started")
+            raise SolidLSPException("Language Server not started")
+
+        companion = self._find_companion_for_operation("rename")
+        if companion:
+            with companion.open_file(relative_file_path):
+                return companion.request_rename_symbol_edit(relative_file_path, line, column, new_name)
+
+        return super().request_rename_symbol_edit(relative_file_path, line, column, new_name)
+
+    def _start_companions(self) -> None:
+        """
+        Start all companion language servers.
+
+        Creates and starts each companion server defined by embedded language configs.
+        """
+        for config in self._get_embedded_language_configs():
+            log.info(f"Creating companion server for {config.language_id}")
+            companion = self._create_companion_server(config)
+
+            log.info(f"Starting companion server for {config.language_id}")
+            companion.start()
+
+            self._companions[config.language_id] = companion
+            self._companion_configs[config.language_id] = config
+            log.info(f"Companion server for {config.language_id} ready")
+
+        self._on_companions_ready()
+        self._setup_domain_protocol_handlers()
+
+    @override
+    def stop(self, shutdown_timeout: float = 2.0) -> None:
+        self._cleanup_indexed_files()
+
+        failed_companions: list[str] = []
+        for lang_id, companion in list(self._companions.items()):
+            try:
+                log.info(f"Stopping companion server for {lang_id}")
+                companion.stop()
+                del self._companions[lang_id]
+                if lang_id in self._companion_configs:
+                    del self._companion_configs[lang_id]
+            except Exception as e:
+                log.error(f"Error stopping companion server {lang_id}: {e}")
+                failed_companions.append(lang_id)
+
+        if failed_companions:
+            log.error(f"Failed to stop companion servers: {', '.join(failed_companions)}")
+
+        self._domain_files_indexed = False
+
+        super().stop(shutdown_timeout)

--- a/src/solidlsp/companion_ls.py
+++ b/src/solidlsp/companion_ls.py
@@ -209,7 +209,7 @@ class CompanionLanguageServer(SolidLanguageServer):
         log.debug(f"Cleaning up {len(self._indexed_file_uris)} indexed files")
 
         failed_cleanups: list[tuple[str, str]] = []
-        for uri in set(self._indexed_file_uris):
+        for uri in list(self._indexed_file_uris):
             for companion in self._companions.values():
                 try:
                     if uri in companion.open_file_buffers:

--- a/src/solidlsp/embedded_language_config.py
+++ b/src/solidlsp/embedded_language_config.py
@@ -1,0 +1,25 @@
+"""
+Configuration for embedded languages handled by companion servers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EmbeddedLanguageConfig:
+    """
+    Configuration for an embedded language handled by a companion language server.
+
+    Specifies which LSP operations the companion handles and which files to index.
+    """
+
+    language_id: str
+    file_patterns: list[str]
+    handles_definitions: bool = False
+    handles_references: bool = False
+    handles_rename: bool = False
+    handles_completions: bool = False
+    handles_diagnostics: bool = False
+    priority: int = 0

--- a/src/solidlsp/language_servers/al_language_server.py
+++ b/src/solidlsp/language_servers/al_language_server.py
@@ -700,9 +700,8 @@ class ALLanguageServer(SolidLanguageServer):
                 raise FileNotFoundError(f"File or directory not found: {within_abs_path}")
 
             if os.path.isfile(within_abs_path):
-                # Single file case - use parent class implementation
-                root_nodes = self.request_document_symbols(within_relative_path).root_symbols
-                return root_nodes
+                # Single file case - delegate to parent which wraps in File symbol
+                return super().request_full_symbol_tree(within_relative_path)
 
             # Directory case - scan within this directory
             scan_root = Path(within_abs_path)

--- a/src/solidlsp/language_servers/astro_language_server.py
+++ b/src/solidlsp/language_servers/astro_language_server.py
@@ -1,0 +1,433 @@
+"""
+Astro Language Server implementation using @astrojs/language-server with companion TypeScript LS.
+Operates in hybrid mode: Astro LS handles .astro files, TypeScript LS handles .ts/.js files.
+"""
+
+import logging
+import os
+import pathlib
+import shutil
+import threading
+from typing import Any
+
+from overrides import override
+
+from solidlsp import ls_types
+from solidlsp.companion_ls import CompanionLanguageServer
+from solidlsp.embedded_language_config import EmbeddedLanguageConfig
+from solidlsp.language_servers.common import RuntimeDependency, RuntimeDependencyCollection
+from solidlsp.language_servers.typescript_language_server import TypeScriptLanguageServer
+from solidlsp.ls import SolidLanguageServer
+from solidlsp.ls_config import Language, LanguageServerConfig
+from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
+from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
+from solidlsp.typescript_companion import (
+    create_typescript_companion_config,
+    prefer_non_node_modules_definition,
+)
+
+log = logging.getLogger(__name__)
+
+
+class AstroTypeScriptServer(TypeScriptLanguageServer):
+    """TypeScript LS configured with @astrojs/ts-plugin for Astro file support."""
+
+    @classmethod
+    @override
+    def get_language_enum_instance(cls) -> Language:
+        return Language.TYPESCRIPT
+
+    @override
+    def _get_language_id_for_file(self, relative_file_path: str) -> str:
+        """Return the correct language ID for files.
+
+        Astro files must be opened with language ID "astro" for the @astrojs/ts-plugin
+        to process them correctly.
+        """
+        ext = os.path.splitext(relative_file_path)[1].lower()
+        if ext == ".astro":
+            return "astro"
+        elif ext in (".ts", ".tsx", ".mts", ".cts"):
+            return "typescript"
+        elif ext in (".js", ".jsx", ".mjs", ".cjs"):
+            return "javascript"
+        else:
+            return "typescript"
+
+    def __init__(
+        self,
+        config: LanguageServerConfig,
+        repository_root_path: str,
+        solidlsp_settings: SolidLSPSettings,
+        astro_plugin_path: str,
+        tsdk_path: str,
+        ts_ls_executable_path: list[str],
+    ):
+        """Initialize the AstroTypeScriptServer with Astro plugin configuration.
+
+        :param config: Language server configuration
+        :param repository_root_path: Root path of the repository
+        :param solidlsp_settings: SolidLSP settings
+        :param astro_plugin_path: Path to the @astrojs/ts-plugin
+        :param tsdk_path: Path to the TypeScript SDK
+        :param ts_ls_executable_path: Path to the TypeScript language server executable
+        """
+        self._astro_plugin_path = astro_plugin_path
+        self._custom_tsdk_path = tsdk_path
+        super().__init__(config, repository_root_path, solidlsp_settings, executable_path=ts_ls_executable_path)
+
+    @override
+    def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
+        params = super()._get_initialize_params(repository_absolute_path)
+
+        params["initializationOptions"] = {
+            "plugins": [
+                {
+                    "name": "@astrojs/ts-plugin",
+                    "location": self._astro_plugin_path,
+                    "languages": ["astro"],
+                }
+            ],
+            "tsserver": {
+                "path": self._custom_tsdk_path,
+            },
+        }
+
+        if "workspace" in params["capabilities"]:
+            params["capabilities"]["workspace"]["executeCommand"] = {"dynamicRegistration": True}
+
+        return params
+
+    @override
+    def _start_server(self) -> None:
+        def workspace_configuration_handler(params: dict[str, Any]) -> list[dict[str, Any]]:
+            items = params.get("items", [])
+            return [{} for _ in items]
+
+        self.server.on_request("workspace/configuration", workspace_configuration_handler)
+        super()._start_server()
+
+
+class AstroLanguageServer(CompanionLanguageServer):
+    """
+    Language server for Astro components using @astrojs/language-server with companion TypeScript LS.
+
+    You can pass the following entries in ls_specific_settings["astro"]:
+        - astro_language_server_version: Version of @astrojs/language-server to install (default: "2.16.8")
+
+    Note: TypeScript versions are configured via ls_specific_settings["typescript"]:
+        - typescript_version: Version of TypeScript to install (default: "5.9.3")
+        - typescript_language_server_version: Version of typescript-language-server to install (default: "5.1.3")
+    """
+
+    TS_SERVER_READY_TIMEOUT = 5.0
+    ASTRO_SERVER_READY_TIMEOUT = 3.0
+    # Windows requires more time due to slower I/O and process operations.
+    ASTRO_INDEXING_WAIT_TIME = 4.0 if os.name == "nt" else 2.0
+
+    def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
+        astro_lsp_executable_path, self.tsdk_path, self._ts_ls_cmd = self._setup_runtime_dependencies(config, solidlsp_settings)
+        self._astro_ls_dir = os.path.join(self.ls_resources_dir(solidlsp_settings), "astro-lsp")
+        self.server_ready = threading.Event()
+        super().__init__(
+            config,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=astro_lsp_executable_path, cwd=repository_root_path),
+            "astro",
+            solidlsp_settings,
+        )
+
+    @override
+    def _get_domain_file_extension(self) -> str:
+        """Return the primary file extension for Astro files."""
+        return ".astro"
+
+    @override
+    def _get_embedded_language_configs(self) -> list[EmbeddedLanguageConfig]:
+        """Define TypeScript as the embedded language for Astro files."""
+        return [
+            create_typescript_companion_config(
+                file_patterns=["*.astro"],
+                handles_definitions=True,
+                handles_references=True,
+                handles_rename=True,
+            )
+        ]
+
+    @override
+    def _create_companion_server(self, config: EmbeddedLanguageConfig) -> SolidLanguageServer:
+        """Create the companion TypeScript server for Astro files."""
+        if config.language_id != "typescript":
+            raise ValueError(f"AstroLanguageServer only supports TypeScript companion, got: {config.language_id}")
+
+        astro_ts_plugin_path = os.path.join(self._astro_ls_dir, "node_modules", "@astrojs", "ts-plugin")
+
+        ts_config = LanguageServerConfig(
+            code_language=Language.TYPESCRIPT,
+            trace_lsp_communication=False,
+        )
+
+        log.info("Creating companion AstroTypeScriptServer")
+        return AstroTypeScriptServer(
+            config=ts_config,
+            repository_root_path=self.repository_root_path,
+            solidlsp_settings=self._solidlsp_settings,
+            astro_plugin_path=astro_ts_plugin_path,
+            tsdk_path=self.tsdk_path,
+            ts_ls_executable_path=self._ts_ls_cmd,
+        )
+
+    @override
+    def _ensure_domain_files_indexed(self) -> None:
+        """Index Astro files on companion servers with additional wait time for TS server processing."""
+        from time import sleep
+
+        if self._domain_files_indexed:
+            return
+
+        # Call base implementation to do the actual indexing
+        super()._ensure_domain_files_indexed()
+
+        # Additional wait time for TypeScript server to process indexed Astro files
+        sleep(self.ASTRO_INDEXING_WAIT_TIME)
+        log.debug("Wait period after Astro file indexing complete")
+
+    @override
+    def _get_preferred_definition(self, definitions: list[ls_types.Location]) -> ls_types.Location:
+        """Prefer non-node_modules definitions when multiple are found."""
+        return prefer_non_node_modules_definition(definitions)
+
+    @override
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        """Include Astro-specific directories to ignore."""
+        return super().is_ignored_dirname(dirname) or dirname in [".astro", "dist"]
+
+    @override
+    def _get_language_id_for_file(self, relative_file_path: str) -> str:
+        """Return correct language ID for files."""
+        ext = os.path.splitext(relative_file_path)[1].lower()
+        if ext == ".astro":
+            return "astro"
+        elif ext in (".ts", ".tsx", ".mts", ".cts"):
+            return "typescript"
+        elif ext in (".js", ".jsx", ".mjs", ".cjs"):
+            return "javascript"
+        else:
+            return "typescript"
+
+    @classmethod
+    def _setup_runtime_dependencies(
+        cls, config: LanguageServerConfig, solidlsp_settings: SolidLSPSettings
+    ) -> tuple[list[str], str, list[str]]:
+        if shutil.which("node") is None:
+            raise RuntimeError("node is not installed or isn't in PATH. Please install NodeJS and try again.")
+        if shutil.which("npm") is None:
+            raise RuntimeError("npm is not installed or isn't in PATH. Please install npm and try again.")
+
+        # Get TypeScript version settings from TypeScript language server settings
+        typescript_config = solidlsp_settings.get_ls_specific_settings(Language.TYPESCRIPT)
+        typescript_version = typescript_config.get("typescript_version", "5.9.3")
+        typescript_language_server_version = typescript_config.get("typescript_language_server_version", "5.1.3")
+        astro_config = solidlsp_settings.get_ls_specific_settings(Language.ASTRO)
+        astro_language_server_version = astro_config.get("astro_language_server_version", "2.16.8")
+
+        deps = RuntimeDependencyCollection(
+            [
+                RuntimeDependency(
+                    id="astro-language-server",
+                    description="Astro language server package",
+                    command=["npm", "install", "--prefix", "./", f"@astrojs/language-server@{astro_language_server_version}"],
+                    platform_id="any",
+                ),
+                RuntimeDependency(
+                    id="typescript",
+                    description="TypeScript (required for tsdk)",
+                    command=["npm", "install", "--prefix", "./", f"typescript@{typescript_version}"],
+                    platform_id="any",
+                ),
+                RuntimeDependency(
+                    id="typescript-language-server",
+                    description="TypeScript language server (for Astro LS tsserver forwarding)",
+                    command=[
+                        "npm",
+                        "install",
+                        "--prefix",
+                        "./",
+                        f"typescript-language-server@{typescript_language_server_version}",
+                    ],
+                    platform_id="any",
+                ),
+            ]
+        )
+
+        astro_ls_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "astro-lsp")
+        astro_executable_path = os.path.join(astro_ls_dir, "node_modules", ".bin", "astro-ls")
+        ts_ls_executable_path = os.path.join(astro_ls_dir, "node_modules", ".bin", "typescript-language-server")
+
+        if os.name == "nt":
+            astro_executable_path += ".cmd"
+            ts_ls_executable_path += ".cmd"
+
+        tsdk_path = os.path.join(astro_ls_dir, "node_modules", "typescript", "lib")
+
+        # Check if installation is needed based on executables AND version
+        version_file = os.path.join(astro_ls_dir, ".installed_version")
+        expected_version = f"{astro_language_server_version}_{typescript_version}_{typescript_language_server_version}"
+
+        needs_install = False
+        if not os.path.exists(astro_executable_path) or not os.path.exists(ts_ls_executable_path):
+            log.info("Astro/TypeScript Language Server executables not found.")
+            needs_install = True
+        elif os.path.exists(version_file):
+            with open(version_file, encoding="utf-8") as f:
+                installed_version = f.read().strip()
+            if installed_version != expected_version:
+                log.info(
+                    f"Astro Language Server version mismatch: installed={installed_version}, expected={expected_version}. Reinstalling..."
+                )
+                needs_install = True
+        else:
+            # No version file exists, install to ensure correct version
+            log.info("Astro Language Server version file not found, installing...")
+            needs_install = True
+
+        if needs_install:
+            log.info("Installing Astro/TypeScript Language Server dependencies...")
+            deps.install(astro_ls_dir)
+            # Write version marker file
+            with open(version_file, "w", encoding="utf-8") as f:
+                f.write(expected_version)
+            log.info("Astro language server dependencies installed successfully")
+
+        if not os.path.exists(astro_executable_path):
+            raise FileNotFoundError(
+                f"astro-ls executable not found at {astro_executable_path}, something went wrong with the installation."
+            )
+
+        if not os.path.exists(ts_ls_executable_path):
+            raise FileNotFoundError(
+                f"typescript-language-server executable not found at {ts_ls_executable_path}, something went wrong with the installation."
+            )
+
+        return [astro_executable_path, "--stdio"], tsdk_path, [ts_ls_executable_path, "--stdio"]
+
+    def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
+        """Return Astro-specific initialization parameters."""
+        root_uri = pathlib.Path(repository_absolute_path).as_uri()
+        initialize_params = {
+            "locale": "en",
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {"didSave": True, "dynamicRegistration": True},
+                    "completion": {"dynamicRegistration": True, "completionItem": {"snippetSupport": True}},
+                    "definition": {"dynamicRegistration": True, "linkSupport": True},
+                    "references": {"dynamicRegistration": True},
+                    "documentSymbol": {
+                        "dynamicRegistration": True,
+                        "hierarchicalDocumentSymbolSupport": True,
+                        "symbolKind": {"valueSet": list(range(1, 27))},
+                    },
+                    "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "signatureHelp": {"dynamicRegistration": True},
+                    "codeAction": {"dynamicRegistration": True},
+                    "rename": {"dynamicRegistration": True, "prepareSupport": True},
+                },
+                "workspace": {
+                    "workspaceFolders": True,
+                    "didChangeConfiguration": {"dynamicRegistration": True},
+                    "symbol": {"dynamicRegistration": True},
+                },
+            },
+            "processId": os.getpid(),
+            "rootPath": repository_absolute_path,
+            "rootUri": root_uri,
+            "workspaceFolders": [
+                {
+                    "uri": root_uri,
+                    "name": os.path.basename(repository_absolute_path),
+                }
+            ],
+            "initializationOptions": {
+                "typescript": {
+                    "tsdk": self.tsdk_path,
+                },
+            },
+        }
+        return initialize_params  # type: ignore
+
+    @override
+    def _start_server(self) -> None:
+        """Start the Astro language server with custom handlers."""
+        # Start companion servers (TypeScript) first
+        self._start_companions()
+
+        # Set up Astro-specific request handlers
+        def register_capability_handler(params: dict[str, Any]) -> None:
+            if "registrations" not in params:
+                log.warning("client/registerCapability received params without 'registrations'")
+                return
+            return
+
+        def configuration_handler(params: dict[str, Any]) -> list[dict[str, Any]]:
+            items = params.get("items", [])
+            return [{} for _ in items]
+
+        def do_nothing(_params: dict[str, Any]) -> None:
+            return
+
+        def window_log_message(msg: dict[str, Any]) -> None:
+            log.info(f"LSP: window/logMessage: {msg}")
+            message_text = msg.get("message", "")
+            if "initialized" in message_text.lower() or "ready" in message_text.lower():
+                log.info("Astro language server ready signal detected")
+                self.server_ready.set()
+                self.completions_available.set()
+
+        self.server.on_request("client/registerCapability", register_capability_handler)
+        self.server.on_request("workspace/configuration", configuration_handler)
+        self.server.on_notification("window/logMessage", window_log_message)
+        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+
+        log.info("Starting Astro server process")
+        self.server.start()
+        initialize_params = self._get_initialize_params(self.repository_root_path)
+
+        log.info("Sending initialize request from LSP client to LSP server and awaiting response")
+        init_response = self.server.send.initialize(initialize_params)
+        log.debug(f"Received initialize response from Astro server: {init_response}")
+
+        assert init_response["capabilities"]["textDocumentSync"] in [1, 2]
+
+        self.server.notify.initialized({})
+
+        log.info("Waiting for Astro language server to be ready...")
+        if not self.server_ready.wait(timeout=self.ASTRO_SERVER_READY_TIMEOUT):
+            log.info("Timeout waiting for Astro server ready signal, proceeding anyway")
+            self.server_ready.set()
+            self.completions_available.set()
+        else:
+            log.info("Astro server initialization complete")
+
+    def _find_tsconfig_for_file(self, relative_file_path: str) -> str | None:
+        """Find the nearest tsconfig.json for a file."""
+        file_path = pathlib.Path(self.repository_root_path) / relative_file_path
+        for parent in file_path.parents:
+            tsconfig = parent / "tsconfig.json"
+            if tsconfig.exists():
+                return str(tsconfig)
+            if parent == pathlib.Path(self.repository_root_path):
+                break
+        return None
+
+    @override
+    def _get_wait_time_for_cross_file_referencing(self) -> float:
+        """Return wait time for cross-file reference operations."""
+        return self.ASTRO_INDEXING_WAIT_TIME
+
+    @override
+    def stop(self, shutdown_timeout: float = 2.0) -> None:
+        """Stop the Astro language server and companions."""
+        self.server_ready.clear()
+        super().stop(shutdown_timeout)

--- a/src/solidlsp/language_servers/astro_language_server.py
+++ b/src/solidlsp/language_servers/astro_language_server.py
@@ -114,7 +114,7 @@ class AstroLanguageServer(CompanionLanguageServer):
     Language server for Astro components using @astrojs/language-server with companion TypeScript LS.
 
     You can pass the following entries in ls_specific_settings["astro"]:
-        - astro_language_server_version: Version of @astrojs/language-server to install (default: "2.16.8")
+        - astro_language_server_version: Version of @astrojs/language-server to install (default: "2.16.2")
 
     Note: TypeScript versions are configured via ls_specific_settings["typescript"]:
         - typescript_version: Version of TypeScript to install (default: "5.9.3")
@@ -230,7 +230,7 @@ class AstroLanguageServer(CompanionLanguageServer):
         typescript_version = typescript_config.get("typescript_version", "5.9.3")
         typescript_language_server_version = typescript_config.get("typescript_language_server_version", "5.1.3")
         astro_config = solidlsp_settings.get_ls_specific_settings(Language.ASTRO)
-        astro_language_server_version = astro_config.get("astro_language_server_version", "2.16.8")
+        astro_language_server_version = astro_config.get("astro_language_server_version", "2.16.2")
 
         deps = RuntimeDependencyCollection(
             [

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -63,6 +63,7 @@ class Language(str, Enum):
     HASKELL = "haskell"
     GROOVY = "groovy"
     VUE = "vue"
+    ASTRO = "astro"
     POWERSHELL = "powershell"
     # Experimental or deprecated Language Servers
     TYPESCRIPT_VTS = "typescript_vts"
@@ -129,8 +130,8 @@ class Language(str, Enum):
         # We assign lower priority to languages that are supersets of others, such that
         # the "larger" language is only chosen when it matches more strongly
         match self:
-            # languages that are supersets of others (Vue is superset of TypeScript/JavaScript)
-            case self.VUE:
+            # languages that are supersets of others (Vue/Astro are supersets of TypeScript/JavaScript)
+            case self.VUE | self.ASTRO:
                 return 1
             # regular languages
             case _:
@@ -221,6 +222,13 @@ class Language(str, Enum):
                         for base_pattern in ["ts", "js"]:
                             path_patterns.append(f"*.{prefix}{base_pattern}{postfix}")
                 return FilenameMatcher(*path_patterns)
+            case self.ASTRO:
+                path_patterns = ["*.astro"]
+                for prefix in ["c", "m", ""]:
+                    for postfix in ["x", ""]:
+                        for base_pattern in ["ts", "js"]:
+                            path_patterns.append(f"*.{prefix}{base_pattern}{postfix}")
+                return FilenameMatcher(*path_patterns)
             case self.POWERSHELL:
                 return FilenameMatcher("*.ps1", "*.psm1", "*.psd1")
             case self.GROOVY:
@@ -270,6 +278,10 @@ class Language(str, Enum):
                 from solidlsp.language_servers.vue_language_server import VueLanguageServer
 
                 return VueLanguageServer
+            case self.ASTRO:
+                from solidlsp.language_servers.astro_language_server import AstroLanguageServer
+
+                return AstroLanguageServer
             case self.GO:
                 from solidlsp.language_servers.gopls import Gopls
 

--- a/src/solidlsp/typescript_companion.py
+++ b/src/solidlsp/typescript_companion.py
@@ -1,0 +1,57 @@
+"""Helpers for configuring TypeScript as a companion language server."""
+
+from __future__ import annotations
+
+from solidlsp import ls_types
+from solidlsp.embedded_language_config import EmbeddedLanguageConfig
+
+
+def create_typescript_companion_config(
+    file_patterns: list[str],
+    handles_definitions: bool = True,
+    handles_references: bool = True,
+    handles_rename: bool = True,
+    handles_completions: bool = False,
+    handles_diagnostics: bool = False,
+    priority: int = 100,
+) -> EmbeddedLanguageConfig:
+    """
+    Create standard TypeScript embedded language configuration.
+
+    :param file_patterns: Glob patterns for files to index (e.g., ["*.vue"])
+    :param handles_definitions: Handle go-to-definition requests
+    :param handles_references: Handle find-references requests
+    :param handles_rename: Handle rename requests
+    :param handles_completions: Handle completion requests
+    :param handles_diagnostics: Handle diagnostic requests
+    :param priority: Priority when multiple companions could handle an operation
+    :return: Configured EmbeddedLanguageConfig for TypeScript
+    """
+    return EmbeddedLanguageConfig(
+        language_id="typescript",
+        file_patterns=file_patterns,
+        handles_definitions=handles_definitions,
+        handles_references=handles_references,
+        handles_rename=handles_rename,
+        handles_completions=handles_completions,
+        handles_diagnostics=handles_diagnostics,
+        priority=priority,
+    )
+
+
+def prefer_non_node_modules_definition(
+    definitions: list[ls_types.Location],
+) -> ls_types.Location:
+    """
+    Select preferred definition, favoring source files over node_modules.
+
+    :param definitions: Non-empty list of definition locations
+    :return: Preferred definition location (first non-node_modules, or first if all in node_modules)
+    """
+    if not definitions:
+        raise ValueError("definitions list cannot be empty")
+    for d in definitions:
+        rel_path = d.get("relativePath", "")
+        if rel_path and "node_modules" not in rel_path:
+            return d
+    return definitions[0]

--- a/test/resources/repos/astro/test_repo/.gitignore
+++ b/test/resources/repos/astro/test_repo/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.astro/

--- a/test/resources/repos/astro/test_repo/astro.config.mjs
+++ b/test/resources/repos/astro/test_repo/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  // Minimal config for testing
+});

--- a/test/resources/repos/astro/test_repo/package.json
+++ b/test/resources/repos/astro/test_repo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "astro-test-fixture",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "astro": "^5.1.0"
+  },
+  "devDependencies": {
+    "@astrojs/language-server": "^2.15.7",
+    "typescript": "~5.9.3"
+  }
+}

--- a/test/resources/repos/astro/test_repo/package.json
+++ b/test/resources/repos/astro/test_repo/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "astro": "^5.1.0"
+    "astro": "^5.16.6"
   },
   "devDependencies": {
-    "@astrojs/language-server": "^2.15.7",
-    "typescript": "~5.9.3"
+    "@astrojs/language-server": "^2.16.2",
+    "typescript": "~5.7.3"
   }
 }

--- a/test/resources/repos/astro/test_repo/src/components/Footer.astro
+++ b/test/resources/repos/astro/test_repo/src/components/Footer.astro
@@ -1,0 +1,7 @@
+---
+const year = new Date().getFullYear();
+---
+
+<footer>
+  <p>&copy; {year} Test Site</p>
+</footer>

--- a/test/resources/repos/astro/test_repo/src/components/Header.astro
+++ b/test/resources/repos/astro/test_repo/src/components/Header.astro
@@ -1,0 +1,13 @@
+---
+interface Props {
+  siteName: string;
+}
+
+const { siteName } = Astro.props;
+---
+
+<header>
+  <nav>
+    <a href="/">{siteName}</a>
+  </nav>
+</header>

--- a/test/resources/repos/astro/test_repo/src/layouts/Layout.astro
+++ b/test/resources/repos/astro/test_repo/src/layouts/Layout.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/test/resources/repos/astro/test_repo/src/pages/index.astro
+++ b/test/resources/repos/astro/test_repo/src/pages/index.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { createCounter } from '../stores/counter';
+import { formatNumber } from '../utils/format';
+
+const counter = createCounter();
+---
+
+<Layout title="Home">
+  <Header siteName="Test Site" />
+  <main>
+    <h1>Welcome</h1>
+    <p>Count: {formatNumber(counter.count)}</p>
+  </main>
+  <Footer />
+</Layout>

--- a/test/resources/repos/astro/test_repo/src/stores/counter.ts
+++ b/test/resources/repos/astro/test_repo/src/stores/counter.ts
@@ -1,0 +1,21 @@
+export interface CounterStore {
+  count: number;
+  increment: () => void;
+  decrement: () => void;
+}
+
+export function createCounter(): CounterStore {
+  let count = 0;
+
+  return {
+    get count() {
+      return count;
+    },
+    increment() {
+      count++;
+    },
+    decrement() {
+      count--;
+    },
+  };
+}

--- a/test/resources/repos/astro/test_repo/src/utils/format.ts
+++ b/test/resources/repos/astro/test_repo/src/utils/format.ts
@@ -1,0 +1,13 @@
+/**
+ * Format a number with thousands separators.
+ */
+export function formatNumber(value: number): string {
+  return value.toLocaleString();
+}
+
+/**
+ * Format a date to locale string.
+ */
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString();
+}

--- a/test/resources/repos/astro/test_repo/tsconfig.json
+++ b/test/resources/repos/astro/test_repo/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "astro/tsconfigs/base",
+  "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "strict": true,
     "jsx": "preserve"
-  }
+  },
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
 }

--- a/test/resources/repos/astro/test_repo/tsconfig.json
+++ b/test/resources/repos/astro/test_repo/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "preserve"
+  }
+}

--- a/test/solidlsp/astro/__init__.py
+++ b/test/solidlsp/astro/__init__.py
@@ -1,0 +1,1 @@
+# Astro language server tests

--- a/test/solidlsp/astro/test_astro_basic.py
+++ b/test/solidlsp/astro/test_astro_basic.py
@@ -38,8 +38,8 @@ class TestAstroLanguageServer:
         symbols = language_server.request_document_symbols(layout_path)
         assert symbols is not None, "Expected document symbols but got None"
         # Layout.astro defines: interface Props { title: string; }
-        all_symbols = symbols.get_all_symbols_and_roots()
-        symbol_names = [s.name for s in all_symbols]
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
         # Verify we found the Props interface from frontmatter
         assert "Props" in symbol_names, f"Expected 'Props' interface in symbols, got: {symbol_names}"
 
@@ -50,8 +50,8 @@ class TestAstroLanguageServer:
         counter_path = str(repo_path / "src" / "stores" / "counter.ts")
         symbols = language_server.request_document_symbols(counter_path)
         assert symbols is not None, "Expected document symbols but got None"
-        all_symbols = symbols.get_all_symbols_and_roots()
-        symbol_names = [s.name for s in all_symbols]
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
         assert "CounterStore" in symbol_names, f"Expected 'CounterStore' in symbols, got: {symbol_names}"
         assert "createCounter" in symbol_names, f"Expected 'createCounter' in symbols, got: {symbol_names}"
 
@@ -135,7 +135,7 @@ class TestAstroEdgeCases:
         # Layout.astro defines: interface Props { title: string; }
         symbols = language_server.request_document_symbols(layout_path)
         assert symbols is not None, "Expected document symbols but got None"
-        all_symbols = symbols.get_all_symbols_and_roots()
-        symbol_names = [s.name for s in all_symbols]
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
         # Verify Props interface is found
         assert "Props" in symbol_names, f"Expected 'Props' interface in Layout.astro, got: {symbol_names}"

--- a/test/solidlsp/astro/test_astro_basic.py
+++ b/test/solidlsp/astro/test_astro_basic.py
@@ -1,0 +1,141 @@
+"""
+Basic tests for Astro language server functionality.
+
+Tests cover:
+- Language server startup
+- Symbol tree extraction from .astro files
+- Cross-file reference finding between Astro and TypeScript
+- Dual server coordination
+- Reference deduplication
+
+Template: test_vue_basic.py
+"""
+
+from pathlib import Path
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+
+
+@pytest.mark.astro
+class TestAstroLanguageServer:
+    """Core Astro language server functionality tests."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_ls_is_running(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that the Astro language server starts and stops successfully."""
+        assert language_server.is_running()
+        assert Path(language_server.language_server.repository_root_path).resolve() == repo_path.resolve()
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_astro_document_symbols(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that document symbols are extracted from .astro files."""
+        layout_path = str(repo_path / "src" / "layouts" / "Layout.astro")
+        symbols = language_server.request_document_symbols(layout_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        # Layout.astro defines: interface Props { title: string; }
+        all_symbols = symbols.get_all_symbols_and_roots()
+        symbol_names = [s.name for s in all_symbols]
+        # Verify we found the Props interface from frontmatter
+        assert "Props" in symbol_names, f"Expected 'Props' interface in symbols, got: {symbol_names}"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_typescript_document_symbols(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that TypeScript files in Astro project have document symbols."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        symbols = language_server.request_document_symbols(counter_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        all_symbols = symbols.get_all_symbols_and_roots()
+        symbol_names = [s.name for s in all_symbols]
+        assert "CounterStore" in symbol_names, f"Expected 'CounterStore' in symbols, got: {symbol_names}"
+        assert "createCounter" in symbol_names, f"Expected 'createCounter' in symbols, got: {symbol_names}"
+
+
+@pytest.mark.astro
+class TestAstroDefinition:
+    """Go-to-definition tests for Astro language server."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_find_definition_within_typescript(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test finding definition within TypeScript file."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        definition_list = language_server.request_definition(counter_path, 6, 35)
+        assert definition_list, "Expected at least one definition"
+        assert len(definition_list) >= 1
+        definition = definition_list[0]
+        assert definition["uri"].endswith("counter.ts"), f"Expected counter.ts, got: {definition['uri']}"
+        assert definition["range"]["start"]["line"] == 0, "Expected definition at line 0"
+
+
+@pytest.mark.astro
+class TestAstroReferences:
+    """Reference finding tests for Astro language server."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_find_references_within_typescript(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test finding references within TypeScript file."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        # CounterStore interface on line 0 (0-indexed), column 20
+        references = language_server.request_references(counter_path, 0, 20)
+        assert references, "Expected at least one reference"
+        assert len(references) >= 1
+        # Verify at least one reference points to counter.ts
+        ref_files = [ref["uri"] for ref in references]
+        assert any("counter.ts" in uri for uri in ref_files), f"Expected reference in counter.ts, got: {ref_files}"
+
+
+@pytest.mark.astro
+class TestAstroDualLspArchitecture:
+    """Tests for TypeScript server coordination in Astro."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_typescript_server_starts(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that companion TypeScript server starts successfully."""
+        astro_ls = language_server.language_server
+        # CompanionLanguageServer stores companions in _companions dict
+        assert hasattr(astro_ls, "_companions"), "Expected _companions attribute on Astro language server"
+        assert "typescript" in astro_ls._companions, "Expected TypeScript companion server"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_dual_server_definition_lookup(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that definitions work with both Astro and TypeScript servers."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        ts_definition = language_server.request_definition(counter_path, 6, 35)
+        assert ts_definition, "Expected definition from TypeScript server"
+
+
+@pytest.mark.astro
+class TestAstroEdgeCases:
+    """Edge case tests for Astro language server."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_astro_file_with_frontmatter(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test handling of .astro files with frontmatter section."""
+        index_path = str(repo_path / "src" / "pages" / "index.astro")
+        # index.astro has imports and variable declarations in frontmatter
+        symbols = language_server.request_document_symbols(index_path)
+        # Should handle frontmatter without errors
+        assert symbols is not None, "Expected document symbols but got None"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_layout_astro_with_props_interface(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test Layout.astro which has Props interface in frontmatter."""
+        layout_path = str(repo_path / "src" / "layouts" / "Layout.astro")
+        # Layout.astro defines: interface Props { title: string; }
+        symbols = language_server.request_document_symbols(layout_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        all_symbols = symbols.get_all_symbols_and_roots()
+        symbol_names = [s.name for s in all_symbols]
+        # Verify Props interface is found
+        assert "Props" in symbol_names, f"Expected 'Props' interface in Layout.astro, got: {symbol_names}"

--- a/test/solidlsp/astro/test_astro_symbol_retrieval.py
+++ b/test/solidlsp/astro/test_astro_symbol_retrieval.py
@@ -30,8 +30,8 @@ class TestAstroSymbolRetrieval:
         # Request document symbols to verify we can get symbols from TS files
         symbols = language_server.request_document_symbols(counter_path)
         assert symbols is not None, "Expected document symbols but got None"
-        all_symbols = symbols.get_all_symbols_and_roots()
-        symbol_names = [s.name for s in all_symbols]
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
         # Verify expected symbols from counter.ts
         assert "CounterStore" in symbol_names, f"Expected 'CounterStore' in symbols, got: {symbol_names}"
         assert "createCounter" in symbol_names, f"Expected 'createCounter' in symbols, got: {symbol_names}"
@@ -72,7 +72,7 @@ class TestAstroSymbolRetrieval:
         format_path = str(repo_path / "src" / "utils" / "format.ts")
         symbols = language_server.request_document_symbols(format_path)
         assert symbols is not None, "Expected document symbols but got None"
-        all_symbols = symbols.get_all_symbols_and_roots()
-        symbol_names = [s.name for s in all_symbols]
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
         assert "formatNumber" in symbol_names, f"Expected 'formatNumber' in symbols, got: {symbol_names}"
         assert "formatDate" in symbol_names, f"Expected 'formatDate' in symbols, got: {symbol_names}"

--- a/test/solidlsp/astro/test_astro_symbol_retrieval.py
+++ b/test/solidlsp/astro/test_astro_symbol_retrieval.py
@@ -1,0 +1,78 @@
+"""
+Symbol retrieval tests for Astro language server.
+
+Tests cover:
+- Containing symbol requests
+- Referencing symbol requests
+- Cross-file type resolution
+- Import resolution
+
+Template: test_vue_symbol_retrieval.py
+"""
+
+from pathlib import Path
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+
+
+@pytest.mark.astro
+class TestAstroSymbolRetrieval:
+    """Symbol retrieval functionality tests."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_get_containing_symbol_in_typescript(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test finding containing symbol in .ts file within Astro project."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        # Request document symbols to verify we can get symbols from TS files
+        symbols = language_server.request_document_symbols(counter_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        all_symbols = symbols.get_all_symbols_and_roots()
+        symbol_names = [s.name for s in all_symbols]
+        # Verify expected symbols from counter.ts
+        assert "CounterStore" in symbol_names, f"Expected 'CounterStore' in symbols, got: {symbol_names}"
+        assert "createCounter" in symbol_names, f"Expected 'createCounter' in symbols, got: {symbol_names}"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_find_references_to_typescript_export(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test finding references to TypeScript export from Astro components."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        # Find references to createCounter function
+        # createCounter is on line 7 (0-indexed: 6), function name starts around char 16
+        references = language_server.request_references(counter_path, 6, 20)
+        # Should find at least the definition
+        assert references is not None, "Expected references but got None"
+        assert len(references) >= 1, f"Expected at least 1 reference, got {len(references)}"
+        # Verify at least one reference is in counter.ts (the definition itself)
+        ref_files = [ref["uri"] for ref in references]
+        assert any("counter.ts" in uri for uri in ref_files), f"Expected reference in counter.ts, got: {ref_files}"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_go_to_definition_from_typescript(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test go-to-definition within TypeScript source."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        # In createCounter function, CounterStore return type is on line 7 (0-indexed: 6)
+        definition_list = language_server.request_definition(counter_path, 6, 35)
+        assert definition_list, "Expected at least one definition"
+        # Should point to CounterStore interface definition
+        definition = definition_list[0]
+        assert definition["uri"].endswith("counter.ts"), f"Expected counter.ts, got: {definition['uri']}"
+        # CounterStore is defined at line 0
+        assert definition["range"]["start"]["line"] == 0, f"Expected line 0, got: {definition['range']['start']['line']}"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_format_utils_symbols(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that format.ts utility file symbols are accessible."""
+        format_path = str(repo_path / "src" / "utils" / "format.ts")
+        symbols = language_server.request_document_symbols(format_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        all_symbols = symbols.get_all_symbols_and_roots()
+        symbol_names = [s.name for s in all_symbols]
+        assert "formatNumber" in symbol_names, f"Expected 'formatNumber' in symbols, got: {symbol_names}"
+        assert "formatDate" in symbol_names, f"Expected 'formatDate' in symbols, got: {symbol_names}"

--- a/test/solidlsp/vue/test_vue_basic.py
+++ b/test/solidlsp/vue/test_vue_basic.py
@@ -1,3 +1,10 @@
+"""
+Basic Vue language server tests.
+
+Tests core functionality including symbol tree parsing, cross-file references,
+and TypeScript coordination through the dual LSP architecture.
+"""
+
 import os
 
 import pytest
@@ -9,6 +16,8 @@ from solidlsp.ls_utils import SymbolUtils
 
 @pytest.mark.vue
 class TestVueLanguageServer:
+    """Tests for basic Vue language server operations."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_vue_files_in_symbol_tree(self, language_server: SolidLanguageServer) -> None:
         symbols = language_server.request_full_symbol_tree()
@@ -45,6 +54,8 @@ class TestVueLanguageServer:
 
 @pytest.mark.vue
 class TestVueDualLspArchitecture:
+    """Tests for Vue + TypeScript dual language server coordination."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_typescript_server_coordination(self, language_server: SolidLanguageServer) -> None:
         ts_file = os.path.join("src", "stores", "calculator.ts")
@@ -180,6 +191,8 @@ class TestVueDualLspArchitecture:
 
 @pytest.mark.vue
 class TestVueEdgeCases:
+    """Tests for edge cases in Vue symbol handling."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_symbol_tree_structure(self, language_server: SolidLanguageServer) -> None:
         full_tree = language_server.request_full_symbol_tree()

--- a/test/solidlsp/vue/test_vue_error_cases.py
+++ b/test/solidlsp/vue/test_vue_error_cases.py
@@ -1,3 +1,10 @@
+"""
+Vue language server error case tests.
+
+Tests error handling for invalid positions, non-existent files,
+undefined symbols, and other edge cases.
+"""
+
 import os
 import sys
 
@@ -28,6 +35,8 @@ class TypeScriptServerBehavior:
 
 
 class TestVueInvalidPositions:
+    """Tests for handling invalid positions in Vue files."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_negative_line_number(self, language_server: SolidLanguageServer) -> None:
         file_path = os.path.join("src", "components", "CalculatorInput.vue")

--- a/test/solidlsp/vue/test_vue_rename.py
+++ b/test/solidlsp/vue/test_vue_rename.py
@@ -1,3 +1,10 @@
+"""
+Vue language server rename tests.
+
+Tests symbol renaming functionality including single-file and
+cross-file rename operations for Vue components and TypeScript files.
+"""
+
 import os
 
 import pytest
@@ -9,6 +16,8 @@ pytestmark = pytest.mark.vue
 
 
 class TestVueRename:
+    """Tests for Vue symbol rename operations."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_rename_function_within_single_file(self, language_server: SolidLanguageServer) -> None:
         file_path = os.path.join("src", "components", "CalculatorInput.vue")

--- a/test/solidlsp/vue/test_vue_symbol_retrieval.py
+++ b/test/solidlsp/vue/test_vue_symbol_retrieval.py
@@ -1,3 +1,10 @@
+"""
+Vue language server symbol retrieval tests.
+
+Tests symbol lookup functionality including containing symbols,
+referencing symbols, cross-component references, and import resolution.
+"""
+
 import os
 
 import pytest
@@ -10,6 +17,8 @@ pytestmark = pytest.mark.vue
 
 
 class TestVueSymbolRetrieval:
+    """Tests for Vue symbol retrieval operations."""
+
     @pytest.mark.parametrize("language_server", [Language.VUE], indirect=True)
     def test_request_containing_symbol_script_setup_function(self, language_server: SolidLanguageServer) -> None:
         file_path = os.path.join("src", "components", "CalculatorInput.vue")


### PR DESCRIPTION
# Add Astro Language Server Support

## Summary

This PR adds support for Astro framework files using the `CompanionLanguageServer` abstraction introduced in #829. The implementation follows the same dual-server architecture pattern used by Vue, where the domain-specific language server (Astro LS) handles `.astro` files while a companion TypeScript language server handles definitions, references, and rename operations for TypeScript/JavaScript code.

## Motivation

Astro is a popular web framework for building content-focused websites. Like Vue, Astro components contain embedded TypeScript/JavaScript in their frontmatter section, requiring coordination between the Astro-specific language server and TypeScript tooling for full IDE functionality.

## Architecture

### Dual Language Server Design

```
                    AstroLanguageServer (extends CompanionLanguageServer)
                              |
         +--------------------+--------------------+
         |                                         |
    Astro LSP                              AstroTypeScriptServer
 (@astrojs/language-server)               (extends TypeScriptLanguageServer)
         |                                         |
    Handles:                               Handles:
    - .astro file parsing                  - Go-to-definition
    - Document symbols                     - Find references
    - Astro-specific features              - Rename operations
                                           - Cross-file resolution
```

### Key Components

**`CompanionLanguageServer`** (from #829)
- Abstract base class for language servers requiring companion servers
- Manages companion lifecycle, LSP operation delegation, cross-file indexing
- Provides reference merging and deduplication

**`AstroLanguageServer`**
- Extends `CompanionLanguageServer`
- Uses `@astrojs/language-server` for Astro file handling
- Configures TypeScript companion for code intelligence operations

**`AstroTypeScriptServer`**
- Extends `TypeScriptLanguageServer`
- Configured with `@astrojs/ts-plugin` for Astro file understanding
- Opens `.astro` files with language ID "astro" for plugin recognition

**`EmbeddedLanguageConfig`**
- Configuration dataclass for embedded language handling
- Specifies which LSP operations each companion handles
- Defines file patterns for cross-file indexing

**`typescript_companion.py`**
- Shared helper for TypeScript companion configuration
- `create_typescript_companion_config()` - Standard TS config factory
- `prefer_non_node_modules_definition()` - Definition prioritization logic
- Reusable by Vue, Astro, and future Svelte implementations

## Files Changed

### New Files

| File | Purpose |
|------|---------|
| `src/solidlsp/language_servers/astro_language_server.py` | Main Astro LSP implementation (434 lines) |
| `src/solidlsp/companion_ls.py` | CompanionLanguageServer base class (390 lines, from #829) |
| `src/solidlsp/embedded_language_config.py` | Configuration dataclass for embedded languages (26 lines) |
| `src/solidlsp/typescript_companion.py` | Shared TypeScript companion helpers (57 lines) |
| `test/solidlsp/astro/__init__.py` | Test package marker |
| `test/solidlsp/astro/test_astro_basic.py` | Core functionality tests (141 lines) |
| `test/solidlsp/astro/test_astro_symbol_retrieval.py` | Symbol retrieval tests (78 lines) |
| `test/resources/repos/astro/test_repo/` | Complete Astro test project (10 files) |

### Modified Files

| File | Changes |
|------|---------|
| `src/solidlsp/ls_config.py` | Added `ASTRO` to `Language` enum, file matchers, LS class mapping |
| `src/solidlsp/language_servers/vue_language_server.py` | Refactored to use `CompanionLanguageServer` (net -162 lines) |
| `src/solidlsp/language_servers/typescript_language_server.py` | Added `executable_path` parameter for custom TS server locations |
| `pyproject.toml` | Added `astro` pytest marker |
| `test/solidlsp/vue/test_vue_*.py` | Added `@pytest.mark.vue` markers (4 files) |
| `CHANGELOG.md` | Added Astro, CompanionLanguageServer, and Vue refactor entries |
| `README.md` | Added Astro and Vue to supported languages list |

## Test Repository Structure

```
test/resources/repos/astro/test_repo/
├── astro.config.mjs          # Astro configuration
├── package.json              # NPM package definition
├── tsconfig.json             # TypeScript configuration
├── src/
│   ├── components/
│   │   ├── Header.astro      # Component with Props interface
│   │   └── Footer.astro      # Simple component
│   ├── layouts/
│   │   └── Layout.astro      # Layout with Props interface (tests frontmatter parsing)
│   ├── pages/
│   │   └── index.astro       # Page with imports and variable declarations
│   ├── stores/
│   │   └── counter.ts        # TypeScript store (tests cross-file resolution)
│   └── utils/
│       └── format.ts         # TypeScript utilities
```

## Test Coverage

### `test_astro_basic.py`

| Test | What It Verifies |
|------|------------------|
| `test_ls_is_running` | Language server starts successfully |
| `test_astro_document_symbols` | Symbols extracted from `.astro` frontmatter (Props interface) |
| `test_typescript_document_symbols` | TypeScript file symbols accessible (CounterStore, createCounter) |
| `test_find_definition_within_typescript` | Go-to-definition within TypeScript files |
| `test_find_references_within_typescript` | Find references within TypeScript files |
| `test_typescript_server_starts` | Companion TypeScript server initialized |
| `test_dual_server_definition_lookup` | Definition lookup through companion server |
| `test_astro_file_with_frontmatter` | Handles frontmatter sections without errors |
| `test_layout_astro_with_props_interface` | Props interface found in Layout component |

### `test_astro_symbol_retrieval.py`

| Test | What It Verifies |
|------|------------------|
| `test_get_containing_symbol_in_typescript` | Document symbols from `.ts` files within Astro project |
| `test_find_references_to_typescript_export` | References to TypeScript exports |
| `test_go_to_definition_from_typescript` | Definition resolution for TypeScript types |
| `test_format_utils_symbols` | Utility file symbols accessible (formatNumber, formatDate) |

## Runtime Dependencies

Automatically installed on first use:
- `@astrojs/language-server@2.16.8` - Astro LSP
- `typescript@5.9.3` - TypeScript SDK
- `typescript-language-server@5.1.3` - TS LSP for companion server

Configurable via `ls_specific_settings` in `serena_config.yml`:
```yaml
ls_specific_settings:
  astro:
    astro_language_server_version: "2.16.8"
  typescript:
    typescript_version: "5.9.3"
    typescript_language_server_version: "5.1.3"
```

## Relationship to #829

This PR depends on the `CompanionLanguageServer` abstraction from #829:
- Uses the same companion server pattern as Vue
- Follows the same architecture for dual-LSP coordination
- Demonstrates the abstraction works for multiple frameworks

The base class handles:
- Companion server lifecycle management
- Cross-file domain file indexing
- Reference merging and deduplication
- LSP operation delegation

If #829 is merged first, this PR may need a rebase to resolve conflicts in shared files.

## Breaking Changes

None. This is purely additive.

## Checklist

- [x] Language server implementation follows existing patterns
- [x] Tests verify actual symbol names and references (not just non-null checks)
- [x] Test repository includes meaningful source files for cross-file testing
- [x] Added pytest marker for Astro tests
- [x] Vue tests updated with markers (prevents unintended test collection)
- [x] Runtime dependencies auto-install with version tracking
- [x] Windows compatibility (`.cmd` suffix handling)
- [x] CHANGELOG.md updated with detailed entries
- [x] README.md updated with Astro and Vue in supported languages

## CHANGELOG Entry

Already added to CHANGELOG.md:

```markdown
* Language support:
  * **Add support for Astro** via @astrojs/language-server with companion TypeScript LS for code intelligence.
    Uses dual-server architecture where Astro LS handles `.astro` file parsing and document symbols,
    while a companion TypeScript server (configured with `@astrojs/ts-plugin`) handles go-to-definition,
    find references, and rename operations. Supports frontmatter TypeScript/JavaScript extraction,
    cross-file symbol resolution, and Props interface detection. Runtime dependencies auto-install on first use.
  * **Add `CompanionLanguageServer` abstraction** for language servers requiring companion servers (Vue, Astro, future Svelte).
    Manages companion lifecycle, LSP operation delegation with priority-based routing, cross-file domain file indexing
    with ref-count tracking, and reference merging/deduplication. Extracted shared TypeScript companion configuration
    to `typescript_companion.py` for reuse across framework implementations.
  * **Refactored Vue language server** to use `CompanionLanguageServer` base class, reducing code by ~160 lines
    while maintaining full functionality and improving maintainability.
```

---

Replaces #884 (closed) with proper `CompanionLanguageServer`-based implementation per maintainer guidance.
