### PR TITLE
fix: handle HTTPError in JetBrainsPluginClient initialization

### DIFF
--- a/src/serena/tools/jetbrains_plugin_client.py
+++ b/src/serena/tools/jetbrains_plugin_client.py
@@ -93,7 +93,7 @@ class JetBrainsPluginClient(ToStringMixin):
             status_response: PluginStatusDTO = cast(jb.PluginStatusDTO, self._make_request("GET", "/status"))
             self._project_root = status_response["project_root"]
             self._plugin_version = Version(status_response["plugin_version"])
-        except ConnectionError:
+        except (ConnectionError, requests.exceptions.HTTPError):
             self._project_root = None
             self._plugin_version = None
 


### PR DESCRIPTION
PR Description                                                                                                                                      
                                                                                                                                                      
  ## Summary                                                                                                                                          
                                                                                                                                                      
  This PR fixes an `AttributeError` that occurs when the JetBrains plugin service returns HTTP 503 error during initialization.                       
                                                                                                                                                      
  **Fixes #962**                                                                                                                                      
                                                                                                                                                      
  ## Problem                                                                                                                                          
                                                                                                                                                      
  When `JetBrainsPluginClient.__init__()` calls `_make_request("GET", "/status")` and receives an HTTP 503 error:                                     
  1. `requests.exceptions.HTTPError` is raised                                                                                                        
  2. The `except ConnectionError:` block doesn't catch it                                                                                             
  3. `_plugin_version` and `_project_root` are never initialized                                                                                      
  4. Later code in `_make_request` exception handler calls `is_version_at_least()` which accesses `self._plugin_version`                              
  5. `AttributeError: 'JetBrainsPluginClient' object has no attribute '_plugin_version'`                                                              
                                                                                                                                                      
  ## Solution                                                                                                                                         
                                                                                                                                                      
  Catch both `ConnectionError` and `requests.exceptions.HTTPError` in the `__init__` method:                                                          
                                                                                                                                                      
  ```python                                                                                                                                           
  # Before                                                                                                                                            
  except ConnectionError:                                                                                                                             
      self._project_root = None                                                                                                                       
      self._plugin_version = None                                                                                                                     
                                                                                                                                                      
  # After                                                                                                                                             
  except (ConnectionError, requests.exceptions.HTTPError):                                                                                            
      self._project_root = None                                                                                                                       
      self._plugin_version = None                                                                                                                     
                                                                                                                                                      
  This allows the port scanning logic in from_project() to continue trying other ports when one port fails with an HTTP error.                        
                                                                                                                                                      
  Test Plan                                                                                                                                           
                                                                                                                                                      
  - Verified the fix handles HTTP 503 gracefully                                                                                                      
  - Port scanning continues to next port after HTTP error        