### PR TITLE
fix: Add Python artifacts to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,9 @@ docs/.jupyter_cache
 docs/_build
 coverage.xml
 docker_build_and_run.sh
+
+# Python artifacts (prevents Docker build conflicts when .venv exists locally)
+.venv
+__pycache__
+*.pyc
+.pytest_cache


### PR DESCRIPTION
## Problem

Docker build fails when a local `.venv` directory exists:

1. `COPY . /workspaces/serena/` copies `.venv` into container
2. `RUN uv venv` fails with error: `A virtual environment already exists at '/workspaces/serena/.venv'. Use '--clear' to replace it`

## Solution

Exclude Python development artifacts from Docker build context:
- `.venv` - virtual environment (not needed, Docker creates its own)
- `__pycache__` - Python bytecode cache
- `*.pyc` - compiled Python files  
- `.pytest_cache` - test cache

These files are standard Python development artifacts that should not be included in Docker images.

## Testing

Verified that Docker build now succeeds even when local `.venv` exists.