### PR TITLE
fix: auto-close dashboard tab when server stops

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -532,6 +532,13 @@ class SerenaAgent:
         """
         Opens the Serena web dashboard in the default web browser.
 
+        On Linux, prefers Chromium/Chrome in ``--app`` mode so the dashboard
+        opens as a standalone window.  This allows the heartbeat-based
+        ``window.close()`` in *dashboard.js* to work, because browsers only
+        permit ``window.close()`` for windows that were not opened as regular
+        tabs.  Falls back to the default browser via ``webbrowser.open()`` if
+        no supported Chromium-based browser is found.
+
         :return: a message indicating success or failure
         """
         if self._dashboard_url is None:
@@ -541,7 +548,25 @@ class SerenaAgent:
             log.warning("Not opening the Serena web dashboard because no usable display was detected.")
             return False
 
-        # Use a subprocess to avoid any output from webbrowser.open being written to stdout
+        # On Linux, try Chromium/Chrome in app-mode so that window.close()
+        # works when the server shuts down (heartbeat-based auto-close).
+        if platform.system() == "Linux":
+            import shutil
+
+            for browser_cmd in ("chromium-browser", "chromium", "google-chrome", "google-chrome-stable"):
+                browser_path = shutil.which(browser_cmd)
+                if browser_path:
+                    subprocess.Popen(
+                        [browser_path, f"--app={self._dashboard_url}"],
+                        stdin=subprocess.DEVNULL,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        start_new_session=True,
+                    )
+                    return True
+
+        # Fallback: use the default browser via webbrowser.open.
+        # Use a subprocess to avoid any output from webbrowser.open being written to stdout.
         subprocess.Popen(
             [sys.executable, "-c", f"import webbrowser; webbrowser.open({self._dashboard_url!r})"],
             stdin=subprocess.DEVNULL,

--- a/src/serena/resources/dashboard/dashboard.js
+++ b/src/serena/resources/dashboard/dashboard.js
@@ -491,9 +491,15 @@ class Dashboard {
             error: function (xhr, status, error) {
                 self.heartbeatFailureCount++;
                 console.error('Heartbeat failure; count = ', self.heartbeatFailureCount);
-                if (self.heartbeatFailureCount >= 1) {
+                if (self.heartbeatFailureCount >= 3) {
                     console.log('Server appears to be down, closing tab');
                     window.close();
+                    // Fallback: window.close() is blocked by most browsers for
+                    // tabs that were not opened via window.open().  Navigate to
+                    // about:blank so the tab is visually cleared.
+                    setTimeout(function () {
+                        window.location.replace('about:blank');
+                    }, 500);
                 }
             },
         });
@@ -2180,6 +2186,10 @@ class Dashboard {
             self.$errorContainer.html('<div class="error-message">Shutting down ...</div>')
             setTimeout(function () {
                 window.close();
+                // Fallback if window.close() was blocked by the browser
+                setTimeout(function () {
+                    window.location.replace('about:blank');
+                }, 500);
             }, 1000);
         }
 


### PR DESCRIPTION
## Summary

The web dashboard tab stays open in the browser after the Serena server stops (e.g. when the parent Claude Code / MCP client session ends). The heartbeat-based `window.close()` in `dashboard.js` doesn't work because modern browsers block `window.close()` for tabs that were not opened by JavaScript's `window.open()`.

**Two fixes:**

- **`agent.py`** — On Linux, prefer opening the dashboard in Chromium/Chrome `--app` mode, which creates a standalone window where `window.close()` is permitted. Falls back to `webbrowser.open()` when no Chromium-based browser is found.
- **`dashboard.js`** — Add `about:blank` redirect as fallback after `window.close()` in both the heartbeat handler and the manual shutdown method, so even without app mode the tab clears itself. Also raises the heartbeat failure threshold from 1 to 3 to avoid premature close on transient network hiccups.

## Test plan

- [ ] Start Serena MCP server with `web_dashboard_open_on_launch: true` on a Linux system with Chromium installed — dashboard should open as a standalone app window (no URL bar)
- [ ] Kill the Serena server process — the dashboard window should close automatically via `window.close()`
- [ ] On a system without Chromium (e.g. Firefox-only), verify it falls back to `webbrowser.open()` and the tab redirects to `about:blank` when the server stops
- [ ] Click Menu → Shutdown Server — tab should close or redirect to `about:blank`