### PR TITLE
feat: Add allow_no_language_servers config option

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -393,7 +393,7 @@ class SerenaAgent:
             raise Exception(
                 "The language server manager is not initialized. This could indicate either:\n"
                 "1. A problem during project activation (check Serena's logs for errors), or\n"
-                "2. The project has no language servers configured (allow_no_language_servers=True).\n"
+                "2. The project has no language servers configured (languages: [] with extra_source_file_extensions set).\n"
                 "Symbolic operations (find_symbol, rename_symbol, etc.) require language servers. "
                 "Only file-based operations (read_file, list_dir, search_for_pattern, etc.) are available.\n"
                 "Inform the user and wait for further instructions before continuing!"
@@ -750,7 +750,6 @@ class SerenaAgent:
             ls_timeout=ls_timeout,
             trace_lsp_communication=self.serena_config.trace_lsp_communication,
             ls_specific_settings=self.serena_config.ls_specific_settings,
-            allow_no_language_servers=self.serena_config.allow_no_language_servers,
         )
 
     def add_language(self, language: Language) -> None:

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -645,7 +645,7 @@ class ProjectCommands(AutoRegisteringGroup):
 
         if ls_mgr is None:
             click.echo("Error: Project has no language servers configured. Cannot index symbols.")
-            click.echo("Hint: Set allow_no_language_servers=True in serena_config.yml if this is intentional.")
+            click.echo("Hint: Projects without language servers (languages: [] with extra_source_file_extensions) cannot be indexed.")
             return
 
         try:
@@ -728,7 +728,7 @@ class ProjectCommands(AutoRegisteringGroup):
 
         if ls_mgr is None:
             click.echo("Error: Project has no language servers configured. Cannot index file.")
-            click.echo("Hint: Set allow_no_language_servers=True in serena_config.yml if this is intentional.")
+            click.echo("Hint: Projects without language servers (languages: [] with extra_source_file_extensions) cannot be indexed.")
             exit(1)
 
         try:

--- a/src/serena/ls_manager.py
+++ b/src/serena/ls_manager.py
@@ -66,7 +66,7 @@ class LanguageServerManager:
         :param language_servers: a mapping from language to language server; the servers are assumed to be already started.
             The first server in the iteration order is used as the default server.
             All servers are assumed to serve the same project root.
-            Can be empty when allow_no_language_servers is enabled.
+            Can be empty when project has no languages but extra_source_file_extensions is set.
         :param language_server_factory: factory for language server creation; if None, dynamic (re)creation of language servers
             is not supported
         :param project_root: the project root path; required when language_servers is empty
@@ -74,7 +74,7 @@ class LanguageServerManager:
         self._language_servers = language_servers
         self._language_server_factory = language_server_factory
 
-        # Handle empty language servers (when allow_no_language_servers is enabled)
+        # Handle empty language servers (when no languages configured but extra_source_file_extensions is set)
         if language_servers:
             self._default_language_server: SolidLanguageServer | None = next(iter(language_servers.values()))
             self._root_path = self._default_language_server.repository_root_path
@@ -90,13 +90,13 @@ class LanguageServerManager:
         Creates a manager with language servers for the given languages using the given factory.
         The language servers are started in parallel threads.
 
-        :param languages: the languages for which to spawn language servers; can be empty when allow_no_language_servers is enabled
+        :param languages: the languages for which to spawn language servers; can be empty when extra_source_file_extensions is set
         :param factory: the factory for language server creation
         :return: the instance
         """
         language_servers: dict[Language, SolidLanguageServer] = {}
 
-        # Handle empty languages list (when allow_no_language_servers is enabled)
+        # Handle empty languages list (when no languages configured but extra_source_file_extensions is set)
         if not languages:
             return LanguageServerManager(language_servers, factory, project_root=factory.project_root)
 

--- a/src/serena/resources/project.template.yml
+++ b/src/serena/resources/project.template.yml
@@ -31,6 +31,13 @@ languages: ["python"]
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: "utf-8"
 
+# additional file extensions to treat as source files (beyond those defined by configured languages)
+# Useful for:
+#   - Projects with languages + additional file types (e.g., Python + SQL: extra_source_file_extensions: [".sql"])
+#   - Projects without language servers (e.g., SQL-only: languages: [], extra_source_file_extensions: [".sql"])
+# Extensions should include the dot (e.g., ".sql", ".md")
+extra_source_file_extensions: []
+
 # whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 

--- a/src/serena/resources/serena_config.template.yml
+++ b/src/serena/resources/serena_config.template.yml
@@ -57,28 +57,6 @@ log_level: 20
 # This is useful for debugging language server issues.
 trace_lsp_communication: False
 
-allow_no_language_servers: False
-# Allow projects to run without any language servers configured.
-# When enabled, projects with an empty languages list can be activated, providing access to
-# file-based tools (read_file, list_dir, search_for_pattern, create_text_file, etc.) but not
-# symbolic tools (find_symbol, rename_symbol, get_symbols_overview, etc.).
-#
-# Use cases:
-#  * Projects containing only files in unsupported languages (e.g., SQL, plain text)
-#  * Documentation-only projects (Markdown, reStructuredText, etc.)
-#  * Configuration file repositories (YAML, JSON, TOML, etc.)
-#
-# When this option is enabled and a project has no supported language files, Serena will:
-#  1. Skip language server initialization (faster startup, no resource overhead)
-#  2. Enable all file-based tools for reading, writing, and searching files
-#  3. Disable symbolic tools that require language server support
-#
-# To use this feature:
-#  1. Set allow_no_language_servers: True in this config file
-#  2. Create a project with languages: [] in the project.yml file
-#
-# Default: False (maintains backward compatibility - projects must have at least one language)
-
 # advanced configuration option allowing to configure language server-specific options.
 # Maps the language key to the options.
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.


### PR DESCRIPTION
Add a new configuration option 'allow_no_language_servers' to SerenaConfig that enables running projects without any language servers configured.

This allows file-based tools (read_file, list_dir, search_for_pattern, etc.) to work on projects containing files in unsupported languages (e.g., SQL, plain text, documentation) while maintaining backward compatibility.

Changes:
- Add allow_no_language_servers field to SerenaConfig with default False
- Update ProjectConfig.autogenerate() to accept and use the option
- Update ProjectConfig.load() to pass through the option
- Update SerenaConfig.add_project_from_path() to use the config value
- Add comprehensive documentation in serena_config.template.yml

Default value of False maintains existing behavior where projects must have at least one language configured.