### PR TITLE
Skip PHP_PHPACTOR tests when PHP is not installed

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -236,6 +236,11 @@ def _determine_disabled_languages() -> list[Language]:
     if not clangd_tests_enabled:
         result.append(Language.CPP)
 
+    # Disable PHP_PHPACTOR tests if php is not available
+    php_tests_enabled = _sh.which("php") is not None
+    if not php_tests_enabled:
+        result.append(Language.PHP_PHPACTOR)
+
     al_tests_enabled = True
     if not al_tests_enabled:
         result.append(Language.AL)

--- a/test/solidlsp/php/test_php_basic.py
+++ b/test/solidlsp/php/test_php_basic.py
@@ -5,18 +5,23 @@ import pytest
 
 from solidlsp import SolidLanguageServer
 from solidlsp.ls_config import Language
+from test.conftest import language_tests_enabled
+
+_php_servers: list[Language] = [Language.PHP]
+if language_tests_enabled(Language.PHP_PHPACTOR):
+    _php_servers.append(Language.PHP_PHPACTOR)
 
 
 @pytest.mark.php
 class TestPhpLanguageServers:
-    @pytest.mark.parametrize("language_server", [Language.PHP, Language.PHP_PHPACTOR], indirect=True)
+    @pytest.mark.parametrize("language_server", _php_servers, indirect=True)
     @pytest.mark.parametrize("repo_path", [Language.PHP], indirect=True)
     def test_ls_is_running(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
         """Test that the language server starts and stops successfully."""
         assert language_server.is_running()
         assert Path(language_server.language_server.repository_root_path).resolve() == repo_path.resolve()
 
-    @pytest.mark.parametrize("language_server", [Language.PHP, Language.PHP_PHPACTOR], indirect=True)
+    @pytest.mark.parametrize("language_server", _php_servers, indirect=True)
     @pytest.mark.parametrize("repo_path", [Language.PHP], indirect=True)
     def test_find_definition_within_file(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
 
@@ -46,7 +51,7 @@ class TestPhpLanguageServers:
         if language_server.language_server.language != Language.PHP_PHPACTOR:
             assert definition_location["range"]["start"]["character"] == 0
 
-    @pytest.mark.parametrize("language_server", [Language.PHP, Language.PHP_PHPACTOR], indirect=True)
+    @pytest.mark.parametrize("language_server", _php_servers, indirect=True)
     @pytest.mark.parametrize("repo_path", [Language.PHP], indirect=True)
     def test_find_definition_across_files(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
         # Intelephense uses line 12 (0-indexed), Phpactor uses line 13 (0-indexed)
@@ -66,7 +71,7 @@ class TestPhpLanguageServers:
         if language_server.language_server.language != Language.PHP_PHPACTOR:
             assert definition_location["range"]["start"]["character"] == 0
 
-    @pytest.mark.parametrize("language_server", [Language.PHP, Language.PHP_PHPACTOR], indirect=True)
+    @pytest.mark.parametrize("language_server", _php_servers, indirect=True)
     @pytest.mark.parametrize("repo_path", [Language.PHP], indirect=True)
     def test_find_definition_simple_variable(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
         file_path = str(repo_path / "simple_var.php")
@@ -91,7 +96,7 @@ class TestPhpLanguageServers:
         if language_server.language_server.language != Language.PHP_PHPACTOR:
             assert definition_location["range"]["start"]["character"] == 0  # $localVar (0-indexed)
 
-    @pytest.mark.parametrize("language_server", [Language.PHP, Language.PHP_PHPACTOR], indirect=True)
+    @pytest.mark.parametrize("language_server", _php_servers, indirect=True)
     @pytest.mark.parametrize("repo_path", [Language.PHP], indirect=True)
     def test_find_references_within_file(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
         if language_server.language == Language.PHP_PHPACTOR and platform.system() == "Windows":
@@ -142,7 +147,7 @@ class TestPhpLanguageServers:
 
             assert actual_locations == expected_locations
 
-    @pytest.mark.parametrize("language_server", [Language.PHP, Language.PHP_PHPACTOR], indirect=True)
+    @pytest.mark.parametrize("language_server", _php_servers, indirect=True)
     @pytest.mark.parametrize("repo_path", [Language.PHP], indirect=True)
     def test_find_references_across_files(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
         if language_server.language_server.language == Language.PHP_PHPACTOR and platform.system() == "Windows":


### PR DESCRIPTION
## Summary

Fixes the PHP_PHPACTOR test failures on platforms where PHP is not installed (macOS CI runners).

When PHP is not available, Phpactor tests now gracefully skip instead of failing with `AssertionError: PHP is not installed or not found in PATH`.

Fixes #1022

## Changes

- **test/conftest.py**: Add `Language.PHP_PHPACTOR` to `_determine_disabled_languages()` with `shutil.which("php")` check
- **test/solidlsp/php/test_php_basic.py**: Replace hardcoded `[Language.PHP, Language.PHP_PHPACTOR]` parametrize lists with dynamic `_php_servers` list that conditionally includes Phpact

## Testing

- `uv run poe format` — passes clean
- `uv run poe type-check` — 0 issues found
- `uv run poe lint` — all checks passed
