### PR TITLE
Fix stale _default_language_server reference causing duplicate LS process spawning after restart

### DIFF
--- a/src/serena/ls_manager.py
+++ b/src/serena/ls_manager.py
@@ -77,9 +77,8 @@ class LanguageServerManager:
         """
         self._language_servers = language_servers
         self._language_server_factory = language_server_factory
-        self._default_language_server: SolidLanguageServer | None = None
-        self._root_path: str | None = None
-        self._sync_default_ls()
+        self._default_language_server = next(iter(language_servers.values()))
+        self._root_path = self._default_language_server.repository_root_path
 
     @staticmethod
     def from_languages(languages: list[Language], factory: LanguageServerFactory) -> "LanguageServerManager":


### PR DESCRIPTION
## Problem

When a language server process (e.g. clangd) terminates unexpectedly, subsequent MCP tool
calls can spawn multiple duplicate language server processes, leaving orphan processes behind.

### Root Cause

`LanguageServerManager` maintains a `_default_language_server` field that is set once during
`__init__` and **never updated** when language servers are restarted or replaced. However,
`get_language_server()` falls back to this field when there is only one managed server
(the common case):

```python
if ls is None:
    ls = self._default_language_server  # always points to the original (now dead) LS
```

This means that after a restart triggered by one task (e.g. Task-6), the `_language_servers`
dict is correctly updated with the new LS instance, but `_default_language_server` still
references the old, dead one. When a subsequent task (e.g. Task-8) calls
`get_language_server()` and falls through to the default, it gets the stale reference,
detects it as not running, and triggers **another** unnecessary restart — overwriting the
perfectly healthy LS that Task-6 just created, which then becomes an orphan process.

### Observed Behavior (from logs)
1. clangd (PID=27453) is killed externally

2. Task-6 detects dead LS → restarts → creates new clangd (PID=29459) ✅

3. Task-7 uses iter_language_servers() → gets PID=29459 from dict → works fine ✅

4. Task-8 uses get_language_server() → falls back to _default_language_server
→ gets the OLD dead LS (PID=27453) → triggers ANOTHER restart
→ creates clangd (PID=29914) → PID=29459 becomes an orphan process ❌

