### PR TITLE
Fix Marksman: remap heading symbol kind from String to Namespace

### DIFF
--- a/test/solidlsp/markdown/test_markdown_basic.py
+++ b/test/solidlsp/markdown/test_markdown_basic.py
@@ -93,3 +93,19 @@ class TestMarkdownLanguageServerBasics:
 
         for symbol in all_symbols:
             assert symbol["kind"] == SymbolKind.Namespace, f"Nested heading '{symbol['name']}' should be remapped to Namespace"
+
+    @pytest.mark.parametrize("language_server", [Language.MARKDOWN], indirect=True)
+    def test_markdown_overview_includes_all_heading_levels(self, language_server: SolidLanguageServer) -> None:
+        """Test that request_document_overview returns all heading levels flattened.
+
+        Verifies that the Marksman override of request_document_overview flattens the
+        heading hierarchy so that H2+ headings appear directly in the overview result,
+        rather than being buried as nested children requiring depth>0 to surface.
+        """
+        overview_symbols = language_server.request_document_overview("README.md")
+        overview_names = [sym["name"] for sym in overview_symbols]
+
+        # README.md has H1 "Test Repository", H2s like "Overview"/"Features", and H3s like "Installation"
+        assert "Test Repository" in overview_names, "H1 heading should appear in overview"
+        assert "Overview" in overview_names, "H2 heading should appear in overview without needing depth>0"
+        assert "Installation" in overview_names, "H3 heading should appear in overview without needing depth>0"


### PR DESCRIPTION
## Problem

Marksman LSP returns all markdown headings (H1–H6) with `SymbolKind.String` (15). Since `String (15) >= Variable (13)`, `is_low_level()` filtered every heading out of `get_symbols_overview` — no headings appeared at all.

Additionally, Marksman nests headings hierarchically (H2 under H1, H3 under H2, etc.) via `hierarchicalDocumentSymbolSupport`. Even after fixing the kind, `request_document_overview` returns only `root_symbols` (H1), so `get_symbols_overview` with the default `depth=0` would still silently omit H2–H6, forcing agents to fall back to `search_for_pattern` for sub-headings.

## Fix

**1. Remap `SymbolKind.String` → `SymbolKind.Namespace` in `request_document_symbols`**

All heading symbols returned by Marksman are recursively remapped so they pass the `is_low_level()` filter. `Namespace` (3) is semantically appropriate — headings are named sections containing other content. Marksman only uses `String` for headings, so the remap is safe.

**2. Flatten heading hierarchy in `request_document_overview`**

Overrides `request_document_overview` to recursively collect all headings from the full symbol tree and return them as a flat list. This ensures H2–H6 appear directly in `get_symbols_overview` at `depth=0` without requiring depth tricks or pattern search fallbacks.

## Tests

- Verify all heading kinds are remapped to `Namespace` (not `String`)
- Verify no heading is classified as `is_low_level()`
- Verify nested headings in `api.md` (H1–H5) are all remapped
- **New:** Verify `request_document_overview` surfaces H1, H2, and H3 without `depth>0`