### PR TITLE
Add SERENA_JETBRAINS_HOST env var for remote IDE connections

### DIFF
--- a/docs/02-usage/025_jetbrains_plugin.md
+++ b/docs/02-usage/025_jetbrains_plugin.md
@@ -62,5 +62,31 @@ will be available exclusively through the JetBrains plugin.
 We realize that not everyone uses a JetBrains IDE as their main code editor.
 You can still take advantage of the JetBrains plugin by running a JetBrains IDE instance alongside your
 preferred editor. Most JetBrains IDEs have a free community edition that you can use for this purpose.
-You just need to make sure that the project you are working on is open and indexed in the JetBrains IDE, 
+You just need to make sure that the project you are working on is open and indexed in the JetBrains IDE,
 so that Serena can connect to it.
+
+## IDE on a Different Host
+
+If your JetBrains IDE runs on a different host than Serena (e.g., IDE on Windows with Serena in WSL2,
+or Serena in a Docker container), you can configure the host address using the `SERENA_JETBRAINS_HOST`
+environment variable:
+
+```bash
+export SERENA_JETBRAINS_HOST=192.168.16.1
+```
+
+Or in your MCP client configuration (e.g., `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "serena": {
+      "env": {
+        "SERENA_JETBRAINS_HOST": "192.168.16.1"
+      }
+    }
+  }
+}
+```
+
+Replace `192.168.16.1` with the IP address of the host where your JetBrains IDE is running.

--- a/src/serena/tools/jetbrains_plugin_client.py
+++ b/src/serena/tools/jetbrains_plugin_client.py
@@ -4,6 +4,7 @@ Client for the Serena JetBrains Plugin
 
 import json
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Any, Literal, Optional, Self, TypeVar, cast
@@ -75,7 +76,8 @@ class JetBrainsPluginClient(ToStringMixin):
 
     def __init__(self, port: int, timeout: int = PLUGIN_REQUEST_TIMEOUT):
         self._port = port
-        self._base_url = f"http://127.0.0.1:{port}"
+        host = os.environ.get("SERENA_JETBRAINS_HOST", "127.0.0.1")
+        self._base_url = f"http://{host}:{port}"
         self._timeout = timeout
         self._session = requests.Session()
         self._session.headers.update({"Content-Type": "application/json", "Accept": "application/json"})


### PR DESCRIPTION
Hey Guys,

so excited about the jetbrains plugin, currently setting this up. I had this idea, too, but very happy that you implemented this now.

I hit a configuration issue though.

I run all my projects within WSL2 and my IDE runs on the windows host. Therefore serena (and e.g. php with xdebug) cannot connect to localhost. You need the IP address of your windows host (instead of using 127.0.0.1).

Now 127.0.0.1 was hardcoded.

This PR now changes that. 

When the JetBrains IDE runs on a different host than Serena (e.g., IDE on Windows with Serena in WSL2, or Serena in a Docker container), the plugin client now supports configuring the host via the SERENA_JETBRAINS_HOST environment variable.