### PR TITLE
Fix Swift find_referencing_symbols: add --scratch-path and resolve via xcrun

### DIFF
--- a/src/solidlsp/language_servers/sourcekit_lsp.py
+++ b/src/solidlsp/language_servers/sourcekit_lsp.py
@@ -31,6 +31,36 @@ class SourceKitLSP(SolidLanguageServer):
         return super().is_ignored_dirname(dirname) or dirname in [".build", ".swiftpm", "node_modules", "dist", "build"]
 
     @staticmethod
+    def _resolve_sourcekit_lsp_path() -> str:
+        """Resolve the path to sourcekit-lsp, preferring Xcode's version over Command Line Tools.
+
+        On macOS, bare `sourcekit-lsp` may resolve to the Command Line Tools version which
+        has limited capabilities. Using `xcrun --find sourcekit-lsp` resolves to Xcode's
+        full-featured version when Xcode is installed.
+        """
+        # Try xcrun with DEVELOPER_DIR pointing to Xcode (not Command Line Tools)
+        xcode_path = "/Applications/Xcode.app/Contents/Developer"
+        for env_override in [{"DEVELOPER_DIR": xcode_path}, {}]:
+            try:
+                run_env = {**os.environ, **env_override} if env_override else None
+                result = subprocess.run(
+                    ["xcrun", "--find", "sourcekit-lsp"],
+                    capture_output=True, text=True, check=False, timeout=10,
+                    env=run_env,
+                )
+                if result.returncode == 0:
+                    resolved = result.stdout.strip()
+                    if resolved and os.path.isfile(resolved):
+                        log.info(f"Resolved sourcekit-lsp via xcrun: {resolved}")
+                        return resolved
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                pass
+
+        # Fall back to bare command (Linux, or macOS without Xcode)
+        log.info("xcrun not available or failed, falling back to bare sourcekit-lsp")
+        return "sourcekit-lsp"
+
+    @staticmethod
     def _get_sourcekit_lsp_version() -> str:
         """Get the installed sourcekit-lsp version or raise error if sourcekit was not found."""
         try:
@@ -49,12 +79,15 @@ class SourceKitLSP(SolidLanguageServer):
         sourcekit_version = self._get_sourcekit_lsp_version()
         log.info(f"Starting sourcekit lsp with version: {sourcekit_version}")
 
+        # Resolve sourcekit-lsp path — prefer Xcode's version over Command Line Tools
+        sourcekit_path = self._resolve_sourcekit_lsp_path()
+
         # sourcekit-lsp needs --scratch-path for background indexing and cross-file references.
         # Without it, textDocument/references returns empty because there's no index store.
         scratch_path = os.path.join(repository_root_path, ".build", "sourcekit-lsp")
         os.makedirs(scratch_path, exist_ok=True)
-        cmd = ["sourcekit-lsp", "--scratch-path", scratch_path]
-        log.info(f"sourcekit-lsp scratch path: {scratch_path}")
+        cmd = [sourcekit_path, "--scratch-path", scratch_path]
+        log.info(f"sourcekit-lsp path: {sourcekit_path}, scratch path: {scratch_path}")
 
         super().__init__(
             config, repository_root_path, ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path), "swift", solidlsp_settings

--- a/src/solidlsp/language_servers/sourcekit_lsp.py
+++ b/src/solidlsp/language_servers/sourcekit_lsp.py
@@ -49,8 +49,15 @@ class SourceKitLSP(SolidLanguageServer):
         sourcekit_version = self._get_sourcekit_lsp_version()
         log.info(f"Starting sourcekit lsp with version: {sourcekit_version}")
 
+        # sourcekit-lsp needs --scratch-path for background indexing and cross-file references.
+        # Without it, textDocument/references returns empty because there's no index store.
+        scratch_path = os.path.join(repository_root_path, ".build", "sourcekit-lsp")
+        os.makedirs(scratch_path, exist_ok=True)
+        cmd = ["sourcekit-lsp", "--scratch-path", scratch_path]
+        log.info(f"sourcekit-lsp scratch path: {scratch_path}")
+
         super().__init__(
-            config, repository_root_path, ProcessLaunchInfo(cmd="sourcekit-lsp", cwd=repository_root_path), "swift", solidlsp_settings
+            config, repository_root_path, ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path), "swift", solidlsp_settings
         )
         self.request_id = 0
         self._did_sleep_before_requesting_references = False
@@ -344,24 +351,26 @@ class SourceKitLSP(SolidLanguageServer):
             # Calculate minimum delay based on how much time has passed since initialization
             if self._initialization_timestamp:
                 elapsed = time.time() - self._initialization_timestamp
-                # Increased CI delay for project indexing: 15s CI, 5s local
-                base_delay = 15 if os.getenv("CI") else 5
+                # Increased delay for project indexing: 15s CI, 10s local
+                # 5s was insufficient for real projects — sourcekit-lsp needs time to index
+                base_delay = 15 if os.getenv("CI") else 10
                 remaining_delay = max(2, base_delay - elapsed)
             else:
                 # Fallback if initialization timestamp is missing
-                remaining_delay = 15 if os.getenv("CI") else 5
+                remaining_delay = 15 if os.getenv("CI") else 10
 
             log.info(f"Sleeping {remaining_delay:.1f}s before requesting references for the first time (CI needs extra indexing time)")
             time.sleep(remaining_delay)
             self._did_sleep_before_requesting_references = True
 
-        # Get references with retry logic for CI stability
+        # Get references with retry logic — indexing may not be complete on first request
         references = super().request_references(relative_file_path, line, column)
 
-        # In CI, if no references found, retry once after additional delay
-        if os.getenv("CI") and not references:
-            log.info("No references found in CI - retrying after additional 5s delay")
-            time.sleep(5)
+        # If no references found, retry once after additional delay (indexing may still be in progress)
+        if not references:
+            retry_delay = 5 if os.getenv("CI") else 3
+            log.info(f"No references found - retrying after additional {retry_delay}s delay (index may still be building)")
+            time.sleep(retry_delay)
             references = super().request_references(relative_file_path, line, column)
 
         return references


### PR DESCRIPTION
## Summary

- **Pass --scratch-path to sourcekit-lsp** — without it, there is no index store for background indexing, so textDocument/references always returns empty results. This is the root cause of #876.
- **Resolve sourcekit-lsp via xcrun with DEVELOPER_DIR** — on macOS, bare sourcekit-lsp can resolve to the Command Line Tools version (limited capabilities). Using xcrun --find with DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer gives the full Xcode version.
- **Increase local indexing delay from 5s to 10s** — real-world Swift projects need more time for background indexing before the first references request.
- **Add retry logic for local runs** — previously only CI retried on empty references; now local also retries once after a 3s delay.

## Root Cause Analysis

Two issues combined to make find_referencing_symbols return empty for Swift:

1. ProcessLaunchInfo launched sourcekit-lsp with no arguments. SourceKit-LSP needs --scratch-path to have a location for its background index store. Without it, textDocument/references returns empty because there is no index data for cross-file symbol resolution.

2. On macOS with both Xcode and Command Line Tools installed, bare sourcekit-lsp resolves to /Library/Developer/CommandLineTools/usr/bin/sourcekit-lsp which has limited indexing capabilities compared to the Xcode version.

## Test plan

- [x] Verified find_referencing_symbols returns cross-file references for Swift structs and methods
- [x] Verified find_symbol and get_symbols_overview continue to work
- [x] Verified sourcekit-lsp process launches with correct path and --scratch-path argument
- [x] Verified fallback to bare sourcekit-lsp when xcrun is unavailable (Linux compatibility)
- [ ] Run existing Swift test suite (test/solidlsp/swift/test_swift_basic.py)

Generated with [Claude Code](https://claude.com/claude-code)