### PR TITLE
Fix: switch_modes tool silently failing to change modes

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -522,7 +522,7 @@ class SerenaAgent:
 
         :param mode_names: List of mode names or paths to use
         """
-        self._active_modes.apply(ModeSelectionDefinition(default_modes=mode_names))
+        self._mode_overrides = ModeSelectionDefinition(default_modes=mode_names)
         self._update_active_modes_and_tools()
 
         log.info(f"Set modes to {[mode.name for mode in self.get_active_modes()]}")

--- a/test/serena/test_set_modes.py
+++ b/test/serena/test_set_modes.py
@@ -1,0 +1,75 @@
+"""Tests for SerenaAgent.set_modes() to verify that mode switching works correctly."""
+
+import logging
+
+from serena.agent import SerenaAgent
+from serena.config.serena_config import ModeSelectionDefinition, SerenaConfig
+
+
+class TestSetModes:
+    """Test that set_modes correctly changes active modes."""
+
+    def _create_agent(self, modes: ModeSelectionDefinition | None = None) -> SerenaAgent:
+        config = SerenaConfig(gui_log_window=False, web_dashboard=False, log_level=logging.ERROR)
+        return SerenaAgent(serena_config=config, modes=modes)
+
+    def test_set_modes_changes_active_modes(self) -> None:
+        """Test that calling set_modes actually changes the active modes."""
+        agent = self._create_agent(modes=ModeSelectionDefinition(default_modes=["editing", "interactive"]))
+
+        initial_mode_names = sorted(m.name for m in agent.get_active_modes())
+        assert "editing" in initial_mode_names
+        assert "interactive" in initial_mode_names
+
+        # Switch to planning mode
+        agent.set_modes(["planning", "interactive"])
+
+        new_mode_names = sorted(m.name for m in agent.get_active_modes())
+        assert "planning" in new_mode_names
+        assert "interactive" in new_mode_names
+        assert "editing" not in new_mode_names
+
+    def test_set_modes_overrides_config_defaults(self) -> None:
+        """Test that set_modes takes precedence over config defaults."""
+        config = SerenaConfig(gui_log_window=False, web_dashboard=False, log_level=logging.ERROR)
+        config.default_modes = ["editing", "interactive"]
+        agent = SerenaAgent(serena_config=config)
+
+        # Verify config defaults are active
+        initial_mode_names = [m.name for m in agent.get_active_modes()]
+        assert "editing" in initial_mode_names
+
+        # Switch modes — should override config defaults
+        agent.set_modes(["planning", "one-shot"])
+
+        new_mode_names = [m.name for m in agent.get_active_modes()]
+        assert "planning" in new_mode_names
+        assert "one-shot" in new_mode_names
+        assert "editing" not in new_mode_names
+
+    def test_set_modes_persists_after_repeated_calls(self) -> None:
+        """Test that set_modes result persists (modes don't revert)."""
+        agent = self._create_agent(modes=ModeSelectionDefinition(default_modes=["editing"]))
+
+        agent.set_modes(["planning"])
+        mode_names_1 = [m.name for m in agent.get_active_modes()]
+        assert "planning" in mode_names_1
+
+        # Call get_active_modes again — should still be planning
+        mode_names_2 = [m.name for m in agent.get_active_modes()]
+        assert mode_names_1 == mode_names_2
+
+    def test_set_modes_can_switch_back(self) -> None:
+        """Test that modes can be switched back to original after switching away."""
+        agent = self._create_agent(modes=ModeSelectionDefinition(default_modes=["editing", "interactive"]))
+
+        # Switch away
+        agent.set_modes(["planning", "one-shot"])
+        assert "planning" in [m.name for m in agent.get_active_modes()]
+
+        # Switch back
+        agent.set_modes(["editing", "interactive"])
+        mode_names = [m.name for m in agent.get_active_modes()]
+        assert "editing" in mode_names
+        assert "interactive" in mode_names
+        assert "planning" not in mode_names


### PR DESCRIPTION
## Fix: `switch_modes` tool silently failing to change modes

### Summary

The `switch_modes` MCP tool reports success but never actually changes the active modes. Regardless of what modes are requested, the active modes always remain at the defaults from configuration.

### Root Cause

`set_modes()` applied the requested modes directly to `self._active_modes`, then immediately called `_update_active_modes_and_tools()` which **recreates** `_active_modes` from scratch, discarding the change.

### Before (Bug)

```mermaid
sequenceDiagram
    participant User as User / MCP Client
    participant Tool as SwitchModesTool
    participant Agent as SerenaAgent
    participant AM as _active_modes

    User->>Tool: switch_modes(["planning", "interactive"])
    Tool->>Agent: set_modes(["planning", "interactive"])
    Agent->>AM: apply(ModeSelectionDefinition(["planning", "interactive"]))
    Note over AM: ✅ Modes updated to planning + interactive

    Agent->>Agent: _update_active_modes_and_tools()
    Note over Agent: self._active_modes = ActiveModes()
    Note over Agent: ❌ NEW empty ActiveModes — previous change discarded
    Agent->>AM: apply(serena_config)
    Note over AM: Applies config defaults (editing, interactive)
    Agent->>AM: apply(project_config)
    Note over AM: Applies project defaults
    Agent->>AM: apply(_mode_overrides)
    Note over AM: _mode_overrides was never updated by set_modes()

    Agent-->>Tool: "Set modes to ['editing', 'interactive']"
    Tool-->>User: ⚠️ Modes unchanged!
```

### After (Fix)

```mermaid
sequenceDiagram
    participant User as User / MCP Client
    participant Tool as SwitchModesTool
    participant Agent as SerenaAgent
    participant AM as _active_modes

    User->>Tool: switch_modes(["planning", "interactive"])
    Tool->>Agent: set_modes(["planning", "interactive"])
    Agent->>Agent: _mode_overrides = ModeSelectionDefinition(["planning", "interactive"])
    Note over Agent: ✅ Persisted into _mode_overrides

    Agent->>Agent: _update_active_modes_and_tools()
    Note over Agent: self._active_modes = ActiveModes()
    Agent->>AM: apply(serena_config)
    Note over AM: Applies config defaults (editing, interactive)
    Agent->>AM: apply(project_config)
    Note over AM: Applies project defaults
    Agent->>AM: apply(_mode_overrides)
    Note over AM: ✅ Overrides with planning + interactive (highest priority)

    Agent-->>Tool: "Set modes to ['interactive', 'planning']"
    Tool-->>User: ✅ Modes switched!
```

### Mode Priority Chain

```mermaid
graph LR
    A[SerenaConfig<br/>Global defaults] -->|overridden by| B[ProjectConfig<br/>Project defaults]
    B -->|overridden by| C[_mode_overrides<br/>CLI flags / set_modes]
    style C fill:#2d6,stroke:#333,color:#fff
```

### Changes

**`src/serena/agent.py`** — 1 line changed in `set_modes()`:
```diff
 def set_modes(self, mode_names: list[str]) -> None:
-    self._active_modes.apply(ModeSelectionDefinition(default_modes=mode_names))
+    self._mode_overrides = ModeSelectionDefinition(default_modes=mode_names)
     self._update_active_modes_and_tools()
```

**`test/serena/test_set_modes.py`** — New test file with 4 tests:
- `test_set_modes_changes_active_modes` — verifies modes actually change
- `test_set_modes_overrides_config_defaults` — verifies dynamic switch overrides config
- `test_set_modes_persists_after_repeated_calls` — verifies modes don't revert
- `test_set_modes_can_switch_back` — verifies round-trip switching

### Verification

- ✅ `uv run poe format` — clean
- ✅ `uv run poe type-check` — no issues (105 source files)
- ✅ All 4 new tests pass

### Bug Introduced

Commit `40a3075` ("Ensure consistent mode configuration for project", Jan 26 2026) renamed `_update_active_tools` → `_update_active_modes_and_tools` and added the rebuild-from-scratch pattern, but forgot to update `set_modes()` to persist changes into `_mode_overrides`.
