### PR TITLE
Fix ruby-lsp startup failures: rbenv support and Bundler isolation

### DIFF
--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -428,7 +428,9 @@ class RubyLsp(SolidLanguageServer):
         gemfile_path = os.path.join(ruby_lsp_dir, "Gemfile")
         if not os.path.exists(gemfile_path):
             with open(gemfile_path, "w") as f:
-                f.write('source "https://rubygems.org"\ngem "ruby-lsp"\n')
+                # Pin rbs < 3.9 to avoid incompatibility with Ruby < 3.4.
+                # rbs >= 3.9 uses bare Pathname() which is only available in Ruby 3.4+.
+                f.write('source "https://rubygems.org"\ngem "ruby-lsp"\ngem "rbs", "< 3.9"\n')
             log.info(f"Created minimal Gemfile at {gemfile_path}")
         # Create composed marker so ruby-lsp skips its own bundle setup
         composed_marker = os.path.join(ruby_lsp_dir, "bundle_is_composed")

--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -42,7 +42,11 @@ class RubyLsp(SolidLanguageServer):
         ruby_lsp_gemfile = os.path.join(repository_root_path, ".ruby-lsp", "Gemfile")
         launch_env = {"BUNDLE_GEMFILE": ruby_lsp_gemfile}
         super().__init__(
-            config, repository_root_path, ProcessLaunchInfo(cmd=ruby_lsp_executable, cwd=repository_root_path, env=launch_env), "ruby", solidlsp_settings
+            config,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=ruby_lsp_executable, cwd=repository_root_path, env=launch_env),
+            "ruby",
+            solidlsp_settings,
         )
         self.analysis_complete = threading.Event()
         self.service_ready_event = threading.Event()


### PR DESCRIPTION
## Problem

ruby-lsp fails to start in two common setups:

**1. rbenv-managed Ruby**
When rbenv is active, ruby-lsp is launched via the shim path (e.g.
`~/.rbenv/shims/ruby-lsp`). Shims route through rbenv at runtime, but
the gem environment they resolve to can differ from the Ruby version
specified in `.ruby-version`. This causes ruby-lsp to run under the
wrong Ruby version or fail to find gems entirely.

**2. Projects with native gem dependencies (e.g. mysql2, pg)**
Ruby's Bundler auto-loads the project's `Gemfile` at startup via
`bundler/setup.rb`. If any gem in the project requires native extensions
that aren't compiled (e.g. `mysql2` without `libmysqlclient`), the
Ruby process fails before ruby-lsp even initialises. This affects any
project using database gems.

## Fix

Three targeted changes, all in `ruby_lsp.py`:

**1. rbenv: launch via `rbenv exec`**
When `use_rbenv` is detected, ruby-lsp is launched as
`["rbenv", "exec", "ruby-lsp"]` instead of via the shim path. This
ensures the correct Ruby version and gem environment are always used.
Same fix applied to `gem install` when ruby-lsp is not yet installed.

**2. `BUNDLE_GEMFILE` isolation**
Sets `BUNDLE_GEMFILE=.ruby-lsp/Gemfile` in the process environment
before launching ruby-lsp. This prevents Bundler from auto-loading
the project's `Gemfile`, isolating ruby-lsp from native project gems.

**3. Minimal composed bundle**
Pre-creates `.ruby-lsp/Gemfile` (with only `ruby-lsp` + `rbs < 3.9`
for Ruby < 3.4 compatibility) and the `bundle_is_composed` marker file
so ruby-lsp skips its own bundle setup entirely. Stale `Gemfile.lock`
and `main_lockfile_hash` from failed previous attempts are cleaned up.

## Example

Before this fix, opening a Rails project with `gem "mysql2"` in its
`Gemfile` would produce:

```
Could not find gem 'mysql2' in locally installed gems.
Run `bundle install` to install missing gems.
```
...and ruby-lsp would never start.

After this fix, ruby-lsp starts cleanly because Bundler never sees
the project's `Gemfile`.