### PR TITLE
Add Apex language support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,6 +316,7 @@ markers = [
   "slow: tests that require additional Expert instances and have long startup times (~60-90s each)",
   "toml: language server running for TOML",
   "matlab: language server running for MATLAB (requires MATLAB R2021b+)",
+  "apex: Apex language support (no LSP, basic file operations only)",
 ]
 
 [tool.codespell]

--- a/src/solidlsp/language_servers/apex_language_server.py
+++ b/src/solidlsp/language_servers/apex_language_server.py
@@ -1,0 +1,84 @@
+"""
+Provides Apex specific instantiation of the LanguageServer class.
+Contains various configurations and settings specific to Salesforce Apex.
+
+Note: This is a minimal implementation as no LSP exists for Apex.
+Only basic file operations (read_file) are supported.
+"""
+
+import logging
+
+from overrides import override
+
+from solidlsp.ls import SolidLanguageServer
+from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
+
+log = logging.getLogger(__name__)
+
+
+class ApexLanguageServer(SolidLanguageServer):
+    """
+    Provides Apex specific instantiation of the LanguageServer class.
+
+    This is a minimal implementation as no Language Server Protocol (LSP) implementation
+    exists for Apex. This class allows Apex files to be recognized and basic file
+    operations (like read_file) to work, but advanced LSP features like symbol
+    navigation, references, and completions are not available.
+
+    Supported file extensions: .cls, .trigger, .apex
+    """
+
+    def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
+        """
+        Creates an ApexLanguageServer instance. This class is not meant to be instantiated directly.
+        Use LanguageServer.create() instead.
+
+        Note: This implementation uses a dummy command since no actual LSP exists for Apex.
+        """
+        # Use a simple echo command as a placeholder since no actual LSP exists
+        # This allows the language server infrastructure to work without actually starting a process
+        super().__init__(
+            config,
+            repository_root_path,
+            ProcessLaunchInfo(cmd="echo 'Apex LSP not available'", cwd=repository_root_path),
+            "apex",
+            solidlsp_settings,
+        )
+
+    @override
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        """
+        Apex-specific directories to ignore.
+        """
+        return super().is_ignored_dirname(dirname) or dirname in [
+            ".sfdx",
+            ".sf",
+            "force-app",  # Don't ignore force-app itself, but this is here as an example
+        ]
+
+    def _start_server(self) -> None:
+        """
+        Minimal start_server implementation for Apex.
+
+        Since no actual LSP exists for Apex, this method does nothing.
+        The language server will not actually start, but file operations
+        will still work through the Project.read_file() method.
+        """
+        log.info("Apex language server: No LSP available for Apex. Only basic file operations are supported.")
+        # Don't actually start any server process
+        # The server_started flag will remain False, which is intentional
+
+    @override
+    def start(self) -> "ApexLanguageServer":
+        """
+        Override start to skip the actual server startup since no LSP exists.
+
+        :return: self for method chaining
+        """
+        log.info(f"Starting Apex language support (no LSP) for {self.repository_root_path}")
+        # Don't call _start_server_process() since we don't have an actual server
+        # Just mark as started so the infrastructure doesn't complain
+        self.server_started = True
+        return self

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -100,6 +100,11 @@ class Language(str, Enum):
     """TOML language server using Taplo.
     Supports TOML validation, formatting, and schema support.
     """
+    APEX = "apex"
+    """Apex language for Salesforce (experimental).
+    No LSP available, but basic file operations (read_file) are supported.
+    Must be explicitly specified as the main language, not auto-detected.
+    """
 
     @classmethod
     def iter_all(cls, include_experimental: bool = False) -> Iterable[Self]:
@@ -124,6 +129,7 @@ class Language(str, Enum):
             self.YAML,
             self.TOML,
             self.GROOVY,
+            self.APEX,
         }
 
     def __str__(self) -> str:
@@ -239,6 +245,8 @@ class Language(str, Enum):
                 return FilenameMatcher("*.groovy", "*.gvy")
             case self.MATLAB:
                 return FilenameMatcher("*.m", "*.mlx", "*.mlapp")
+            case self.APEX:
+                return FilenameMatcher("*.cls", "*.trigger", "*.apex")
             case _:
                 raise ValueError(f"Unhandled language: {self}")
 
@@ -412,6 +420,10 @@ class Language(str, Enum):
                 from solidlsp.language_servers.matlab_language_server import MatlabLanguageServer
 
                 return MatlabLanguageServer
+            case self.APEX:
+                from solidlsp.language_servers.apex_language_server import ApexLanguageServer
+
+                return ApexLanguageServer
             case _:
                 raise ValueError(f"Unhandled language: {self}")
 

--- a/test/resources/repos/apex/test_repo/AccountController.cls
+++ b/test/resources/repos/apex/test_repo/AccountController.cls
@@ -1,0 +1,34 @@
+/**
+ * Controller class for Account operations
+ */
+public class AccountController {
+    
+    /**
+     * Get all active accounts
+     */
+    public static List<Account> getActiveAccounts() {
+        return [SELECT Id, Name, Industry FROM Account WHERE IsActive__c = true];
+    }
+    
+    /**
+     * Create a new account
+     */
+    public static Account createAccount(String name, String industry) {
+        Account acc = new Account(
+            Name = name,
+            Industry = industry
+        );
+        insert acc;
+        return acc;
+    }
+    
+    /**
+     * Update account industry
+     */
+    public static void updateAccountIndustry(Id accountId, String newIndustry) {
+        Account acc = [SELECT Id FROM Account WHERE Id = :accountId];
+        acc.Industry = newIndustry;
+        update acc;
+    }
+}
+

--- a/test/resources/repos/apex/test_repo/AccountTrigger.trigger
+++ b/test/resources/repos/apex/test_repo/AccountTrigger.trigger
@@ -1,0 +1,38 @@
+/**
+ * Trigger for Account object
+ */
+trigger AccountTrigger on Account (before insert, before update, after insert, after update) {
+    
+    if (Trigger.isBefore) {
+        if (Trigger.isInsert) {
+            // Before insert logic
+            for (Account acc : Trigger.new) {
+                if (String.isBlank(acc.Industry)) {
+                    acc.Industry = 'Other';
+                }
+            }
+        }
+        
+        if (Trigger.isUpdate) {
+            // Before update logic
+            for (Account acc : Trigger.new) {
+                Account oldAcc = Trigger.oldMap.get(acc.Id);
+                if (acc.Name != oldAcc.Name) {
+                    acc.Description = 'Name changed from ' + oldAcc.Name + ' to ' + acc.Name;
+                }
+            }
+        }
+    }
+    
+    if (Trigger.isAfter) {
+        if (Trigger.isInsert || Trigger.isUpdate) {
+            // After insert/update logic
+            Set<Id> accountIds = new Set<Id>();
+            for (Account acc : Trigger.new) {
+                accountIds.add(acc.Id);
+            }
+            // Process accounts
+        }
+    }
+}
+

--- a/test/solidlsp/apex/__init__.py
+++ b/test/solidlsp/apex/__init__.py
@@ -1,0 +1,1 @@
+# Apex language server tests

--- a/test/solidlsp/apex/test_apex_basic.py
+++ b/test/solidlsp/apex/test_apex_basic.py
@@ -1,0 +1,107 @@
+"""
+Basic tests for Apex language support.
+
+Since no LSP exists for Apex, these tests verify that:
+1. Apex files are recognized by their extensions
+2. Basic file operations work
+3. The language server can be created (even though it doesn't start an actual LSP)
+"""
+
+from pathlib import Path
+
+import pytest
+
+from serena.project import Project
+from solidlsp.ls_config import Language
+
+
+@pytest.fixture
+def apex_test_repo():
+    """Path to the Apex test repository."""
+    return str(Path(__file__).parent.parent.parent / "resources" / "repos" / "apex" / "test_repo")
+
+
+@pytest.mark.apex
+def test_apex_language_enum():
+    """Test that Apex is in the Language enum."""
+    assert Language.APEX == "apex"
+    assert Language.APEX.value == "apex"
+
+
+@pytest.mark.apex
+def test_apex_file_extensions():
+    """Test that Apex file extensions are recognized."""
+    matcher = Language.APEX.get_source_fn_matcher()
+
+    # Should match Apex files
+    assert matcher.is_relevant_filename("AccountController.cls")
+    assert matcher.is_relevant_filename("AccountTrigger.trigger")
+    assert matcher.is_relevant_filename("SomeClass.apex")
+
+    # Should not match non-Apex files
+    assert not matcher.is_relevant_filename("test.py")
+    assert not matcher.is_relevant_filename("test.java")
+    assert not matcher.is_relevant_filename("test.js")
+
+
+@pytest.mark.apex
+def test_apex_is_experimental():
+    """Test that Apex is marked as experimental."""
+    assert Language.APEX.is_experimental()
+
+
+@pytest.mark.apex
+def test_read_apex_file(apex_test_repo):
+    """Test that Apex files can be read using the Project.read_file method."""
+    # Create a project with Apex language
+    from serena.config.serena_config import ProjectConfig
+
+    config = ProjectConfig(
+        project_name="apex_test",
+        languages=[Language.APEX],
+        encoding="utf-8",
+    )
+
+    project = Project(apex_test_repo, config)
+
+    # Read the AccountController.cls file
+    content = project.read_file("AccountController.cls")
+
+    # Verify content
+    assert "public class AccountController" in content
+    assert "getActiveAccounts" in content
+    assert "createAccount" in content
+
+    # Read the AccountTrigger.trigger file
+    trigger_content = project.read_file("AccountTrigger.trigger")
+
+    # Verify trigger content
+    assert "trigger AccountTrigger on Account" in trigger_content
+    assert "Trigger.isBefore" in trigger_content
+
+
+@pytest.mark.apex
+def test_apex_language_server_creation(apex_test_repo):
+    """Test that an Apex language server can be created (even though it won't start an actual LSP)."""
+    from solidlsp.ls_config import LanguageServerConfig
+    from solidlsp.settings import SolidLSPSettings
+
+    config = LanguageServerConfig(
+        code_language=Language.APEX,
+        encoding="utf-8",
+    )
+
+    settings = SolidLSPSettings()
+
+    # Create the language server
+    ls_class = Language.APEX.get_ls_class()
+    ls = ls_class(config, apex_test_repo, settings)
+
+    # Verify it was created
+    assert ls is not None
+    assert ls.language_id == "apex"
+    assert ls.repository_root_path == apex_test_repo
+
+    # Start the server (which should succeed even though no actual LSP starts)
+    ls.start()
+    assert ls.server_started is True


### PR DESCRIPTION
- Add APEX to Language enum in ls_config.py
- Add file extension matching for .cls, .trigger, .apex files
- Mark Apex as experimental language (not auto-detected)
- Create minimal ApexLanguageServer that supports basic file operations
- Add test repository with sample Apex files
- Add comprehensive test suite for Apex support
- Add apex pytest marker

Note: No LSP exists for Apex, so only basic file operations like read_file are supported. Advanced LSP features (symbol navigation, references, completions) are not available.