### PR TITLE
Adjust the activation prompt for Codex, to make GPT-5 more compliant.

### DIFF
--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -159,9 +159,11 @@ args = ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-s
 
 After codex has started, you need to activate the project, which you can do by saying:
 
-"Activate the current dir as project using serena"
+> Call serena.activate_project, serena.check_onboarding_performed and serena.initial_instructions
 
-> If you don't activate the project, you will not be able to use Serena's tools!
+**If you don't activate the project, you will not be able to use Serena's tools!**
+
+It is recommend to set this prompt as a [custom prompt](https://developers.openai.com/codex/custom-prompts), so you don't need to type this every time.
 
 That's it! Have a look at `~/.codex/log/codex-tui.log` to see if any errors occurred.
 


### PR DESCRIPTION
The previous prompt had a 15% to 30% chance that GPT-5 would forget to execute necessary tools, such as `read serena instruction`