### PR TITLE
fix(kotlin): Kill Gradle daemons on KLS shutdown

### DIFF
--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -23,6 +23,7 @@ import stat
 import threading
 from typing import cast
 
+import psutil
 from overrides import override
 
 from solidlsp.ls import (
@@ -554,3 +555,61 @@ class KotlinLanguageServer(SolidLanguageServer):
     def _get_wait_time_for_cross_file_referencing(self) -> float:
         """Small safety buffer since we already waited for indexing to complete in _start_server."""
         return 1.0
+
+    @override
+    def stop(self, shutdown_timeout: float = 2.0) -> None:
+        java_home = self._get_java_home_from_dependency_provider()
+        super().stop(shutdown_timeout=shutdown_timeout)
+        if java_home:
+            self._kill_gradle_daemons(java_home)
+
+    def _get_java_home_from_dependency_provider(self) -> str | None:
+        if isinstance(self._dependency_provider, self.DependencyProvider):
+            return self._dependency_provider._java_home_path
+        return None
+
+    @staticmethod
+    def _kill_gradle_daemons(java_home: str) -> None:
+        """Kill Gradle daemons spawned by KLS during project indexing.
+
+        KLS triggers Gradle during indexing, which spawns persistent daemon processes that
+        outlive the KLS process (3-hour idle timeout, ~500MB RSS each). These daemons are
+        not children of KLS and are invisible to normal process-tree cleanup.
+
+        We identify them by matching the java executable in their command line against
+        the JAVA_HOME used by this KLS instance.
+        """
+        java_bin = os.path.join(java_home, "bin", "java")
+        try:
+            java_bin_resolved = os.path.realpath(java_bin)
+        except OSError:
+            return
+
+        killed: list[psutil.Process] = []
+        for proc in psutil.process_iter(["pid", "cmdline"]):
+            try:
+                cmdline = proc.info["cmdline"]
+                if not cmdline:
+                    continue
+                if not any("GradleDaemon" in arg for arg in cmdline):
+                    continue
+                # cmdline[0] is the java binary path used to start the daemon
+                try:
+                    proc_java_resolved = os.path.realpath(cmdline[0])
+                except OSError:
+                    continue
+                if proc_java_resolved == java_bin_resolved:
+                    log.info("Terminating Gradle daemon (PID %d) spawned by KLS", proc.pid)
+                    proc.terminate()
+                    killed.append(proc)
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                continue
+
+        if killed:
+            _, alive = psutil.wait_procs(killed, timeout=5)
+            for proc in alive:
+                log.warning("Gradle daemon (PID %d) did not terminate gracefully, killing", proc.pid)
+                try:
+                    proc.kill()
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass

--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -558,15 +558,11 @@ class KotlinLanguageServer(SolidLanguageServer):
 
     @override
     def stop(self, shutdown_timeout: float = 2.0) -> None:
-        java_home = self._get_java_home_from_dependency_provider()
+        assert isinstance(self._dependency_provider, self.DependencyProvider)
+        java_home = self._dependency_provider._java_home_path
+        assert java_home is not None
         super().stop(shutdown_timeout=shutdown_timeout)
-        if java_home:
-            self._kill_gradle_daemons(java_home)
-
-    def _get_java_home_from_dependency_provider(self) -> str | None:
-        if isinstance(self._dependency_provider, self.DependencyProvider):
-            return self._dependency_provider._java_home_path
-        return None
+        self._kill_gradle_daemons(java_home)
 
     @staticmethod
     def _kill_gradle_daemons(java_home: str) -> None:
@@ -579,11 +575,7 @@ class KotlinLanguageServer(SolidLanguageServer):
         We identify them by matching the java executable in their command line against
         the JAVA_HOME used by this KLS instance.
         """
-        java_bin = os.path.join(java_home, "bin", "java")
-        try:
-            java_bin_resolved = os.path.realpath(java_bin)
-        except OSError:
-            return
+        java_bin_resolved = os.path.realpath(os.path.join(java_home, "bin", "java"))
 
         killed: list[psutil.Process] = []
         for proc in psutil.process_iter(["pid", "cmdline"]):
@@ -594,11 +586,7 @@ class KotlinLanguageServer(SolidLanguageServer):
                 if not any("GradleDaemon" in arg for arg in cmdline):
                     continue
                 # cmdline[0] is the java binary path used to start the daemon
-                try:
-                    proc_java_resolved = os.path.realpath(cmdline[0])
-                except OSError:
-                    continue
-                if proc_java_resolved == java_bin_resolved:
+                if os.path.realpath(cmdline[0]) == java_bin_resolved:
                     log.info("Terminating Gradle daemon (PID %d) spawned by KLS", proc.pid)
                     proc.terminate()
                     killed.append(proc)


### PR DESCRIPTION
## Summary

- KLS triggers Gradle during project indexing, which spawns persistent daemon processes (~500MB RSS each, 3-hour idle timeout)
- These daemons detach from KLS (reparented to init/systemd) and are invisible to `psutil.Process.children(recursive=True)` cleanup
- Override `stop()` in `KotlinLanguageServer` to find and terminate matching Gradle daemons after normal shutdown
- Identification: match the java binary in the daemon's `cmdline[0]` against `JAVA_HOME/bin/java` from this KLS instance

## Root cause investigation

Investigation performed in #1079 (discussion thread) confirmed:

1. **KLS itself cleans up properly** — even under SIGKILL, the stdio pipe EOF causes KLS to exit naturally
2. **The real culprit: Gradle daemons** spawned during KLS project indexing:
   - Run independently (parent = systemd)
   - Use KLS's bundled JRE (`JAVA_HOME` points to `~/.serena/language_servers/static/KotlinLanguageServer/...`)
   - 3-hour default idle timeout
   - ~500MB RSS each
3. **Verified deterministically** via `/proc/PID/environ` and controlled before/after test runs

## Test results

Full test suite run with `pytest -n auto` (32 workers):

- **667 passed**, 82 skipped, 1 xfailed
- **23 failed** — all pre-existing, unrelated to this change:
  - Missing runtimes: .NET 10, Go/gopls, Nix, Ruby-dev, Zig, Perl, Swift
  - Flaky LS tests: Vue cross-file refs, SystemVerilog cross-file, Elm document symbols
  - CLI edge cases: project index/create
- **121 errors** — all missing runtime environments (dotnet, zig, perl, swift, ruby-dev)
- **All 5 Kotlin tests pass** ✓
- mypy type-check: **no issues** ✓

### Gradle daemon before/after verification

| | Before fix | After fix |
|---|---|---|
| New Gradle daemons after `pytest -m kotlin` | 1 new (~500MB) | **0** |
| Pre-existing system Gradle daemons | Untouched | Untouched |

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)