### PR TITLE
fix: append PID to log filename to prevent concurrent server collision

### DIFF
--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -104,7 +104,7 @@ class SerenaPaths:
         """
         log_dir = os.path.join(self.serena_user_home_dir, "logs", datetime.now().strftime("%Y-%m-%d"))
         os.makedirs(log_dir, exist_ok=True)
-        self.last_returned_log_file_path = os.path.join(log_dir, prefix + "_" + datetime_tag() + ".txt")
+        self.last_returned_log_file_path = os.path.join(log_dir, prefix + "_" + datetime_tag() + f"_{os.getpid()}" + ".txt")
         return self.last_returned_log_file_path
 
     # TODO: Paths from constants.py should be moved here


### PR DESCRIPTION
  When multiple MCP servers start within the same second, they derive the
  same log filename from datetime_tag() (second-level precision only).
  Both then open the file with mode='w', causing one server's logs to be
  truncated and all subsequent output to be interleaved.

  Appending os.getpid() to the filename guarantees uniqueness across
  concurrent processes regardless of timing.