### PR TITLE
Fix path_to_project_yml method to use config instead of removed constant

### DIFF
--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -333,7 +333,7 @@ class Project(ToStringMixin):
         return self._serena_data_folder
 
     def path_to_project_yml(self) -> str:
-        return os.path.join(self._serena_data_folder, ProjectConfig.SERENA_DEFAULT_PROJECT_FILE)
+        return self._serena_config.get_project_yml_location(self.project_root)
 
     def get_activation_message(self) -> str:
         """


### PR DESCRIPTION
I installed Serena from the main branch and got the following error when trying to remove / add language support using the Serena Dashboard:

```sh
ERROR 2026-03-09 17:00:46,710 [Task-3:RemoveLanguage:python] serena.task_executor:__exit__:342 - Task-3:RemoveLanguage:python failed after 0.000 seconds
ERROR 2026-03-09 17:00:46,710 [Task-3:RemoveLanguage:python] serena.task_executor:run_task:62 - Error during execution of Task-3:RemoveLanguage:python: type object 'ProjectConfig' has no attribute 'SERENA_DEFAULT_PROJECT_FILE'
Traceback (most recent call last):
  File "/home/tamaro-skaljic/Desktop/serena/src/serena/task_executor.py", line 57, in run_task
    result = self._function()
             ^^^^^^^^^^^^^^^^
  File "/home/tamaro-skaljic/Desktop/serena/src/serena/agent.py", line 847, in <lambda>
    self.issue_task(lambda: self.get_active_project_or_raise().remove_language(language), name=f"RemoveLanguage:{language.value}")
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tamaro-skaljic/Desktop/serena/src/serena/project.py", line 662, in remove_language
    self.save_config()
  File "/home/tamaro-skaljic/Desktop/serena/src/serena/project.py", line 330, in save_config
    self.project_config.save(self.path_to_project_yml())
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tamaro-skaljic/Desktop/serena/src/serena/project.py", line 336, in path_to_project_yml
    return os.path.join(self._serena_data_folder, ProjectConfig.SERENA_DEFAULT_PROJECT_FILE)
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'ProjectConfig' has no attribute 'SERENA_DEFAULT_PROJECT_FILE'
```