### PR TITLE
Clarify `repl` parameter: backslash escapes are not expanded (GPT-5.2-codex fix)

### DIFF
--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -190,7 +190,7 @@ class ReplaceContentTool(Tool, ToolMarkerCanEdit):
             If `mode` is "literal", this string will be matched exactly.
             If `mode` is "regex", this string will be treated as a regular expression (syntax of Python's `re` module,
             with flags DOTALL and MULTILINE enabled).
-        :param repl: the replacement string (verbatim).
+        :param repl: the replacement string (used as-is; backslash escapes are not expanded).
             If mode is "regex", the string can contain backreferences to matched groups in the needle regex,
             specified using the syntax $!1, $!2, etc. for groups 1, 2, etc.
         :param mode: either "literal" or "regex", specifying how the `needle` parameter is to be interpreted.

--- a/src/serena/tools/memory_tools.py
+++ b/src/serena/tools/memory_tools.py
@@ -82,7 +82,7 @@ class EditMemoryTool(Tool, ToolMarkerCanEdit):
             If `mode` is "literal", this string will be matched exactly.
             If `mode` is "regex", this string will be treated as a regular expression (syntax of Python's `re` module,
             with flags DOTALL and MULTILINE enabled).
-        :param repl: the replacement string (verbatim).
+        :param repl: the replacement string (used as-is; backslash escapes are not expanded).
         :param mode: either "literal" or "regex", specifying how the `needle` parameter is to be interpreted.
         """
         replace_content_tool = self.agent.get_tool(ReplaceContentTool)


### PR DESCRIPTION
This MR updates the tool help text for the `repl` parameter to prevent a recurring formatting failure observed with **`GPT-5.2-codex`**.

In practice, the model sometimes interprets the wording “verbatim” too literally and produces tool arguments where `repl` contains **literal escape sequences** such as `\\n` (and potentially `\\t`, etc.). Since the replacement string is applied **as-is**, those two-character sequences (`\` + `n`) get written into the target file instead of becoming real newlines/tabs, resulting in broken edits.