### PR TITLE
Dashboard: Replace automatic banner rotation with random initial display and manual rotation

### DIFF
--- a/src/serena/resources/dashboard/dashboard.css
+++ b/src/serena/resources/dashboard/dashboard.css
@@ -207,6 +207,7 @@ body {
     top: 0;
     left: 0;
     order: 2;
+    height: var(--header-height);
     max-height: var(--header-height);
 }
 
@@ -311,17 +312,13 @@ body {
 }
 
 .platinum-banner-slide {
-    position: absolute;
-    top: 0;
-    left: 0;
+    display: none;
     pointer-events: none;
     height: 100%;
-    opacity: 0;
-    transition: opacity 0.5s ease-in-out;
 }
 
 .platinum-banner-slide.active {
-    opacity: 1;
+    display: block;
     pointer-events: auto;
 }
 
@@ -351,25 +348,59 @@ body {
 .gold-banner {
     position: relative;
     width: 100%;
-    height: 60px;
     overflow: hidden;
 }
 
 .gold-banner-slide {
-    position: absolute;
+    display: none;
     pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.5s ease-in-out;
 }
 
 .gold-banner-slide.active {
-    opacity: 1;
+    display: block;
     pointer-events: auto;
 }
 
 .gold-banner-slide .banner-image {
     max-width: 100%;
     object-fit: contain;
+}
+
+/* Banner Arrow Navigation */
+.banner-arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 10;
+    background: rgba(128, 128, 128, 0.15);
+    color: var(--text-muted);
+    border: none;
+    font-size: 18px;
+    line-height: 1;
+    width: 24px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    border-radius: 4px;
+    opacity: 0.3;
+    transition: opacity 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+    padding: 0;
+}
+
+.banner-arrow:hover {
+    opacity: 0.8;
+    background: rgba(128, 128, 128, 0.4);
+    color: var(--text-primary);
+}
+
+.banner-arrow-left {
+    left: 0;
+}
+
+.banner-arrow-right {
+    right: 0;
 }
 
 .page-view {

--- a/src/serena/resources/dashboard/index.html
+++ b/src/serena/resources/dashboard/index.html
@@ -26,6 +26,8 @@
 
         <!-- Platinum Banners in Header -->
         <div id="platinum-banners" class="header-banner">
+            <button class="banner-arrow banner-arrow-left" data-target="platinum" aria-label="Previous banner">&#8249;</button>
+            <button class="banner-arrow banner-arrow-right" data-target="platinum" aria-label="Next banner">&#8250;</button>
         </div>
     </div>
 
@@ -147,6 +149,8 @@
 
                 <!-- Gold Banners -->
                 <section id="gold-banners" class="gold-banners-section">
+                    <button class="banner-arrow banner-arrow-left" data-target="gold" aria-label="Previous banner">&#8249;</button>
+                    <button class="banner-arrow banner-arrow-right" data-target="gold" aria-label="Next banner">&#8250;</button>
                 </section>
             </div>
         </div>


### PR DESCRIPTION
Would look like this if we had multiple platinum banners, but since we only have one, arrows are hidden on platinum.


<img width="2553" height="1734" alt="image" src="https://github.com/user-attachments/assets/62f6036e-a53b-441d-bc0f-1917d03cadee" />



Closes: #1068 