### PR TITLE
[Kotlin LSP] Do not download extra Java.

### DIFF
--- a/docs/02-usage/050_configuration.md
+++ b/docs/02-usage/050_configuration.md
@@ -206,7 +206,7 @@ instead of Serena's managed installation, you can set the `ls_path` setting as f
 ```yaml
 ls_specific_settings:
   <language>:
-    ls_path: ["/path/to/language-server"]
+    ls_path: "/path/to/language-server"
 ```
 
 This is supported by all language servers deriving their dependency provider from  `LanguageServerDependencyProviderSinglePath`.


### PR DESCRIPTION
# Changes

- Do not download an extra jre, as kotlin lsp already ships one
