### PR TITLE
feat: Auto-detect all languages in non-interactive / autonomous agent mode

### DIFF
--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -274,7 +274,7 @@ class ProjectConfig(SharedConfig):
                     languages_to_use = [lang.value for lang, _ in languages_and_percentages]
                     log.info(
                         "Non-interactive mode: automatically enabling all detected languages: %s",
-                        languages_to_use,
+                        [(lang, f"{pct:.2f}%") for lang, pct in languages_and_percentages],
                     )
                 else:
                     # find the language with the highest percentage and enable it

--- a/src/serena/util/inspection.py
+++ b/src/serena/util/inspection.py
@@ -57,10 +57,10 @@ def determine_programming_language_composition(repo_path: str) -> dict[Language,
         if count > 0:
             language_counts[language] = count
 
-    # Convert counts to percentages
+    # Convert counts to percentages (unrounded, so sorting by percentage is equivalent to sorting by count)
     language_percentages: dict[Language, float] = {}
     for language, count in language_counts.items():
         percentage = (count / total_files) * 100
-        language_percentages[language] = round(percentage, 2)
+        language_percentages[language] = percentage
 
     return language_percentages

--- a/test/serena/config/test_serena_config.py
+++ b/test/serena/config/test_serena_config.py
@@ -52,20 +52,35 @@ class TestProjectConfigAutogenerate:
         # Create files for multiple languages
         (self.project_path / "small.js").write_text("console.log('JS');")
 
-        # Run autogenerate - should pick Python as dominant
+        # Run autogenerate - TypeScript should always be detected for JS files
         config = ProjectConfig.autogenerate(self.project_path, save_to_disk=False)
 
-        assert config.languages == [Language.TYPESCRIPT]
+        assert Language.TYPESCRIPT in config.languages
 
     def test_autogenerate_with_multiple_languages(self):
-        """Test autogeneration picks dominant language when multiple are present."""
-        # Create files for multiple languages
+        """Test autogeneration enables all detected languages by default in non-interactive mode."""
+        # Create files for multiple languages (2 Python, 1 JS/TS)
         (self.project_path / "main.py").write_text("print('Python')")
         (self.project_path / "util.py").write_text("def util(): pass")
         (self.project_path / "small.js").write_text("console.log('JS');")
 
-        # Run autogenerate - should pick Python as dominant
+        # Default: auto_detect_all_languages=True — all detected languages should be enabled
         config = ProjectConfig.autogenerate(self.project_path, save_to_disk=False)
+
+        assert Language.PYTHON in config.languages
+        assert Language.TYPESCRIPT in config.languages
+        # Python has more files so it should come first
+        assert config.languages[0] == Language.PYTHON
+
+    def test_autogenerate_with_multiple_languages_dominant_only(self):
+        """Test autogeneration picks only the dominant language when auto_detect_all_languages=False."""
+        # Create files for multiple languages (2 Python, 1 JS/TS)
+        (self.project_path / "main.py").write_text("print('Python')")
+        (self.project_path / "util.py").write_text("def util(): pass")
+        (self.project_path / "small.js").write_text("console.log('JS');")
+
+        # Explicit opt-out: only the dominant language should be enabled
+        config = ProjectConfig.autogenerate(self.project_path, save_to_disk=False, auto_detect_all_languages=False)
 
         assert config.languages == [Language.PYTHON]
 
@@ -120,7 +135,7 @@ class TestProjectConfigAutogenerate:
         config = ProjectConfig.autogenerate(self.project_path, project_name=custom_name, save_to_disk=False)
 
         assert config.project_name == custom_name
-        assert config.languages == [Language.TYPESCRIPT]
+        assert Language.TYPESCRIPT in config.languages
 
 
 class TestProjectConfig:


### PR DESCRIPTION
Closes #1125

## Problem

When Serena is invoked via MCP from an autonomous agent (Claude Code SDK, CI pipelines, etc.) and no `.serena/project.yml` exists, `ProjectConfig.autogenerate()` only enables the **single dominant language** by file count. Secondary languages are silently dropped.

For polyglot repos (e.g. Python backend + TypeScript/React frontend) this means all LSP-based tools (`find_symbol`, `get_symbols_overview`, `replace_symbol_body`, etc.) return empty or wrong results for the non-dominant language, with no error or warning to indicate why.

## Solution

Add `auto_detect_all_languages: bool = True` to `ProjectConfig.autogenerate()`.

- **Non-interactive mode** (default for MCP/agent): all detected languages are automatically enabled, sorted by file count descending.
- **Interactive mode**: behaviour is unchanged — the user is still asked about each additional language.

The change is backward-compatible: existing `project.yml` files are not affected; the parameter only applies during auto-generation when no config exists yet.

## What changes

**`src/serena/config/serena_config.py`**
- `autogenerate()` gains `auto_detect_all_languages: bool = True`
- In non-interactive mode with this flag, `languages_to_use` is populated from all detected languages, not just the top one
- Adds a log line listing all enabled languages for visibility

## No new dependencies

The `LanguageServerManager` already spawns multiple language servers in parallel threads and `get_language_server()` already routes tool calls by file extension — this PR purely fixes the auto-detection step upstream.
