### PR TITLE
Fix linux-musl platform ID string format

### DIFF
--- a/src/solidlsp/ls_utils.py
+++ b/src/solidlsp/ls_utils.py
@@ -324,7 +324,8 @@ class PlatformUtils:
             if system == "Linux" and bitness == "64bit":
                 libc = platform.libc_ver()[0]
                 if libc != "glibc":
-                    platform_id += "-" + libc
+                    # Format: linux-musl-arch (e.g., linux-musl-arm64)
+                    platform_id = f"{system_map[system]}-{libc}-{machine_map[machine]}"
             return PlatformId(platform_id)
         else:
             raise SolidLSPException(f"Unknown platform: {system=}, {machine=}, {bitness=}")


### PR DESCRIPTION
## Summary
- Fix `get_platform_id()` generating incorrect platform ID string for musl-based Linux systems
- The function was producing `linux-arm64-musl` but the `PlatformId` enum expects `linux-musl-arm64`
- This caused `ValueError: 'linux-arm64-musl' is not a valid PlatformId` on Alpine Linux arm64 and similar systems

## Test plan
- [x] Verified the fix matches the existing enum values (`linux-musl-x64`, `linux-musl-arm64`)
- [x] Test on musl-based Linux (e.g., Alpine Linux on arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)