### PR TITLE
Add ignore_all_dot_files config option; fix Pyright dot-directory indexing

### DIFF
--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -180,6 +180,7 @@ class ProjectConfig(SharedConfig):
     ignored_paths: list[str] = field(default_factory=list)
     read_only: bool = False
     ignore_all_files_in_gitignore: bool = True
+    ignore_all_dot_files: bool = True
     initial_prompt: str = ""
     encoding: str = DEFAULT_SOURCE_FILE_ENCODING
 

--- a/src/serena/ls_manager.py
+++ b/src/serena/ls_manager.py
@@ -23,6 +23,7 @@ class LanguageServerFactory:
         ls_timeout: float | None = None,
         ls_specific_settings: dict | None = None,
         trace_lsp_communication: bool = False,
+        ignore_all_dot_files: bool = True,
     ):
         self.project_root = project_root
         self.encoding = encoding
@@ -30,6 +31,7 @@ class LanguageServerFactory:
         self.ls_timeout = ls_timeout
         self.ls_specific_settings = ls_specific_settings
         self.trace_lsp_communication = trace_lsp_communication
+        self.ignore_all_dot_files = ignore_all_dot_files
 
     def create_language_server(self, language: Language) -> SolidLanguageServer:
         ls_config = LanguageServerConfig(
@@ -37,6 +39,7 @@ class LanguageServerFactory:
             ignored_paths=self.ignored_patterns,
             trace_lsp_communication=self.trace_lsp_communication,
             encoding=self.encoding,
+            ignore_all_dot_files=self.ignore_all_dot_files,
         )
 
         log.info(f"Creating language server instance for {self.project_root}, language={language}.")

--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -495,6 +495,7 @@ class Project(ToStringMixin):
             ls_timeout=ls_timeout,
             ls_specific_settings=ls_specific_settings,
             trace_lsp_communication=trace_lsp_communication,
+            ignore_all_dot_files=self.project_config.ignore_all_dot_files,
         )
         self.language_server_manager = LanguageServerManager.from_languages(self.project_config.languages, factory)
         return self.language_server_manager

--- a/src/serena/resources/project.template.yml
+++ b/src/serena/resources/project.template.yml
@@ -41,6 +41,11 @@ language_backend:
 # whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
+# whether to ignore all directories whose name starts with a dot (e.g. .git, .venv, .config).
+# Set to false if you need symbol retrieval in dot-prefixed directories (e.g. .github workflows).
+# Note: .git is always ignored via .gitignore regardless of this setting.
+ignore_all_dot_files: true
+
 # list of additional paths to ignore in this project.
 # Same syntax as gitignore, so you can use * and **.
 # Note: global ignored_paths from serena_config.yml are also applied additively.

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -352,7 +352,11 @@ class SolidLanguageServer(ABC):
         A language-specific condition for directories that should always be ignored. For example, venv
         in Python and node_modules in JS/TS should be ignored always.
         """
-        return dirname.startswith(".")
+        if dirname == ".git":
+            return True
+        if self._ignore_all_dot_files and dirname.startswith("."):
+            return True
+        return False
 
     @staticmethod
     def _determine_log_level(line: str) -> int:
@@ -466,6 +470,7 @@ class SolidLanguageServer(ABC):
         self._ls_resources_dir = self.ls_resources_dir(solidlsp_settings)
         log.debug(f"Custom config (LS-specific settings) for {lang}: {self._custom_settings}")
         self._encoding = config.encoding
+        self._ignore_all_dot_files = config.ignore_all_dot_files
         self.repository_root_path: str = repository_root_path
 
         log.debug(

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -467,6 +467,8 @@ class LanguageServerConfig:
     start_independent_lsp_process: bool = True
     ignored_paths: list[str] = field(default_factory=list)
     """Paths, dirs or glob-like patterns. The matching will follow the same logic as for .gitignore entries"""
+    ignore_all_dot_files: bool = True
+    """Whether to ignore all directories whose name starts with a dot (e.g. .git, .venv, .config)"""
     encoding: str = "utf-8"
     """File encoding to use when reading source files"""
 


### PR DESCRIPTION
## Problem

Serena unconditionally ignores all dot-prefixed directories (e.g.
`.github`, `.config`, `.devcontainer`) via `is_ignored_dirname()`.
This is the right default for most cases, but breaks legitimate
workflows:

- **`.github/` workflows**: teams that store YAML, scripts or
  documentation in `.github/` cannot get symbol support for those files
- **`.config/` or `.devcontainer/`**: project config files in
  dot-directories are invisible to Serena

Additionally, Pyright has its own internal dot-directory exclusion that
is separate from Serena's. Even when Serena's exclusion was adjusted,
Pyright would still skip dot-directories because its `initializationOptions`
excluded `**/.venv` etc., and its own defaults excluded `**/.*`.
Pyright also sends `workspace/configuration` requests to fetch
`python.analysis` settings — these were previously unhandled, causing
silent misconfiguration.

## Fix

**New config option: `ignore_all_dot_files`** (default: `true`)

Added to `ProjectConfig`, `LanguageServerConfig`, and
`project.template.yml`. When set to `false`:

- `SolidLanguageServer.is_ignored_dirname()` only ignores `.git`
  unconditionally; all other dot-directories are traversed
- `PyrightServer._get_initialize_params()` becomes an instance method
  and builds exclude/include lists based on `ignore_all_dot_files`:
  - `false`: adds `include: ["."]` to override Pyright's internal
    dot-directory exclusion
  - `true`: keeps existing behaviour (excludes `.venv`, `.env`, `.pixi`)
- `PyrightServer` now handles `workspace/configuration` requests,
  returning appropriate `python.analysis` include/exclude settings

## Example

```yaml
# .serena/project.yml
ignore_all_dot_files: false  # enable symbol retrieval in .github/, etc.
```

```python
# Before: .github/workflows/ci.yml invisible to Serena
get_symbols_overview(".github/workflows/ci.yml")
# → FileNotFoundError or empty (directory ignored)

# After:
get_symbols_overview(".github/workflows/ci.yml")
# → {"on": {}, "jobs": {...}}
```