### PR TITLE
SolidLSP (TypeScript): ensure didOpen before textDocument/rename to avoid null edits

### DIFF
--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -1856,7 +1856,8 @@ class SolidLanguageServer(ABC):
             newName=new_name,
         )
 
-        return self.server.send.rename(params)
+        with self.open_file(relative_file_path):
+            return self.server.send.rename(params)
 
     def apply_text_edits_to_file(self, relative_path: str, edits: list[ls_types.TextEdit]) -> None:
         """

--- a/test/solidlsp/test_rename_didopen.py
+++ b/test/solidlsp/test_rename_didopen.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+
+from solidlsp.ls import SolidLanguageServer
+
+
+class DummyLanguageServer(SolidLanguageServer):
+    def _start_server(self) -> None:
+        raise AssertionError("Not used in this test")
+
+
+def test_request_rename_symbol_edit_opens_file_before_rename(tmp_path) -> None:
+    (tmp_path / "index.ts").write_text("export const x = 1;\n", encoding="utf-8")
+
+    events: list[str] = []
+
+    notify = MagicMock()
+    notify.did_open_text_document.side_effect = lambda *_args, **_kwargs: events.append("didOpen")
+    notify.did_close_text_document.side_effect = lambda *_args, **_kwargs: events.append("didClose")
+
+    send = MagicMock()
+    send.rename.side_effect = lambda *_args, **_kwargs: events.append("rename")
+
+    server = MagicMock()
+    server.notify = notify
+    server.send = send
+
+    language_server = object.__new__(DummyLanguageServer)
+    language_server.repository_root_path = str(tmp_path)
+    language_server.server_started = True
+    language_server.open_file_buffers = {}
+    language_server._encoding = "utf-8"
+    language_server.language_id = "typescript"
+    language_server.server = server
+
+    result = language_server.request_rename_symbol_edit(
+        relative_file_path="index.ts",
+        line=0,
+        column=0,
+        new_name="y",
+    )
+    assert result is None
+    assert events == ["didOpen", "rename", "didClose"]


### PR DESCRIPTION
Fixes #927

## Summary

TypeScript renames via the LSP backend can fail with “no rename edits” because `typescript-language-server` may return `null` for `textDocument/rename` when the target document has not been opened via `textDocument/didOpen`.

This PR makes SolidLSP’s rename request path consistent with other request paths by ensuring the target file is opened before sending `textDocument/rename`.

## What changed

- Wrap `request_rename_symbol_edit(...)`’s rename request in `open_file(...)`, so `didOpen` is sent before `textDocument/rename` and `didClose` after.
- Add a small regression unit test (mock-based) asserting the call order `didOpen → rename → didClose` (no real TS language server startup required).

## Tests

- Added: `test/solidlsp/test_rename_didopen.py`
- Local (targeted): `pytest -q -o addopts= --confcutdir=test/solidlsp test/solidlsp/test_rename_didopen.py`

## Notes / trade-offs

- Overhead: adds one `didOpen`/`didClose` pair per rename request (rename is typically low-frequency).
- As with other filesystem-based flows, if a user has unsaved editor buffers, reading from disk may not reflect in-memory edits; this is outside the scope of this change.

## Files changed

- `src/solidlsp/ls.py`
- `test/solidlsp/test_rename_didopen.py`