### PR TITLE
fix: Kotlin LSP synthetic info fallback for symbols without hover

### DIFF
--- a/src/serena/symbol.py
+++ b/src/serena/symbol.py
@@ -678,11 +678,9 @@ class LanguageServerSymbolRetriever:
                     parent = sym.get_parent()
                     lang_server = self.get_language_server(file_path)
                     info = lang_server._get_symbol_metadata_info(
-                        name=sym.name,
-                        kind=sym.symbol_kind,
-                        parent_name=parent.name if parent else None,
-                        parent_kind=parent.symbol_kind if parent else None,
-                        detail=sym.symbol_root.get("detail"),
+                        symbol=sym.symbol_root,
+                        parent=parent.symbol_root if parent else None,
+                        relative_file_path=file_path,
                     )
 
                 info_by_symbol[sym] = info

--- a/src/serena/symbol.py
+++ b/src/serena/symbol.py
@@ -682,6 +682,7 @@ class LanguageServerSymbolRetriever:
                         kind=sym.symbol_kind,
                         parent_name=parent.name if parent else None,
                         parent_kind=parent.symbol_kind if parent else None,
+                        detail=sym.symbol_root.get("detail"),
                     )
 
                 info_by_symbol[sym] = info

--- a/src/serena/symbol.py
+++ b/src/serena/symbol.py
@@ -670,6 +670,20 @@ class LanguageServerSymbolRetriever:
                     file_hover_lookups += 1
                     total_hover_lookups += 1
 
+                # When hover returns nothing, fall back to a synthetic descriptor
+                # built from the symbol's own metadata (name, kind, parent class).
+                # This is free (no LSP round-trip) and works even when the LSP
+                # does not implement textDocument/hover for a given symbol type.
+                if info is None:
+                    parent = sym.get_parent()
+                    lang_server = self.get_language_server(file_path)
+                    info = lang_server._get_symbol_metadata_info(
+                        name=sym.name,
+                        kind=sym.symbol_kind,
+                        parent_name=parent.name if parent else None,
+                        parent_kind=parent.symbol_kind if parent else None,
+                    )
+
                 info_by_symbol[sym] = info
 
             if debug_enabled:

--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -21,10 +21,12 @@ import os
 import pathlib
 import stat
 import threading
+from time import sleep
 from typing import cast
 
 from overrides import override
 
+from solidlsp import ls_types
 from solidlsp.ls import (
     LanguageServerDependencyProvider,
     LanguageServerDependencyProviderSinglePath,
@@ -554,3 +556,22 @@ class KotlinLanguageServer(SolidLanguageServer):
     def _get_wait_time_for_cross_file_referencing(self) -> float:
         """Small safety buffer since we already waited for indexing to complete in _start_server."""
         return 1.0
+
+    @override
+    def _request_hover(self, uri: str, line: int, column: int) -> ls_types.Hover | None:
+        """Override to retry hover requests for Kotlin LSP.
+
+        The Kotlin LSP (IntelliJ-based) lazily resolves hover info: the first
+        request after didOpen often returns None while the engine parses the file.
+        A retry loop with increasing patience (matching the pattern used for
+        Eclipse JDTLS) handles this lazy-loading behaviour.
+        """
+        max_retries = 10
+        retry_delay = 0.2  # 200 ms between retries → up to 2 s total wait
+        result = super()._request_hover(uri, line, column)
+        for _ in range(max_retries):
+            if result is not None:
+                break
+            sleep(retry_delay)
+            result = super()._request_hover(uri, line, column)
+        return result

--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -21,7 +21,6 @@ import os
 import pathlib
 import stat
 import threading
-from time import sleep
 from typing import cast
 
 from overrides import override
@@ -557,25 +556,6 @@ class KotlinLanguageServer(SolidLanguageServer):
         """Small safety buffer since we already waited for indexing to complete in _start_server."""
         return 1.0
 
-    @override
-    def _request_hover(self, uri: str, line: int, column: int) -> ls_types.Hover | None:
-        """Override to retry hover requests for Kotlin LSP.
-
-        The Kotlin LSP (IntelliJ-based) lazily resolves hover info: the first
-        request after didOpen often returns None while the engine parses the file.
-        A retry loop with increasing patience (matching the pattern used for
-        Eclipse JDTLS) handles this lazy-loading behaviour.
-        """
-        max_retries = 10
-        retry_delay = 0.2  # 200 ms between retries → up to 2 s total wait
-        result = super()._request_hover(uri, line, column)
-        for _ in range(max_retries):
-            if result is not None:
-                break
-            sleep(retry_delay)
-            result = super()._request_hover(uri, line, column)
-        return result
-
     # Mapping from LSP SymbolKind to Kotlin keyword / descriptor
     _KOTLIN_KIND_KEYWORD: dict[ls_types.SymbolKind, str | None] = {
         ls_types.SymbolKind.File: None,
@@ -608,35 +588,102 @@ class KotlinLanguageServer(SolidLanguageServer):
         }
     )
 
+    def _extract_source_info(self, relative_file_path: str, symbol: ls_types.UnifiedSymbolInformation) -> str | None:
+        """Extract the declaration (with optional KDoc) directly from the source file.
+
+        Uses the symbol's range to locate the declaration line, then scans backwards
+        for a KDoc comment. Returns the KDoc + declaration signature (up to the opening
+        brace), or None if the source cannot be read.
+        """
+        sym_range = symbol.get("range")
+        if not sym_range:
+            return None
+
+        abs_path = os.path.join(self.repository_root_path, relative_file_path)
+        try:
+            with open(abs_path, encoding=self._encoding) as f:
+                lines = f.readlines()
+        except OSError:
+            return None
+
+        decl_start = sym_range["start"]["line"]  # 0-based
+        decl_end = sym_range["end"]["line"]
+
+        # Extract the declaration line(s): from range start to the first line containing '{'
+        # or the end of a single-line declaration
+        decl_lines: list[str] = []
+        for i in range(decl_start, min(decl_end + 1, len(lines))):
+            line = lines[i].rstrip()
+            decl_lines.append(line)
+            if "{" in line:
+                # Trim everything after the opening brace
+                idx = line.index("{")
+                decl_lines[-1] = line[:idx].rstrip()
+                break
+
+        # Scan backwards from the declaration for a KDoc comment (/** ... */)
+        kdoc_lines: list[str] = []
+        scan_start = decl_start - 1
+        while scan_start >= 0:
+            stripped = lines[scan_start].strip()
+            if not stripped or stripped.startswith("@"):
+                # Skip blank lines and annotations between KDoc and declaration
+                scan_start -= 1
+                continue
+            if stripped.endswith("*/"):
+                # Found end of a KDoc — collect it
+                for j in range(scan_start, -1, -1):
+                    kdoc_lines.insert(0, lines[j].rstrip())
+                    if "/**" in lines[j]:
+                        break
+            break
+
+        result_parts = kdoc_lines + decl_lines
+        if not result_parts:
+            return None
+
+        result = "\n".join(result_parts).strip()
+        # Safety: cap length to avoid token bloat
+        if len(result) > 500:
+            result = result[:500] + "..."
+        return result if result else None
+
     @override
     def _get_symbol_metadata_info(
         self,
-        name: str,
-        kind: ls_types.SymbolKind,
-        parent_name: str | None,
-        parent_kind: ls_types.SymbolKind | None,
-        detail: str | None = None,
+        symbol: ls_types.UnifiedSymbolInformation,
+        parent: ls_types.UnifiedSymbolInformation | None,
+        relative_file_path: str,
     ) -> str | None:
-        """Build a Kotlin-style synthetic info string from symbol metadata.
+        """Build info for a Kotlin symbol by extracting its declaration from source.
 
-        Used as a fallback when the Kotlin LSP returns null for hover requests.
-        When the LSP provides a ``detail`` field (e.g. a function signature or type),
-        it is incorporated into the output.  Otherwise a concise descriptor is
-        synthesized from the symbol's kind and parent, e.g.
-        ``fun solve(): Unit [in Stage1SolverService]`` or ``data class Model``.
+        First attempts to read the actual source file to extract the KDoc + declaration
+        signature. Falls back to synthesizing a descriptor from symbol metadata if the
+        source cannot be read.
         """
+        name = symbol["name"]
+        kind = symbol["kind"]
+
         keyword = self._KOTLIN_KIND_KEYWORD.get(kind)
 
         # Skip file/package-level symbols — they carry no useful info on their own
         if keyword is None and kind not in (ls_types.SymbolKind.EnumMember,):
             return None
 
-        # Only show parent context when the parent is a meaningful container
+        # Try source-based extraction first
+        source_info = self._extract_source_info(relative_file_path, symbol)
+        if source_info:
+            return source_info
+
+        # Fallback: synthesize from metadata
+        detail = symbol.get("detail")
+        parent_name = parent["name"] if parent else None
+        parent_kind = parent["kind"] if parent else None
+
         show_parent = parent_name is not None and parent_kind is not None and parent_kind not in self._NON_CONTAINER_KINDS
         parent_context = f" [in {parent_name}]" if show_parent else ""
 
         if kind in (ls_types.SymbolKind.Method, ls_types.SymbolKind.Function):
-            # detail may contain the signature, e.g. "(param: Type): ReturnType"
             if detail:
                 return f"fun {name}{detail}{parent_context}"
             return f"fun {name}(){parent_context}"
@@ -649,7 +696,6 @@ class KotlinLanguageServer(SolidLanguageServer):
                 return f"{keyword} {name}: {detail}{parent_context}"
             return f"{keyword} {name}{parent_context}"
         else:
-            # EnumMember and similar — just the name with context
             if detail:
                 return f"{name}: {detail}{parent_context}"
             return f"{name}{parent_context}"

--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -575,3 +575,69 @@ class KotlinLanguageServer(SolidLanguageServer):
             sleep(retry_delay)
             result = super()._request_hover(uri, line, column)
         return result
+
+    # Mapping from LSP SymbolKind to Kotlin keyword / descriptor
+    _KOTLIN_KIND_KEYWORD: dict[ls_types.SymbolKind, str | None] = {
+        ls_types.SymbolKind.File: None,
+        ls_types.SymbolKind.Package: None,
+        ls_types.SymbolKind.Namespace: None,
+        ls_types.SymbolKind.Module: None,
+        ls_types.SymbolKind.Class: "class",
+        ls_types.SymbolKind.Struct: "data class",  # Kotlin data classes are reported as Struct
+        ls_types.SymbolKind.Object: "object",  # Kotlin object declarations
+        ls_types.SymbolKind.Interface: "interface",
+        ls_types.SymbolKind.Enum: "enum class",
+        ls_types.SymbolKind.EnumMember: None,
+        ls_types.SymbolKind.Method: "fun",
+        ls_types.SymbolKind.Function: "fun",
+        ls_types.SymbolKind.Constructor: "constructor",
+        ls_types.SymbolKind.Property: "val",
+        ls_types.SymbolKind.Field: "val",
+        ls_types.SymbolKind.Variable: "val",
+        ls_types.SymbolKind.Constant: "val",
+        ls_types.SymbolKind.TypeParameter: "typealias",
+    }
+
+    # SymbolKinds that are not meaningful as parent context (file/package level)
+    _NON_CONTAINER_KINDS: frozenset[ls_types.SymbolKind] = frozenset(
+        {
+            ls_types.SymbolKind.File,
+            ls_types.SymbolKind.Package,
+            ls_types.SymbolKind.Namespace,
+            ls_types.SymbolKind.Module,
+        }
+    )
+
+    @override
+    def _get_symbol_metadata_info(
+        self,
+        name: str,
+        kind: ls_types.SymbolKind,
+        parent_name: str | None,
+        parent_kind: ls_types.SymbolKind | None,
+    ) -> str | None:
+        """Build a Kotlin-style synthetic info string from symbol metadata.
+
+        Used as a fallback when the Kotlin LSP returns null for hover requests.
+        Produces concise descriptors like ``fun solve() [in Stage1SolverService]``
+        or ``data class Model``.
+        """
+        keyword = self._KOTLIN_KIND_KEYWORD.get(kind)
+
+        # Skip file/package-level symbols — they carry no useful info on their own
+        if keyword is None and kind not in (ls_types.SymbolKind.EnumMember,):
+            return None
+
+        # Only show parent context when the parent is a meaningful container
+        show_parent = parent_name is not None and parent_kind is not None and parent_kind not in self._NON_CONTAINER_KINDS
+        parent_context = f" [in {parent_name}]" if show_parent else ""
+
+        if kind in (ls_types.SymbolKind.Method, ls_types.SymbolKind.Function):
+            return f"fun {name}(){parent_context}"
+        elif kind == ls_types.SymbolKind.Constructor:
+            return f"constructor{parent_context}"
+        elif keyword is not None:
+            return f"{keyword} {name}{parent_context}"
+        else:
+            # EnumMember and similar — just the name with context
+            return f"{name}{parent_context}"

--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -615,12 +615,15 @@ class KotlinLanguageServer(SolidLanguageServer):
         kind: ls_types.SymbolKind,
         parent_name: str | None,
         parent_kind: ls_types.SymbolKind | None,
+        detail: str | None = None,
     ) -> str | None:
         """Build a Kotlin-style synthetic info string from symbol metadata.
 
         Used as a fallback when the Kotlin LSP returns null for hover requests.
-        Produces concise descriptors like ``fun solve() [in Stage1SolverService]``
-        or ``data class Model``.
+        When the LSP provides a ``detail`` field (e.g. a function signature or type),
+        it is incorporated into the output.  Otherwise a concise descriptor is
+        synthesized from the symbol's kind and parent, e.g.
+        ``fun solve(): Unit [in Stage1SolverService]`` or ``data class Model``.
         """
         keyword = self._KOTLIN_KIND_KEYWORD.get(kind)
 
@@ -633,11 +636,20 @@ class KotlinLanguageServer(SolidLanguageServer):
         parent_context = f" [in {parent_name}]" if show_parent else ""
 
         if kind in (ls_types.SymbolKind.Method, ls_types.SymbolKind.Function):
+            # detail may contain the signature, e.g. "(param: Type): ReturnType"
+            if detail:
+                return f"fun {name}{detail}{parent_context}"
             return f"fun {name}(){parent_context}"
         elif kind == ls_types.SymbolKind.Constructor:
+            if detail:
+                return f"constructor{detail}{parent_context}"
             return f"constructor{parent_context}"
         elif keyword is not None:
+            if detail:
+                return f"{keyword} {name}: {detail}{parent_context}"
             return f"{keyword} {name}{parent_context}"
         else:
             # EnumMember and similar — just the name with context
+            if detail:
+                return f"{name}: {detail}{parent_context}"
             return f"{name}{parent_context}"

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -1599,6 +1599,26 @@ class SolidLanguageServer(ABC):
             return None
         return ls_types.Hover(**response)  # type: ignore
 
+    def _get_symbol_metadata_info(
+        self,
+        name: str,
+        kind: ls_types.SymbolKind,
+        parent_name: str | None,
+        parent_kind: ls_types.SymbolKind | None,
+    ) -> str | None:
+        """Return a synthetic info string built from symbol metadata when hover is unavailable.
+
+        Returns None by default. Override in language server subclasses to provide
+        language-specific fallback info (e.g., when the LSP does not implement hover).
+
+        :param name: the symbol name
+        :param kind: the LSP symbol kind
+        :param parent_name: the name of the direct parent symbol, or None for top-level symbols
+        :param parent_kind: the kind of the direct parent symbol, or None
+        :return: a short info string describing the symbol, or None
+        """
+        return None
+
     def request_signature_help(self, relative_file_path: str, line: int, column: int) -> ls_types.SignatureHelp | None:
         """
         Raise a [textDocument/signatureHelp](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_signatureHelp)

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -1601,22 +1601,18 @@ class SolidLanguageServer(ABC):
 
     def _get_symbol_metadata_info(
         self,
-        name: str,
-        kind: ls_types.SymbolKind,
-        parent_name: str | None,
-        parent_kind: ls_types.SymbolKind | None,
-        detail: str | None = None,
+        symbol: ls_types.UnifiedSymbolInformation,
+        parent: ls_types.UnifiedSymbolInformation | None,
+        relative_file_path: str,
     ) -> str | None:
         """Return a synthetic info string built from symbol metadata when hover is unavailable.
 
         Returns None by default. Override in language server subclasses to provide
         language-specific fallback info (e.g., when the LSP does not implement hover).
 
-        :param name: the symbol name
-        :param kind: the LSP symbol kind
-        :param parent_name: the name of the direct parent symbol, or None for top-level symbols
-        :param parent_kind: the kind of the direct parent symbol, or None
-        :param detail: the DocumentSymbol.detail string from the LSP (e.g. function signature), or None
+        :param symbol: the full symbol dict from the LSP (name, kind, range, detail, etc.)
+        :param parent: the parent symbol dict, or None for top-level symbols
+        :param relative_file_path: the file path relative to the repository root
         :return: a short info string describing the symbol, or None
         """
         return None

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -1605,6 +1605,7 @@ class SolidLanguageServer(ABC):
         kind: ls_types.SymbolKind,
         parent_name: str | None,
         parent_kind: ls_types.SymbolKind | None,
+        detail: str | None = None,
     ) -> str | None:
         """Return a synthetic info string built from symbol metadata when hover is unavailable.
 
@@ -1615,6 +1616,7 @@ class SolidLanguageServer(ABC):
         :param kind: the LSP symbol kind
         :param parent_name: the name of the direct parent symbol, or None for top-level symbols
         :param parent_kind: the kind of the direct parent symbol, or None
+        :param detail: the DocumentSymbol.detail string from the LSP (e.g. function signature), or None
         :return: a short info string describing the symbol, or None
         """
         return None

--- a/test/serena/test_serena_agent.py
+++ b/test/serena/test_serena_agent.py
@@ -146,9 +146,6 @@ class TestSerenaAgent:
             for s in symbols
         ), f"Expected to find {symbol_name} ({expected_kind}) in {expected_file}"
         # testing retrieval of symbol info
-        if serena_agent.get_active_lsp_languages() == [Language.KOTLIN]:
-            # kotlin LS doesn't seem to provide hover info right now, at least for the struct we test this on
-            return
         for s in symbols:
             if s["kind"] in (SymbolKind.File.name, SymbolKind.Module.name):
                 # we ignore file and module symbols for the info test

--- a/test/solidlsp/kotlin/test_kotlin_basic.py
+++ b/test/solidlsp/kotlin/test_kotlin_basic.py
@@ -57,50 +57,6 @@ class TestKotlinLanguageServer:
         assert SymbolUtils.symbol_tree_contains_name(symbols, "Model"), "Model missing from overview"
 
     @pytest.mark.parametrize("language_server", [Language.KOTLIN], indirect=True)
-    def test_hover(self, language_server: SolidLanguageServer) -> None:
-        """Test that hover (include_info) returns information for Kotlin symbols.
-
-        Verifies the _request_hover retry logic that handles the Kotlin LSP's
-        lazy-loading behaviour (hover may return None on the first request
-        after didOpen).
-        """
-        file_path = os.path.join("src", "main", "kotlin", "test_repo", "Utils.kt")
-        doc_symbols = language_server.request_document_symbols(file_path)
-        all_symbols, _ = doc_symbols.get_all_symbols_and_roots()
-
-        # Find the Utils object symbol
-        utils_symbol = None
-        for sym in all_symbols:
-            if sym.get("name") == "Utils":
-                utils_symbol = sym
-                break
-        assert utils_symbol is not None, "Utils symbol not found in Utils.kt"
-
-        # Use selectionRange (identifier position) for hover
-        sel_start = utils_symbol.get("selectionRange", utils_symbol.get("range", {}))["start"]
-        line = sel_start["line"]
-        col = sel_start["character"]
-
-        hover = language_server.request_hover(file_path, line, col)
-        if hover is None:
-            # Kotlin LSP (IntelliJ-based, early versions like v261) may return null for hover
-            # even after our retry loop. This is a known limitation; the retry logic in
-            # KotlinLanguageServer._request_hover handles future versions that improve hover support.
-            pytest.skip("Kotlin LSP hover returned None - hover not yet supported in this LSP version")
-
-        contents = hover.get("contents")
-        assert contents, "Hover contents are empty"
-
-        # Extract text regardless of format (MarkupContent dict, MarkedString list, or plain string)
-        if isinstance(contents, dict):
-            text = contents.get("value", "")
-        elif isinstance(contents, list):
-            text = " ".join(p if isinstance(p, str) else p.get("value", "") for p in contents)
-        else:
-            text = str(contents)
-        assert text.strip(), "Hover text is empty"
-
-    @pytest.mark.parametrize("language_server", [Language.KOTLIN], indirect=True)
     def test_dir_overview(self, language_server: SolidLanguageServer) -> None:
         result = language_server.request_dir_overview("src/main/kotlin/test_repo")
         print(f"dir_overview keys: {list(result.keys())}")

--- a/test/solidlsp/kotlin/test_kotlin_basic.py
+++ b/test/solidlsp/kotlin/test_kotlin_basic.py
@@ -55,3 +55,63 @@ class TestKotlinLanguageServer:
         assert SymbolUtils.symbol_tree_contains_name(symbols, "Main"), "Main missing from overview"
         assert SymbolUtils.symbol_tree_contains_name(symbols, "Utils"), "Utils missing from overview"
         assert SymbolUtils.symbol_tree_contains_name(symbols, "Model"), "Model missing from overview"
+
+    @pytest.mark.parametrize("language_server", [Language.KOTLIN], indirect=True)
+    def test_hover(self, language_server: SolidLanguageServer) -> None:
+        """Test that hover (include_info) returns information for Kotlin symbols.
+
+        Verifies the _request_hover retry logic that handles the Kotlin LSP's
+        lazy-loading behaviour (hover may return None on the first request
+        after didOpen).
+        """
+        file_path = os.path.join("src", "main", "kotlin", "test_repo", "Utils.kt")
+        doc_symbols = language_server.request_document_symbols(file_path)
+        all_symbols, _ = doc_symbols.get_all_symbols_and_roots()
+
+        # Find the Utils object symbol
+        utils_symbol = None
+        for sym in all_symbols:
+            if sym.get("name") == "Utils":
+                utils_symbol = sym
+                break
+        assert utils_symbol is not None, "Utils symbol not found in Utils.kt"
+
+        # Use selectionRange (identifier position) for hover
+        sel_start = utils_symbol.get("selectionRange", utils_symbol.get("range", {}))["start"]
+        line = sel_start["line"]
+        col = sel_start["character"]
+
+        hover = language_server.request_hover(file_path, line, col)
+        if hover is None:
+            # Kotlin LSP (IntelliJ-based, early versions like v261) may return null for hover
+            # even after our retry loop. This is a known limitation; the retry logic in
+            # KotlinLanguageServer._request_hover handles future versions that improve hover support.
+            pytest.skip("Kotlin LSP hover returned None - hover not yet supported in this LSP version")
+
+        contents = hover.get("contents")
+        assert contents, "Hover contents are empty"
+
+        # Extract text regardless of format (MarkupContent dict, MarkedString list, or plain string)
+        if isinstance(contents, dict):
+            text = contents.get("value", "")
+        elif isinstance(contents, list):
+            text = " ".join(p if isinstance(p, str) else p.get("value", "") for p in contents)
+        else:
+            text = str(contents)
+        assert text.strip(), "Hover text is empty"
+
+    @pytest.mark.parametrize("language_server", [Language.KOTLIN], indirect=True)
+    def test_dir_overview(self, language_server: SolidLanguageServer) -> None:
+        result = language_server.request_dir_overview("src/main/kotlin/test_repo")
+        print(f"dir_overview keys: {list(result.keys())}")
+        for k, v in result.items():
+            print(f"  {k}: {[s.get('name') for s in v]}")
+        assert len(result) > 0, "Directory overview should return symbols for at least one file"
+        # Should find symbols from all 4 .kt files
+        all_symbol_names = set()
+        for symbols in result.values():
+            for s in symbols:
+                all_symbol_names.add(s.get("name"))
+        assert "Main" in all_symbol_names, "Main should be in directory overview"
+        assert "Utils" in all_symbol_names, "Utils should be in directory overview"
+        assert "Model" in all_symbol_names, "Model should be in directory overview"


### PR DESCRIPTION
## Summary

The Kotlin LSP (KLS v0.1, IntelliJ-based) advertises `hoverProvider: true` but returns `null` for every hover request on Kotlin symbols (verified via wire-level tracing — not a timing issue, consistently null). This PR adds a source-based fallback that reads the actual Kotlin source file to extract declaration signatures and KDoc comments.

### Changes

1. **Source-based info extraction** — reads the Kotlin source file using the symbol's LSP range, extracts the declaration signature (up to opening `{`) and any preceding KDoc comment. Capped at 500 chars to avoid token bloat. Falls back to metadata synthesis if the source can't be read.
2. **Simplified `_get_symbol_metadata_info` API** — accepts the full symbol and parent dicts instead of individual fields, giving subclasses access to ranges and other metadata.
3. **Removed hover retry logic** — retries don't help; KLS v0.1 returns null consistently (not lazy-loading like Eclipse JDTLS).
4. **Removed test workaround** — the `test_find_symbol[kotlin-Model-Struct-Model.kt]` early return is no longer needed.

### Test plan

- [x] `test_find_symbol[kotlin-Model-Struct-Model.kt]` passes with workaround removed
- [x] All 6 Kotlin-marked tests pass
- [x] Format, type-check, lint all clean

Fixes #924