### PR TITLE
fix(kotlin): redirect idea.system.path to prevent stale /tmp dirs

### DIFF
--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -14,6 +14,13 @@ Example configuration for large projects:
     ls_specific_settings:
       kotlin:
         jvm_options: '-Xmx4G -XX:+UseG1GC'
+
+IntelliJ system directory:
+    KLS is built on IntelliJ's platform, which by default creates a new ~52 MB
+    idea-system<random>/ directory in /tmp for each instance. These directories
+    are never cleaned up, which can exhaust RAM on tmpfs systems after many runs.
+    Serena redirects idea.system.path to <ls_resources_dir>/kotlin_language_server/system/,
+    making it a bounded per-project cache that persists across sessions (faster restarts).
 """
 
 import logging
@@ -146,7 +153,18 @@ class KotlinLanguageServer(SolidLanguageServer):
             else:
                 jvm_options = DEFAULT_KOTLIN_JVM_OPTIONS
 
-            env["JAVA_TOOL_OPTIONS"] = jvm_options
+            # Redirect IntelliJ's system directory to a stable path under ls_resources_dir.
+            # Without this, each KLS instance creates a new ~52 MB /tmp/idea-system<random>/ directory
+            # that is never removed on shutdown. On tmpfs systems this causes unbounded RAM consumption
+            # (e.g. 329 stale directories totalling 30 GiB after repeated test runs).
+            # Using a fixed path makes it a bounded per-project cache and preserves the IntelliJ index
+            # across sessions for faster restarts.
+            system_dir = os.path.join(self._ls_resources_dir, "kotlin_language_server", "system")
+            os.makedirs(system_dir, exist_ok=True)
+            idea_system_path_opt = f"-Didea.system.path={system_dir}"
+            jvm_options_full = f"{jvm_options} {idea_system_path_opt}".strip() if jvm_options else idea_system_path_opt
+
+            env["JAVA_TOOL_OPTIONS"] = jvm_options_full
             return env
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes #1087

The Kotlin Language Server (KLS) is built on IntelliJ's platform, which by default creates a new `idea-system<random>/` directory in `/tmp` for each instance. These directories are never removed on shutdown, causing unbounded accumulation.

On `tmpfs` systems (the default on modern Linux), this means unbounded RAM consumption — the issue author observed 329 stale directories totalling 30 GiB after repeated test runs.

## Fix

In `DependencyProvider.create_launch_command_env()`, append `-Didea.system.path=<ls_resources_dir>/kotlin_language_server/system/` to `JAVA_TOOL_OPTIONS`. This redirects IntelliJ to a fixed, per-project location instead of `/tmp/idea-system<random>/`.

The chosen location (`ls_resources_dir/kotlin_language_server/system/`) is:
- **Bounded**: one directory per project (not one per run)
- **Persistent**: IntelliJ index is preserved across sessions → faster restarts
- **Controlled**: within Serena's own resource directory, not system-wide `/tmp`

## Changes

- **`src/solidlsp/language_servers/kotlin_language_server.py`**
  - `create_launch_command_env()`: compute `system_dir`, create it, and append `-Didea.system.path` to `JAVA_TOOL_OPTIONS`
  - Updated module docstring to document the IntelliJ system directory behaviour

## Testing

The fix can be verified by running the Kotlin language server tests and confirming that no new `idea-system*` directories appear in `/tmp` during the test run, while `<ls_resources_dir>/kotlin_language_server/system/` is populated instead.

---
🤖 Generated with Claude Code