### PR TITLE
docs: clarify that JavaScript is handled via the TypeScript language server

### DIFF
--- a/docs/01-about/020_programming-languages.md
+++ b/docs/01-about/020_programming-languages.md
@@ -59,7 +59,8 @@ Some languages require additional installations or setup steps, as noted.
   on macOS, requires Rust toolchain for building from source;
   note: reference search is not supported by this language server)
 * **Java**  
-* **JavaScript**
+* **JavaScript**  
+  (handled via the TypeScript language server; projects will appear as TypeScript in the dashboard and the Add Language menu does not show JavaScript separately — this is expected and all JavaScript features work normally)
 * **Julia**
 * **Kotlin**  
   (uses the pre-alpha [official kotlin LS](https://github.com/Kotlin/kotlin-lsp), some issues may appear)
@@ -87,7 +88,7 @@ Some languages require additional installations or setup steps, as noted.
 * **Scala**  
   (requires some [manual setup](../03-special-guides/scala_setup_guide_for_serena); uses Metals LSP)
 * **Swift**
-* **TypeScript**
+* **TypeScript** (also handles JavaScript — see JavaScript entry above)
 * **Vue**    
   (3.x with TypeScript; requires Node.js v18+ and npm; supports .vue Single File Components with monorepo detection)
 * **YAML**


### PR DESCRIPTION
Closes #1141

JavaScript support is provided internally by the TypeScript language server (via a `lang_name_mapping` in the config). This means JavaScript projects will appear as TypeScript in the Serena dashboard, and the Add Language menu doesn't list JavaScript as a separate option — which is expected and works correctly.

Without a note, users (and LLMs) get confused when they see the dashboard report "TypeScript" for a plain JS project. The LLM then warns the user about a mismatch that doesn't actually indicate a problem.

Added an inline note under the JavaScript entry in the language support docs, and a cross-reference on the TypeScript entry.

Co-Authored-By: Claude <noreply@anthropic.com>