### PR TITLE
fix: add dedicated max_memory_length config for write_memory tool

### DIFF
--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -604,6 +604,12 @@ class SerenaConfig(SharedConfig):
     Even though the value of the max_answer_chars can be changed when calling the tool, it may make sense to adjust this default 
     through the global configuration.
     """
+    max_memory_length: int = 50_000
+    """Maximum number of characters that can be written to a memory file via the write_memory tool.
+    This limit is independent of default_max_tool_answer_chars, which controls the size of tool responses
+    sent back to the LLM. Memory files are stored on disk, so they can be larger than typical tool responses,
+    but should still be kept concise to remain useful.
+    """
     ls_specific_settings: dict = field(default_factory=dict)
     """Advanced configuration option allowing to configure language server implementation specific options, see SolidLSPSettings for more info."""
 

--- a/src/serena/resources/serena_config.template.yml
+++ b/src/serena/resources/serena_config.template.yml
@@ -110,6 +110,11 @@ default_modes:
 # through the global configuration.
 default_max_tool_answer_chars: 150000
 
+# Maximum number of characters that can be written to a memory file via the write_memory tool.
+# This limit is independent of default_max_tool_answer_chars, which controls tool response sizes.
+# Increase this if you need to store larger memory files.
+max_memory_length: 50000
+
 # the name of the token count estimator to use for tool usage statistics.
 # See the `RegisteredTokenCountEstimator` enum for available options.
 #

--- a/src/serena/tools/memory_tools.py
+++ b/src/serena/tools/memory_tools.py
@@ -16,12 +16,12 @@ class WriteMemoryTool(Tool, ToolMarkerCanEdit):
         If explicitly instructed, use the "global/" prefix for writing a memory that is shared across projects
         (e.g., "global/java/style_guide")
 
-        :param max_chars: the maximum number of characters to write. By default, determined by the config,
-            change only if instructed to do so.
+        :param max_chars: the maximum number of characters to write. By default, determined by the
+            max_memory_length config setting. Change only if instructed to do so.
         """
         # NOTE: utf-8 encoding is configured in the MemoriesManager
         if max_chars == -1:
-            max_chars = self.agent.serena_config.default_max_tool_answer_chars
+            max_chars = self.agent.serena_config.max_memory_length
         if len(content) > max_chars:
             raise ValueError(
                 f"Content for {memory_name} is too long. Max length is {max_chars} characters. " + "Please make the content shorter."


### PR DESCRIPTION
fixes #527

write_memory was using `default_max_tool_answer_chars` to cap memory content length. that's the config for tool response sizes (what gets sent to the LLM), not for what gets written to disk — two different things.

added `max_memory_length: 50_000` to `SerenaConfig` as an independent limit. also added it to `serena_config.template.yml` so users can see and override it.

changes:
- `src/serena/config/serena_config.py`: new `max_memory_length` field (default 50k chars)
- `src/serena/resources/serena_config.template.yml`: documented the new option
- `src/serena/tools/memory_tools.py`: use `max_memory_length` instead of `default_max_tool_answer_chars`

Co-Authored-By: Claude <noreply@anthropic.com>