### PR TITLE
feat(dashboard): Add i18n support with Japanese translation

### DIFF
--- a/src/serena/resources/dashboard/dashboard.css
+++ b/src/serena/resources/dashboard/dashboard.css
@@ -214,7 +214,7 @@ body {
     position: relative;
     display: flex;
     align-items: flex-end;
-    width: 200px;
+    width: 280px;
     height: 100%;
     gap: 10px;
     flex-shrink: 0;
@@ -836,6 +836,67 @@ body {
 
 .theme-toggle span {
     line-height: 1;
+}
+
+/* Language toggle button */
+.lang-toggle {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+#lang-toggle {
+    position: relative;
+}
+
+.lang-toggle:hover {
+    background-color: var(--border-color);
+}
+
+.lang-toggle #lang-icon {
+    font-size: 16px;
+}
+
+.lang-dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 5px;
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    box-shadow: var(--shadow);
+    min-width: 100px;
+    z-index: 1000;
+}
+
+.lang-dropdown a {
+    display: block;
+    padding: 10px 15px;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 14px;
+    transition: background-color 0.2s ease;
+}
+
+.lang-dropdown a:hover {
+    background-color: var(--border-color);
+}
+
+.lang-dropdown a:first-child {
+    border-radius: 4px 4px 0 0;
+}
+
+.lang-dropdown a:last-child {
+    border-radius: 0 0 4px 4px;
 }
 
 .log-debug {

--- a/src/serena/resources/dashboard/index.html
+++ b/src/serena/resources/dashboard/index.html
@@ -30,6 +30,14 @@
     </div>
 
     <nav class="header-nav">
+        <button id="lang-toggle" class="lang-toggle" title="Change language">
+            <span id="lang-icon">🌐</span>
+            <span id="lang-text">EN</span>
+        </button>
+        <div id="lang-dropdown" class="lang-dropdown" style="display:none">
+            <a href="#" data-lang="en">English</a>
+            <a href="#" data-lang="ja">日本語</a>
+        </div>
         <button id="theme-toggle" class="theme-toggle">
             <span id="theme-icon" style="height: 21px">🌙</span>
             <span id="theme-text">Dark</span>

--- a/src/serena/resources/dashboard/locales/en.json
+++ b/src/serena/resources/dashboard/locales/en.json
@@ -1,0 +1,145 @@
+{
+  "dashboard": {
+    "title": "Serena Dashboard",
+    "theme": {
+      "dark": "Dark",
+      "light": "Light"
+    },
+    "menu": {
+      "menu": "Menu",
+      "overview": "Overview",
+      "logs": "Logs",
+      "advancedStats": "Advanced Stats",
+      "shutdownServer": "Shutdown Server"
+    },
+    "common": {
+      "loading": "Loading...",
+      "loadingNews": "Loading news...",
+      "loadingConfig": "Loading configuration...",
+      "loadingStats": "Loading stats...",
+      "loadingExecutions": "Loading executions...",
+      "loadingTools": "Loading tools...",
+      "loadingModes": "Loading modes...",
+      "loadingContexts": "Loading contexts...",
+      "loadingProjects": "Loading projects...",
+      "cancel": "Cancel",
+      "save": "Save",
+      "ok": "OK",
+      "create": "Create",
+      "none": "None",
+      "na": "N/A"
+    },
+    "sections": {
+      "whatsNew": "What's New",
+      "currentConfiguration": "Current Configuration",
+      "toolUsage": "Tool Usage",
+      "executionsQueue": "Executions Queue",
+      "lastExecution": "Last Execution",
+      "cancelledExecutions": "Cancelled Executions",
+      "registeredProjects": "Registered Projects",
+      "availableToolsDisabled": "Available Tools (Disabled)",
+      "availableModes": "Available Modes",
+      "availableContexts": "Available Contexts"
+    },
+    "config": {
+      "activeProject": "Active Project:",
+      "languages": "Languages:",
+      "usingJetBrains": "Using JetBrains backend",
+      "addLanguage": "+ Add Language",
+      "context": "Context:",
+      "activeModes": "Active Modes:",
+      "fileEncoding": "File Encoding:",
+      "currentClient": "Current Client:",
+      "activeTools": "Active Tools",
+      "availableMemories": "Available Memories",
+      "addMemory": "+ Add Memory",
+      "viewConfigGuide": "View Configuration Guide",
+      "editGlobalConfig": "Edit Global Serena Config"
+    },
+    "stats": {
+      "refreshStats": "Refresh Stats",
+      "clearStats": "Clear Stats",
+      "noStatsYet": "No tool stats collected yet.",
+      "toolCalls": "Tool Calls",
+      "inputTokens": "Input Tokens",
+      "outputTokens": "Output Tokens",
+      "inputVsOutput": "Input vs Output Tokens"
+    },
+    "logs": {
+      "copyLogs": "copy logs",
+      "noLogs": "No logs to copy",
+      "copyFailed": "Failed to copy logs to clipboard"
+    },
+    "modal": {
+      "addLanguage": {
+        "title": "Add Language",
+        "info": "Adding a language to serena config of project",
+        "note": "Note that this may download some dependencies needed for the language server and then start it, it may take a few seconds before the LS is responsive.",
+        "selectLabel": "Select Language:",
+        "noLanguages": "No languages available to add",
+        "addButton": "Add Language"
+      },
+      "removeLanguage": {
+        "confirm": "Remove language",
+        "fromConfig": "from configuration?"
+      },
+      "editMemory": {
+        "title": "Memory:"
+      },
+      "deleteMemory": {
+        "confirm": "Delete memory"
+      },
+      "createMemory": {
+        "title": "Create a new memory for project",
+        "nameHint": "Memory names should be descriptive and use underscores instead of spaces (e.g., \"api_architecture\", \"testing_guidelines\").",
+        "nameLabel": "Memory Name:",
+        "namePlaceholder": "e.g., project_overview"
+      },
+      "cancelExecution": {
+        "confirm": "Are you sure? The execution will continue running until timeout, it will simply no longer be in the queue. Abandoning a running execution is only advised as a measure for unblocking Serena."
+      },
+      "editSerenaConfig": {
+        "title": "Global Serena Configuration",
+        "note": "Note: Changes to the configuration will only take effect after Serena is restarted.",
+        "saveSuccess": "Configuration saved successfully. Please restart Serena for changes to take effect."
+      }
+    },
+    "messages": {
+      "noCancelledExecutions": "No cancelled executions.",
+      "unsavedChanges": "You have unsaved changes. Are you sure you want to close?",
+      "pleaseEnterMemoryName": "Please enter a memory name",
+      "memoryNameInvalid": "Memory name can only contain letters, numbers, and underscores",
+      "markAsRead": "Mark as read"
+    },
+    "errors": {
+      "loadingConfig": "Error loading configuration",
+      "loadingStats": "Error loading stats",
+      "loadingProjects": "Error loading projects",
+      "loadingTools": "Error loading tools",
+      "loadingModes": "Error loading modes",
+      "loadingContexts": "Error loading contexts",
+      "removingLanguage": "Error removing language",
+      "addingLanguage": "Error adding language",
+      "loadingMemory": "Error loading memory",
+      "savingMemory": "Error saving memory",
+      "deletingMemory": "Error deleting memory",
+      "creatingMemory": "Error creating memory",
+      "cancellingTask": "Error cancelling task",
+      "unexpectedResponse": "Unexpected response from server",
+      "loadingSerenaConfig": "Error loading serena config",
+      "noLanguageSelected": "No language selected or no languages available to add",
+      "noMemorySelected": "No memory selected"
+    },
+    "executions": {
+      "running": "Running",
+      "queued": "Queued",
+      "noActiveExecutions": "No active executions",
+      "noQueuedExecutions": "No executions in queue"
+    },
+    "language": {
+      "label": "Language",
+      "en": "English",
+      "ja": "日本語"
+    }
+  }
+}

--- a/src/serena/resources/dashboard/locales/ja.json
+++ b/src/serena/resources/dashboard/locales/ja.json
@@ -1,0 +1,145 @@
+{
+  "dashboard": {
+    "title": "Serena ダッシュボード",
+    "theme": {
+      "dark": "ダーク",
+      "light": "ライト"
+    },
+    "menu": {
+      "menu": "メニュー",
+      "overview": "概要",
+      "logs": "ログ",
+      "advancedStats": "詳細統計",
+      "shutdownServer": "サーバー停止"
+    },
+    "common": {
+      "loading": "読み込み中...",
+      "loadingNews": "ニュースを読み込み中...",
+      "loadingConfig": "設定を読み込み中...",
+      "loadingStats": "統計を読み込み中...",
+      "loadingExecutions": "実行を読み込み中...",
+      "loadingTools": "ツールを読み込み中...",
+      "loadingModes": "モードを読み込み中...",
+      "loadingContexts": "コンテキストを読み込み中...",
+      "loadingProjects": "プロジェクトを読み込み中...",
+      "cancel": "キャンセル",
+      "save": "保存",
+      "ok": "OK",
+      "create": "作成",
+      "none": "なし",
+      "na": "N/A"
+    },
+    "sections": {
+      "whatsNew": "新着情報",
+      "currentConfiguration": "現在の設定",
+      "toolUsage": "ツール使用状況",
+      "executionsQueue": "実行キュー",
+      "lastExecution": "最後の実行",
+      "cancelledExecutions": "キャンセルされた実行",
+      "registeredProjects": "登録済みプロジェクト",
+      "availableToolsDisabled": "利用可能なツール（無効）",
+      "availableModes": "利用可能なモード",
+      "availableContexts": "利用可能なコンテキスト"
+    },
+    "config": {
+      "activeProject": "アクティブプロジェクト:",
+      "languages": "言語:",
+      "usingJetBrains": "JetBrainsバックエンドを使用中",
+      "addLanguage": "+ 言語を追加",
+      "context": "コンテキスト:",
+      "activeModes": "アクティブモード:",
+      "fileEncoding": "ファイルエンコーディング:",
+      "currentClient": "現在のクライアント:",
+      "activeTools": "アクティブツール",
+      "availableMemories": "利用可能なメモリ",
+      "addMemory": "+ メモリを追加",
+      "viewConfigGuide": "設定ガイドを見る",
+      "editGlobalConfig": "グローバル設定を編集"
+    },
+    "stats": {
+      "refreshStats": "統計を更新",
+      "clearStats": "統計をクリア",
+      "noStatsYet": "まだツール統計がありません。",
+      "toolCalls": "ツール呼び出し",
+      "inputTokens": "入力トークン",
+      "outputTokens": "出力トークン",
+      "inputVsOutput": "入力 vs 出力トークン"
+    },
+    "logs": {
+      "copyLogs": "ログをコピー",
+      "noLogs": "コピーするログがありません",
+      "copyFailed": "ログのコピーに失敗しました"
+    },
+    "modal": {
+      "addLanguage": {
+        "title": "言語を追加",
+        "info": "プロジェクトのserena設定に言語を追加します:",
+        "note": "言語サーバーに必要な依存関係のダウンロードと起動に数秒かかる場合があります。",
+        "selectLabel": "言語を選択:",
+        "noLanguages": "追加可能な言語がありません",
+        "addButton": "言語を追加"
+      },
+      "removeLanguage": {
+        "confirm": "言語を削除:",
+        "fromConfig": "を設定から削除しますか？"
+      },
+      "editMemory": {
+        "title": "メモリ:"
+      },
+      "deleteMemory": {
+        "confirm": "メモリを削除:"
+      },
+      "createMemory": {
+        "title": "新しいメモリを作成（プロジェクト:",
+        "nameHint": "メモリ名は説明的で、スペースの代わりにアンダースコアを使用してください（例: \"api_architecture\", \"testing_guidelines\"）。",
+        "nameLabel": "メモリ名:",
+        "namePlaceholder": "例: project_overview"
+      },
+      "cancelExecution": {
+        "confirm": "本当によろしいですか？実行はタイムアウトまで継続しますが、キューからは削除されます。実行中のタスクの放棄は、Serenaのブロック解除のための措置としてのみ推奨されます。"
+      },
+      "editSerenaConfig": {
+        "title": "グローバルSerena設定",
+        "note": "注意: 設定の変更はSerenaを再起動するまで反映されません。",
+        "saveSuccess": "設定が保存されました。変更を反映するにはSerenaを再起動してください。"
+      }
+    },
+    "messages": {
+      "noCancelledExecutions": "キャンセルされた実行はありません。",
+      "unsavedChanges": "保存されていない変更があります。閉じてもよろしいですか？",
+      "pleaseEnterMemoryName": "メモリ名を入力してください",
+      "memoryNameInvalid": "メモリ名には英数字とアンダースコアのみ使用できます",
+      "markAsRead": "既読にする"
+    },
+    "errors": {
+      "loadingConfig": "設定の読み込みエラー",
+      "loadingStats": "統計の読み込みエラー",
+      "loadingProjects": "プロジェクトの読み込みエラー",
+      "loadingTools": "ツールの読み込みエラー",
+      "loadingModes": "モードの読み込みエラー",
+      "loadingContexts": "コンテキストの読み込みエラー",
+      "removingLanguage": "言語削除エラー",
+      "addingLanguage": "言語追加エラー",
+      "loadingMemory": "メモリ読み込みエラー",
+      "savingMemory": "メモリ保存エラー",
+      "deletingMemory": "メモリ削除エラー",
+      "creatingMemory": "メモリ作成エラー",
+      "cancellingTask": "タスクキャンセルエラー",
+      "unexpectedResponse": "サーバーから予期しない応答",
+      "loadingSerenaConfig": "Serena設定の読み込みエラー",
+      "noLanguageSelected": "言語が選択されていないか、追加可能な言語がありません",
+      "noMemorySelected": "メモリが選択されていません"
+    },
+    "executions": {
+      "running": "実行中",
+      "queued": "キュー待ち",
+      "noActiveExecutions": "アクティブな実行がありません",
+      "noQueuedExecutions": "キューに実行がありません"
+    },
+    "language": {
+      "label": "言語",
+      "en": "English",
+      "ja": "日本語"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add I18n class in `dashboard.js` for managing translations
- Implement locale detection from browser settings with localStorage persistence
- Add language toggle button (🌐) in the header navigation
- Translate main UI elements including menus, section headers, config labels, error messages
- Create `locales/en.json` and `locales/ja.json` translation files

## Features

- **Automatic language detection**: Detects browser language and defaults to Japanese for `ja-*` locales
- **Language switcher**: Click the globe icon (🌐) in the header to toggle between English and Japanese
- **Persistent preference**: Language choice is saved in localStorage
- **Dynamic updates**: Switching language updates both static HTML text and dynamically generated content

## Screenshots

The language toggle appears next to the theme toggle in the header navigation.

## Test plan

- [ ] Load dashboard with browser set to Japanese - should show Japanese UI
- [ ] Load dashboard with browser set to English - should show English UI  
- [ ] Click language toggle and switch between EN/JA
- [ ] Verify language preference persists after page reload
- [ ] Verify all main UI sections are translated

## Future improvements

- Add more translations for alert/confirm messages
- Consider adding more languages (community contributions welcome)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)