### PR TITLE
Adding completion, hover, inlay_hints, get_diagnostic tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     (and which requires no escaping in the replacement text, making it more robust)
   * Added `CompletionTool` for getting code completion suggestions at a cursor position
   * Added `HoverTool` for getting type information and documentation at a cursor position
-  * Added `InlayHintsTool` for getting type hints and parameter names for a code range 
+  * Added `InlayHintsTool` for getting type hints and parameter names for a code range
+  * Added `GetDiagnosticsTool` for retrieving compiler errors, warnings, and hints from language servers 
 
 * Language support:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,10 @@ Status of the `main` branch. Changes prior to the next official version change w
 * Tools:
   * Added `RenameSymbolTool` for renaming symbols across the codebase (if LS supports this operation).
   * Replaced `ReplaceRegexTool` with `ReplaceContentTool`, which supports both plain text and regex-based replacements
-    (and which requires no escaping in the replacement text, making it more robust) 
+    (and which requires no escaping in the replacement text, making it more robust)
+  * Added `CompletionTool` for getting code completion suggestions at a cursor position
+  * Added `HoverTool` for getting type information and documentation at a cursor position
+  * Added `InlayHintsTool` for getting type hints and parameter names for a code range 
 
 * Language support:
 

--- a/docs/01-about/035_tools.md
+++ b/docs/01-about/035_tools.md
@@ -17,6 +17,7 @@ Note that in most configurations, only a subset of these tools will be enabled s
   ed by type).
 * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools,
   contexts, and modes.
+* `get_diagnostics`: Get compiler/linter diagnostics (errors, warnings) for files in the project.
 * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
 * `hover`: Get type information and documentation at a cursor position.
 * `initial_instructions`: Provides instructions on how to use the Serena toolbox.

--- a/docs/01-about/035_tools.md
+++ b/docs/01-about/035_tools.md
@@ -6,6 +6,7 @@ Note that in most configurations, only a subset of these tools will be enabled s
 
 * `activate_project`: Activates a project based on the project name or path.
 * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+* `completion`: Get code completion suggestions at a cursor position.
 * `create_text_file`: Creates/overwrites a file in the project directory.
 * `delete_lines`: Deletes a range of lines within a file.
 * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
@@ -17,7 +18,9 @@ Note that in most configurations, only a subset of these tools will be enabled s
 * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools,
   contexts, and modes.
 * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+* `hover`: Get type information and documentation at a cursor position.
 * `initial_instructions`: Provides instructions on how to use the Serena toolbox.
+* `inlay_hints`: Get type hints and parameter names for a code range.
 * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
 * `insert_at_line`: Inserts content at a given line in a file.
 * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.

--- a/src/serena/symbol.py
+++ b/src/serena/symbol.py
@@ -502,6 +502,9 @@ class LanguageServerSymbolRetriever:
     def get_language_server(self, relative_path: str) -> SolidLanguageServer:
         return self._ls_manager.get_language_server(relative_path)
 
+    def get_all_language_servers(self) -> Iterator[SolidLanguageServer]:
+        return self._ls_manager.iter_language_servers()
+
     def find(
         self,
         name_path_pattern: str,

--- a/src/solidlsp/language_servers/al_language_server.py
+++ b/src/solidlsp/language_servers/al_language_server.py
@@ -450,6 +450,7 @@ class ALLanguageServer(SolidLanguageServer):
                         },
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "definition": {"dynamicRegistration": True, "linkSupport": True},
                     "references": {"dynamicRegistration": True},
                     "documentHighlight": {"dynamicRegistration": True},

--- a/src/solidlsp/language_servers/al_language_server.py
+++ b/src/solidlsp/language_servers/al_language_server.py
@@ -495,6 +495,7 @@ class ALLanguageServer(SolidLanguageServer):
 
         def publish_diagnostics(params: dict) -> None:
             # AL server publishes diagnostics during initialization
+            self._handle_publish_diagnostics(params)
             uri = params.get("uri", "")
             diagnostics = params.get("diagnostics", [])
             log.debug(f"AL LSP: Diagnostics for {uri}: {len(diagnostics)} issues")

--- a/src/solidlsp/language_servers/bash_language_server.py
+++ b/src/solidlsp/language_servers/bash_language_server.py
@@ -155,7 +155,7 @@ class BashLanguageServer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Bash server process")
         self.server.start()

--- a/src/solidlsp/language_servers/bash_language_server.py
+++ b/src/solidlsp/language_servers/bash_language_server.py
@@ -102,6 +102,7 @@ class BashLanguageServer(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                 },

--- a/src/solidlsp/language_servers/clangd_language_server.py
+++ b/src/solidlsp/language_servers/clangd_language_server.py
@@ -194,7 +194,7 @@ class ClangdLanguageServer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)
 

--- a/src/solidlsp/language_servers/clangd_language_server.py
+++ b/src/solidlsp/language_servers/clangd_language_server.py
@@ -130,6 +130,7 @@ class ClangdLanguageServer(SolidLanguageServer):
                     "synchronization": {"didSave": True, "dynamicRegistration": True},
                     "completion": {"dynamicRegistration": True, "completionItem": {"snippetSupport": True}},
                     "definition": {"dynamicRegistration": True},
+                    "inlayHint": {"dynamicRegistration": True},
                 },
                 "workspace": {"workspaceFolders": True, "didChangeConfiguration": {"dynamicRegistration": True}},
             },

--- a/src/solidlsp/language_servers/clojure_lsp.py
+++ b/src/solidlsp/language_servers/clojure_lsp.py
@@ -144,6 +144,7 @@ class ClojureLSP(SolidLanguageServer):
                     "definition": {"linkSupport": True},
                     "references": {},
                     "hover": {"contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "documentSymbol": {
                         "hierarchicalDocumentSymbolSupport": True,
                         "symbolKind": {"valueSet": list(range(1, 27))},  #

--- a/src/solidlsp/language_servers/clojure_lsp.py
+++ b/src/solidlsp/language_servers/clojure_lsp.py
@@ -192,7 +192,7 @@ class ClojureLSP(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)
 

--- a/src/solidlsp/language_servers/csharp_language_server.py
+++ b/src/solidlsp/language_servers/csharp_language_server.py
@@ -634,7 +634,7 @@ class CSharpLanguageServer(SolidLanguageServer):
         # Set up notification handlers
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", handle_progress)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("workspace/projectInitializationComplete", handle_workspace_indexing_complete)
         self.server.on_request("workspace/configuration", handle_workspace_configuration)
         self.server.on_request("window/workDoneProgress/create", handle_work_done_progress_create)

--- a/src/solidlsp/language_servers/csharp_language_server.py
+++ b/src/solidlsp/language_servers/csharp_language_server.py
@@ -501,6 +501,7 @@ class CSharpLanguageServer(SolidLanguageServer):
                     "textDocument": {
                         "synchronization": {"dynamicRegistration": True, "willSave": True, "willSaveWaitUntil": True, "didSave": True},
                         "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                        "inlayHint": {"dynamicRegistration": True},
                         "signatureHelp": {
                             "dynamicRegistration": True,
                             "signatureInformation": {

--- a/src/solidlsp/language_servers/dart_language_server.py
+++ b/src/solidlsp/language_servers/dart_language_server.py
@@ -141,7 +141,7 @@ class DartLanguageServer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)
 

--- a/src/solidlsp/language_servers/dart_language_server.py
+++ b/src/solidlsp/language_servers/dart_language_server.py
@@ -93,7 +93,11 @@ class DartLanguageServer(SolidLanguageServer):
         """
         root_uri = pathlib.Path(repository_absolute_path).as_uri()
         initialize_params = {
-            "capabilities": {},
+            "capabilities": {
+                "textDocument": {
+                    "inlayHint": {"dynamicRegistration": True},
+                },
+            },
             "initializationOptions": {
                 "onlyAnalyzeProjectsWithOpenFiles": False,
                 "closingLabels": False,

--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -48,6 +48,8 @@ class EclipseJDTLS(SolidLanguageServer):
     You can configure the following options in ls_specific_settings (in serena_config.yml):
         - maven_user_settings: Path to Maven settings.xml file (default: ~/.m2/settings.xml)
         - gradle_user_home: Path to Gradle user home directory (default: ~/.gradle)
+        - enable_maven: Enable Maven project detection (default: true)
+        - enable_gradle: Enable Gradle project detection (default: true)
 
     Note: Gradle wrapper is disabled by default. Projects will use the bundled Gradle distribution.
 
@@ -59,6 +61,8 @@ class EclipseJDTLS(SolidLanguageServer):
         # maven_user_settings: 'C:\\Users\\YourName\\.m2\\settings.xml'  # Windows (use single quotes!)
         gradle_user_home: "/home/user/.gradle"  # Unix/Linux/Mac
         # gradle_user_home: 'C:\\Users\\YourName\\.gradle'  # Windows (use single quotes!)
+        enable_maven: true   # Set to false to disable Maven project detection
+        enable_gradle: true  # Set to false to disable Gradle project detection
     ```
     """
 
@@ -384,6 +388,10 @@ class EclipseJDTLS(SolidLanguageServer):
             gradle_user_home = None
             log.info(f"Gradle user home not found at default location ({default_gradle_home}), will use JDTLS defaults")
 
+        # Build system enable flags: default to True for backward compatibility
+        enable_maven = self._custom_settings.get("enable_maven", True)
+        enable_gradle = self._custom_settings.get("enable_gradle", True)
+
         initialize_params = {
             "locale": "en",
             "rootPath": repository_absolute_path,
@@ -583,12 +591,12 @@ class EclipseJDTLS(SolidLanguageServer):
                         "trace": {"server": "verbose"},
                         "import": {
                             "maven": {
-                                "enabled": True,
+                                "enabled": enable_maven,
                                 "offline": {"enabled": False},
                                 "disableTestClasspathFlag": False,
                             },
                             "gradle": {
-                                "enabled": True,
+                                "enabled": enable_gradle,
                                 "wrapper": {"enabled": False},
                                 "version": None,
                                 "home": "abs(static/gradle-7.3.3)",

--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -465,6 +465,7 @@ class EclipseJDTLS(SolidLanguageServer):
                         "completionList": {"itemDefaults": ["commitCharacters", "editRange", "insertTextFormat", "insertTextMode"]},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {
                         "dynamicRegistration": True,
                         "signatureInformation": {

--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -756,7 +756,7 @@ class EclipseJDTLS(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
 
         log.info("Starting EclipseJDTLS server process")

--- a/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
+++ b/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
@@ -310,7 +310,7 @@ class ElixirTools(SolidLanguageServer):
 
         def publish_diagnostics(params: Any) -> None:
             """Handle textDocument/publishDiagnostics notifications."""
-            return
+            self._handle_publish_diagnostics(params)
 
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)

--- a/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
+++ b/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
@@ -228,6 +228,7 @@ class ElixirTools(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "formatting": {"dynamicRegistration": True},
                     "codeAction": {
                         "dynamicRegistration": True,

--- a/src/solidlsp/language_servers/elm_language_server.py
+++ b/src/solidlsp/language_servers/elm_language_server.py
@@ -151,7 +151,7 @@ class ElmLanguageServer(SolidLanguageServer):
 
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Elm server process")
         self.server.start()

--- a/src/solidlsp/language_servers/elm_language_server.py
+++ b/src/solidlsp/language_servers/elm_language_server.py
@@ -109,6 +109,7 @@ class ElmLanguageServer(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                     "rename": {"dynamicRegistration": True},
                 },

--- a/src/solidlsp/language_servers/erlang_language_server.py
+++ b/src/solidlsp/language_servers/erlang_language_server.py
@@ -125,7 +125,7 @@ class ErlangLanguageServer(SolidLanguageServer):
         self.server.on_notification("$/progress", check_server_ready)
         self.server.on_notification("window/workDoneProgress/create", do_nothing)
         self.server.on_notification("$/workDoneProgress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Erlang LS server process")
         self.server.start()

--- a/src/solidlsp/language_servers/erlang_language_server.py
+++ b/src/solidlsp/language_servers/erlang_language_server.py
@@ -143,6 +143,7 @@ class ErlangLanguageServer(SolidLanguageServer):
                     "references": {"dynamicRegistration": True},
                     "documentSymbol": {"dynamicRegistration": True},
                     "hover": {"dynamicRegistration": True},
+                    "inlayHint": {"dynamicRegistration": True},
                 }
             },
         }

--- a/src/solidlsp/language_servers/fortran_language_server.py
+++ b/src/solidlsp/language_servers/fortran_language_server.py
@@ -261,7 +261,7 @@ class FortranLanguageServer(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Fortran Language Server (fortls) process")
         self.server.start()

--- a/src/solidlsp/language_servers/fortran_language_server.py
+++ b/src/solidlsp/language_servers/fortran_language_server.py
@@ -212,6 +212,7 @@ class FortranLanguageServer(SolidLanguageServer):
                         },
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "definition": {"dynamicRegistration": True},
                     "references": {"dynamicRegistration": True},
                     "documentSymbol": {

--- a/src/solidlsp/language_servers/fsharp_language_server.py
+++ b/src/solidlsp/language_servers/fsharp_language_server.py
@@ -347,6 +347,7 @@ class FSharpLanguageServer(SolidLanguageServer):
         # Register custom handlers
         self.server.on_notification("window/logMessage", handle_window_log_message)
         self.server.on_notification("window/showMessage", handle_window_show_message)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_request("workspace/configuration", handle_workspace_configuration)
         self.server.on_request("client/registerCapability", handle_client_register_capability)
         self.server.on_request("client/unregisterCapability", handle_client_unregister_capability)

--- a/src/solidlsp/language_servers/fsharp_language_server.py
+++ b/src/solidlsp/language_servers/fsharp_language_server.py
@@ -170,6 +170,7 @@ class FSharpLanguageServer(SolidLanguageServer):
                         "dynamicRegistration": True,
                         "contentFormat": ["markdown", "plaintext"],
                     },
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {
                         "dynamicRegistration": True,
                         "signatureInformation": {"documentationFormat": ["markdown", "plaintext"]},

--- a/src/solidlsp/language_servers/gopls.py
+++ b/src/solidlsp/language_servers/gopls.py
@@ -115,6 +115,7 @@ class Gopls(SolidLanguageServer):
                         "hierarchicalDocumentSymbolSupport": True,
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
+                    "inlayHint": {"dynamicRegistration": True},
                 },
                 "workspace": {"workspaceFolders": True, "didChangeConfiguration": {"dynamicRegistration": True}},
             },

--- a/src/solidlsp/language_servers/gopls.py
+++ b/src/solidlsp/language_servers/gopls.py
@@ -146,7 +146,7 @@ class Gopls(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting gopls server process")
         self.server.start()

--- a/src/solidlsp/language_servers/groovy_language_server.py
+++ b/src/solidlsp/language_servers/groovy_language_server.py
@@ -201,6 +201,7 @@ class GroovyLanguageServer(SolidLanguageServer):
                     "synchronization": {"dynamicRegistration": True, "didSave": True},
                     "completion": {"dynamicRegistration": True},
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "definition": {"dynamicRegistration": True},
                     "references": {"dynamicRegistration": True},
                     "documentSymbol": {"dynamicRegistration": True},

--- a/src/solidlsp/language_servers/groovy_language_server.py
+++ b/src/solidlsp/language_servers/groovy_language_server.py
@@ -251,7 +251,7 @@ class GroovyLanguageServer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
 
         log.info("Starting Groovy server process")

--- a/src/solidlsp/language_servers/haskell_language_server.py
+++ b/src/solidlsp/language_servers/haskell_language_server.py
@@ -359,7 +359,7 @@ class HaskellLanguageServer(SolidLanguageServer):
 
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_request("workspace/configuration", workspace_configuration_handler)
 

--- a/src/solidlsp/language_servers/haskell_language_server.py
+++ b/src/solidlsp/language_servers/haskell_language_server.py
@@ -169,6 +169,7 @@ class HaskellLanguageServer(SolidLanguageServer):
                         },
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {
                         "dynamicRegistration": True,
                         "signatureInformation": {

--- a/src/solidlsp/language_servers/intelephense.py
+++ b/src/solidlsp/language_servers/intelephense.py
@@ -112,6 +112,7 @@ class Intelephense(SolidLanguageServer):
                 "textDocument": {
                     "synchronization": {"didSave": True, "dynamicRegistration": True},
                     "definition": {"dynamicRegistration": True},
+                    "inlayHint": {"dynamicRegistration": True},
                 },
                 "workspace": {"workspaceFolders": True, "didChangeConfiguration": {"dynamicRegistration": True}},
             },

--- a/src/solidlsp/language_servers/intelephense.py
+++ b/src/solidlsp/language_servers/intelephense.py
@@ -157,7 +157,7 @@ class Intelephense(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Intelephense server process")
         self.server.start()

--- a/src/solidlsp/language_servers/jedi_server.py
+++ b/src/solidlsp/language_servers/jedi_server.py
@@ -174,7 +174,7 @@ class JediServer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)
 

--- a/src/solidlsp/language_servers/julia_server.py
+++ b/src/solidlsp/language_servers/julia_server.py
@@ -130,6 +130,7 @@ class JuliaLanguageServer(SolidLanguageServer):
                     "definition": {"dynamicRegistration": True},
                     "references": {"dynamicRegistration": True},
                     "documentSymbol": {"dynamicRegistration": True},
+                    "inlayHint": {"dynamicRegistration": True},
                 },
             },
             "workspaceFolders": [

--- a/src/solidlsp/language_servers/julia_server.py
+++ b/src/solidlsp/language_servers/julia_server.py
@@ -153,7 +153,7 @@ class JuliaLanguageServer(SolidLanguageServer):
 
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting LanguageServer.jl server process")
         self.server.start()

--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -463,7 +463,7 @@ class KotlinLanguageServer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
 
         log.info("Starting Kotlin server process")

--- a/src/solidlsp/language_servers/lua_ls.py
+++ b/src/solidlsp/language_servers/lua_ls.py
@@ -266,7 +266,7 @@ class LuaLanguageServer(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Lua Language Server process")
         self.server.start()

--- a/src/solidlsp/language_servers/lua_ls.py
+++ b/src/solidlsp/language_servers/lua_ls.py
@@ -196,6 +196,7 @@ class LuaLanguageServer(SolidLanguageServer):
                         "dynamicRegistration": True,
                         "contentFormat": ["markdown", "plaintext"],
                     },
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {
                         "dynamicRegistration": True,
                         "signatureInformation": {

--- a/src/solidlsp/language_servers/marksman.py
+++ b/src/solidlsp/language_servers/marksman.py
@@ -163,7 +163,7 @@ class Marksman(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting marksman server process")
         self.server.start()

--- a/src/solidlsp/language_servers/marksman.py
+++ b/src/solidlsp/language_servers/marksman.py
@@ -128,6 +128,7 @@ class Marksman(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},  # type: ignore[arg-type]
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},  # type: ignore[list-item]
+                    "inlayHint": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                 },
                 "workspace": {

--- a/src/solidlsp/language_servers/nixd_ls.py
+++ b/src/solidlsp/language_servers/nixd_ls.py
@@ -284,6 +284,7 @@ class NixLanguageServer(SolidLanguageServer):
                         "dynamicRegistration": True,
                         "contentFormat": ["markdown", "plaintext"],
                     },
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {
                         "dynamicRegistration": True,
                         "signatureInformation": {

--- a/src/solidlsp/language_servers/nixd_ls.py
+++ b/src/solidlsp/language_servers/nixd_ls.py
@@ -359,7 +359,7 @@ class NixLanguageServer(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting nixd server process")
         self.server.start()

--- a/src/solidlsp/language_servers/omnisharp.py
+++ b/src/solidlsp/language_servers/omnisharp.py
@@ -348,7 +348,7 @@ class OmniSharp(SolidLanguageServer):
         self.server.on_notification("language/status", lang_status_handler)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)
         self.server.on_request("workspace/configuration", workspace_configuration_handler)

--- a/src/solidlsp/language_servers/perl_language_server.py
+++ b/src/solidlsp/language_servers/perl_language_server.py
@@ -173,7 +173,7 @@ class PerlLanguageServer(SolidLanguageServer):
         self.server.on_request("workspace/configuration", workspace_configuration_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Perl::LanguageServer process")
         self.server.start()

--- a/src/solidlsp/language_servers/perl_language_server.py
+++ b/src/solidlsp/language_servers/perl_language_server.py
@@ -126,6 +126,7 @@ class PerlLanguageServer(SolidLanguageServer):
                     "references": {"dynamicRegistration": True},
                     "documentSymbol": {"dynamicRegistration": True},
                     "hover": {"dynamicRegistration": True},
+                    "inlayHint": {"dynamicRegistration": True},
                 },
                 "workspace": {
                     "workspaceFolders": True,

--- a/src/solidlsp/language_servers/powershell_language_server.py
+++ b/src/solidlsp/language_servers/powershell_language_server.py
@@ -296,7 +296,7 @@ class PowerShellLanguageServer(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("powerShell/executionStatusChanged", do_nothing)
 
         log.info("Starting PowerShell Editor Services process")

--- a/src/solidlsp/language_servers/powershell_language_server.py
+++ b/src/solidlsp/language_servers/powershell_language_server.py
@@ -229,6 +229,7 @@ class PowerShellLanguageServer(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {
                         "dynamicRegistration": True,
                         "signatureInformation": {

--- a/src/solidlsp/language_servers/pyright_server.py
+++ b/src/solidlsp/language_servers/pyright_server.py
@@ -162,7 +162,7 @@ class PyrightServer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)
 

--- a/src/solidlsp/language_servers/r_language_server.py
+++ b/src/solidlsp/language_servers/r_language_server.py
@@ -138,7 +138,7 @@ class RLanguageServer(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting R Language Server process")
         self.server.start()

--- a/src/solidlsp/language_servers/r_language_server.py
+++ b/src/solidlsp/language_servers/r_language_server.py
@@ -90,6 +90,7 @@ class RLanguageServer(SolidLanguageServer):
                         },
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "definition": {"dynamicRegistration": True},
                     "references": {"dynamicRegistration": True},
                     "documentSymbol": {

--- a/src/solidlsp/language_servers/regal_server.py
+++ b/src/solidlsp/language_servers/regal_server.py
@@ -114,7 +114,7 @@ class RegalLanguageServer(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Regal language server process")
         self.server.start()

--- a/src/solidlsp/language_servers/regal_server.py
+++ b/src/solidlsp/language_servers/regal_server.py
@@ -81,6 +81,7 @@ class RegalLanguageServer(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},  # type: ignore[arg-type]
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},  # type: ignore[list-item]
+                    "inlayHint": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                     "formatting": {"dynamicRegistration": True},
                 },

--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -398,7 +398,7 @@ class RubyLsp(SolidLanguageServer):
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", progress_handler)
         self.server.on_request("window/workDoneProgress/create", window_work_done_progress_create)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting ruby-lsp server process")
         self.server.start()

--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -319,6 +319,7 @@ class RubyLsp(SolidLanguageServer):
                             "commitCharactersSupport": True,
                         }
                     },
+                    "inlayHint": {"dynamicRegistration": True},
                 },
             },
             "initializationOptions": {

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -631,7 +631,7 @@ class RustAnalyzer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)
 

--- a/src/solidlsp/language_servers/scala_language_server.py
+++ b/src/solidlsp/language_servers/scala_language_server.py
@@ -165,6 +165,9 @@ class ScalaLanguageServer(SolidLanguageServer):
         """
         Starts the Scala Language Server
         """
+        # Register notification handlers
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
+
         log.info("Starting Scala server process")
         self.server.start()
 

--- a/src/solidlsp/language_servers/scala_language_server.py
+++ b/src/solidlsp/language_servers/scala_language_server.py
@@ -152,7 +152,12 @@ class ScalaLanguageServer(SolidLanguageServer):
                 "copyWorksheetOutputProvider": False,
                 "doctorVisibilityProvider": False,
             },
-            "capabilities": {"textDocument": {"documentSymbol": {"hierarchicalDocumentSymbolSupport": True}}},
+            "capabilities": {
+                "textDocument": {
+                    "documentSymbol": {"hierarchicalDocumentSymbolSupport": True},
+                    "inlayHint": {"dynamicRegistration": True},
+                }
+            },
         }
         return initialize_params  # type: ignore
 

--- a/src/solidlsp/language_servers/solargraph.py
+++ b/src/solidlsp/language_servers/solargraph.py
@@ -336,7 +336,7 @@ class Solargraph(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("language/actionableNotification", do_nothing)
 
         log.info("Starting solargraph server process")

--- a/src/solidlsp/language_servers/sourcekit_lsp.py
+++ b/src/solidlsp/language_servers/sourcekit_lsp.py
@@ -316,7 +316,7 @@ class SourceKitLSP(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting sourcekit-lsp server process")
         self.server.start()

--- a/src/solidlsp/language_servers/taplo_server.py
+++ b/src/solidlsp/language_servers/taplo_server.py
@@ -289,7 +289,7 @@ class TaploServer(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Taplo server process")
         self.server.start()

--- a/src/solidlsp/language_servers/taplo_server.py
+++ b/src/solidlsp/language_servers/taplo_server.py
@@ -251,6 +251,7 @@ class TaploServer(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                 },
                 "workspace": {

--- a/src/solidlsp/language_servers/terraform_ls.py
+++ b/src/solidlsp/language_servers/terraform_ls.py
@@ -218,7 +218,7 @@ class TerraformLS(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting terraform-ls server process")
         self.server.start()

--- a/src/solidlsp/language_servers/terraform_ls.py
+++ b/src/solidlsp/language_servers/terraform_ls.py
@@ -190,6 +190,7 @@ class TerraformLS(SolidLanguageServer):
                         "hierarchicalDocumentSymbolSupport": True,
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
+                    "inlayHint": {"dynamicRegistration": True},
                 },
                 "workspace": {"workspaceFolders": True, "didChangeConfiguration": {"dynamicRegistration": True}},
             },

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -203,6 +203,7 @@ class TypeScriptLanguageServer(SolidLanguageServer):
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
                     "inlayHint": {"dynamicRegistration": True},
+                    "publishDiagnostics": {"relatedInformation": True},
                     "signatureHelp": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                     "rename": {"dynamicRegistration": True, "prepareSupport": True},
@@ -270,7 +271,7 @@ class TypeScriptLanguageServer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)
 
         log.info("Starting TypeScript server process")

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -202,6 +202,7 @@ class TypeScriptLanguageServer(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                     "rename": {"dynamicRegistration": True, "prepareSupport": True},

--- a/src/solidlsp/language_servers/vts_language_server.py
+++ b/src/solidlsp/language_servers/vts_language_server.py
@@ -194,7 +194,7 @@ class VtsLanguageServer(SolidLanguageServer):
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_request("workspace/configuration", workspace_configuration_handler)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)
 
         log.info("Starting VTS server process")

--- a/src/solidlsp/language_servers/vts_language_server.py
+++ b/src/solidlsp/language_servers/vts_language_server.py
@@ -121,6 +121,7 @@ class VtsLanguageServer(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                 },

--- a/src/solidlsp/language_servers/vue_language_server.py
+++ b/src/solidlsp/language_servers/vue_language_server.py
@@ -669,7 +669,7 @@ class VueLanguageServer(SolidLanguageServer):
         self.server.on_notification("tsserver/request", tsserver_request_notification_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting Vue server process")
         self.server.start()

--- a/src/solidlsp/language_servers/vue_language_server.py
+++ b/src/solidlsp/language_servers/vue_language_server.py
@@ -494,6 +494,7 @@ class VueLanguageServer(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "signatureHelp": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                     "rename": {"dynamicRegistration": True, "prepareSupport": True},

--- a/src/solidlsp/language_servers/yaml_language_server.py
+++ b/src/solidlsp/language_servers/yaml_language_server.py
@@ -165,7 +165,7 @@ class YamlLanguageServer(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting YAML server process")
         self.server.start()

--- a/src/solidlsp/language_servers/yaml_language_server.py
+++ b/src/solidlsp/language_servers/yaml_language_server.py
@@ -118,6 +118,7 @@ class YamlLanguageServer(SolidLanguageServer):
                         "symbolKind": {"valueSet": list(range(1, 27))},
                     },
                     "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "inlayHint": {"dynamicRegistration": True},
                     "codeAction": {"dynamicRegistration": True},
                 },
                 "workspace": {

--- a/src/solidlsp/language_servers/zls.py
+++ b/src/solidlsp/language_servers/zls.py
@@ -135,6 +135,7 @@ class ZigLanguageServer(SolidLanguageServer):
                         "dynamicRegistration": True,
                         "contentFormat": ["markdown", "plaintext"],
                     },
+                    "inlayHint": {"dynamicRegistration": True},
                 },
                 "workspace": {
                     "workspaceFolders": True,

--- a/src/solidlsp/language_servers/zls.py
+++ b/src/solidlsp/language_servers/zls.py
@@ -198,7 +198,7 @@ class ZigLanguageServer(SolidLanguageServer):
         self.server.on_request("client/registerCapability", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_notification("$/progress", do_nothing)
-        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", self._handle_publish_diagnostics)
 
         log.info("Starting ZLS server process")
         self.server.start()


### PR DESCRIPTION
## Notes
- Adding the following tools:
  -  `completion`: suggested autocompletions. Allows AI agents to discover what members a symbol has, especially useful for dependencies where it may not able to read the source easily.
  - `hover`: to get documentation of symbol, especially useful for dependencies where it may not be able to read the source easily.
  - `inlay_hints`: to see type hints
  - `get_diagnostics`: shows any LSP reported errors or warnings, helpful for agents to know if they have made errors without having to build; allows agents to see warnings (e.g. deprecation warnings) which they would not have seen otherwise.
- Additionally adding settings to Eclipse JDTLS to disable maven/gradle project discovery. In certain circumstances I would like to be able to force it to use the Eclipse project setup by disabling maven and gradle project discovery.

## Issues
#841 

## Testing
Tested manually with Java (Eclipse JDTLS), TypeScript, Python and Rust languages. 
- Java: `completion`, `hover` and `get_diagnostics` work as expected. `inlay_hints` always returns an empty list.
- TypeScript: `completion`, `hover` and `get_diagnostics` work as expected. `inlay_hints` always returns an empty list - I think something in the LSP needs to be enabled for these to be visible.
- Python: `completion`, `hover` and `get_diagnostics` work as expected. Pyright does not support inlay hints.
- Rust: All four tools work and give non-empty response.

