### PR TITLE
fix: add meta property to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,13 +78,15 @@
       packages = {
         serena-env = pythonSet.mkVirtualEnv "serena-env" workspace.deps.default;
         serena = pkgs.runCommand "serena" {
-          meta = {
-            description = "A powerful coding agent toolkit providing semantic retrieval and editing capabilities (MCP server & Agno integration)";
-            homepage = "https://github.com/oraios/serena";
-            mainProgram = "serena";
-            platforms = lib.platforms.all;
-          };
-        } ''
+            meta = {
+              description = "A powerful coding agent toolkit providing semantic retrieval and editing capabilities (MCP server & Agno integration)";
+              homepage = "https://oraios.github.io/serena";
+              changelog = "https://github.com/oraios/serena/blob/main/CHANGELOG.md";
+              mainProgram = "serena";
+              license = pkgs.lib.licenses.mit;
+              platforms = lib.platforms.all;
+            };
+          } ''
           mkdir -p $out/bin
           ln -s ${packages.serena-env}/bin/serena $out/bin/serena
         '';


### PR DESCRIPTION
## Summary
Add the meta property to the serena package in the `flake.nix`.

## Rationale
I wanted this specifically to get the `lib.getExe` nix function work.

## Testing
I tested this by changing my personal system's nix flake to point to my fork, and confirmed that serena continues to work as expected, and the `lib.getExe` function now works.