### PR TITLE
fix: preserve config order in LanguageServerManager for directory LS selection

### DIFF
--- a/src/serena/ls_manager.py
+++ b/src/serena/ls_manager.py
@@ -117,7 +117,10 @@ class LanguageServerManager:
             failure_messages = "\n".join([f"{lang.value}: {e}" for lang, e in exceptions.items()])
             raise Exception(f"Failed to start language servers:\n{failure_messages}")
 
-        return LanguageServerManager(language_servers, factory)
+        # Reorder to match the original config order (threads complete in arbitrary order,
+        # but get_language_server iterates in dict order to pick the right LS for a path)
+        ordered = {lang: language_servers[lang] for lang in languages}
+        return LanguageServerManager(ordered, factory)
 
     def get_root_path(self) -> str:
         return self._root_path


### PR DESCRIPTION
## Summary

- Fix `LanguageServerManager.from_languages()` populating its internal dict in thread-completion order instead of config order
- For multi-language projects, `get_language_server(directory_path)` picked the wrong LS because directories bypass the file extension check, so the first LS in dict iteration order was selected
- Reorder the dict to match the original config order after all parallel threads complete

**Impact:** Affects all multi-language projects where slower LSes (e.g. Kotlin ~7s) are configured as primary but faster ones (e.g. Python <1s) finish first. `request_full_symbol_tree` would return `{}` for the primary language's files.

## Test plan

- [x] `uv run poe format` clean
- [x] `uv run poe type-check` clean
- [x] `uv run poe test -m kotlin` — all 6 tests pass
- [x] Manual testing with multi-language project (kotlin+python+typescript+bash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)