### PR TITLE
fix(java): add missing linux-arm64 configuration for Eclipse JDTLS

### DIFF
--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -215,6 +215,11 @@ class EclipseJDTLS(SolidLanguageServer):
                     "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-linux-arm64-1.42.0-561.vsix",
                     "archiveType": "zip",
                     "relative_extraction_path": "vscode-java",
+                    "jre_home_path": "extension/jre/21.0.7-linux-aarch64",
+                    "jre_path": "extension/jre/21.0.7-linux-aarch64/bin/java",
+                    "lombok_jar_path": "extension/lombok/lombok-1.18.36.jar",
+                    "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.7.0.v20250424-1814.jar",
+                    "jdtls_readonly_config_path": "extension/server/config_linux_arm",
                 },
                 "linux-x64": {
                     "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.42.0/java-linux-x64-1.42.0-561.vsix",


### PR DESCRIPTION
The linux-arm64 platform entry was missing required fields (jre_home_path, jre_path, lombok_jar_path, jdtls_launcher_jar_path, jdtls_readonly_config_path) causing a KeyError when activating Java projects on ARM64 Linux systems.

Fixes #486