### PR TITLE
feat: add MiniMax as an OpenAI-compatible model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 GOOGLE_API_KEY=<your_google_api_key>
 ANTHROPIC_API_KEY=<your_key>
+MINIMAX_API_KEY=<your_minimax_api_key>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ In general, Serena can be integrated with an LLM in several ways:
 * by using [mcpo to connect it to ChatGPT](docs/03-special-guides/serena_on_chatgpt.md) or other clients that don't support MCP but do support tool calling via OpenAPI.
 * by incorporating Serena's tools into an agent framework of your choice, as illustrated [here](docs/03-special-guides/custom_agent.md).
   Serena's tool implementation is decoupled from the framework-specific code and can thus easily be adapted to any agent framework.
+  Any OpenAI-compatible provider (such as [MiniMax](https://www.minimax.io/)) can be used via Agno's `OpenAILike` model class.
 
 ## Serena in Action
 

--- a/docs/03-special-guides/custom_agent.md
+++ b/docs/03-special-guides/custom_agent.md
@@ -34,7 +34,16 @@ Here's how it works:
    uv run python scripts/agno_agent.py
    ```
    By default, the script uses Claude as the model, but you can choose any model
-   supported by Agno (which is essentially any existing model).
+   supported by Agno (which is essentially any existing model), including
+   OpenAI-compatible providers like [MiniMax](https://www.minimax.io/) via Agno's `OpenAILike`:
+   ```python
+   from agno.models.openai import OpenAILike
+   model = OpenAILike(
+       id="MiniMax-M2.5",
+       api_key=os.environ["MINIMAX_API_KEY"],
+       base_url="https://api.minimax.io/v1",
+   )
+   ```
 
 5. In a new terminal, start the agno UI with
    ```shell

--- a/scripts/agno_agent.py
+++ b/scripts/agno_agent.py
@@ -1,12 +1,13 @@
 from agno.models.anthropic.claude import Claude
 from agno.models.google.gemini import Gemini
+from agno.models.openai import OpenAILike
 from agno.os import AgentOS
 from sensai.util import logging
 from sensai.util.helper import mark_used
 
 from serena.agno import SerenaAgnoAgentProvider
 
-mark_used(Gemini, Claude)
+mark_used(Gemini, Claude, OpenAILike)
 
 # initialize logging
 if __name__ == "__main__":
@@ -15,6 +16,7 @@ if __name__ == "__main__":
 # Define the model to use (see Agno documentation for supported models; these are just examples)
 # model = Claude(id="claude-3-7-sonnet-20250219")
 model = Gemini(id="gemini-2.5-pro")
+# model = OpenAILike(id="MiniMax-M2.5", api_key="<your_minimax_api_key>", base_url="https://api.minimax.io/v1")
 
 # Create the Serena agent using the existing provider
 serena_agent = SerenaAgnoAgentProvider.get_agent(model)


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io/) as a supported model provider via Agno's `OpenAILike` class. MiniMax offers models like MiniMax-M2.5 and MiniMax-M2.5-highspeed with 204K context windows through an OpenAI-compatible API at `https://api.minimax.io/v1`.

## Changes

- **`scripts/agno_agent.py`**: Add `OpenAILike` import and commented-out MiniMax model example alongside existing Claude and Gemini options
- **`.env.example`**: Add `MINIMAX_API_KEY` placeholder
- **`docs/03-special-guides/custom_agent.md`**: Document how to use MiniMax via `OpenAILike` with a code snippet
- **`README.md`**: Mention MiniMax as an example of OpenAI-compatible providers in the LLM Integration section

## Why MiniMax?

- OpenAI-compatible API — works out of the box with Agno's `OpenAILike`
- 204K context window — ideal for large codebase analysis with Serena
- Available models: `MiniMax-M2.5` and `MiniMax-M2.5-highspeed`

## Test Plan

- [x] Python syntax verified (`ast.parse`)
- [x] `ruff check` passes
- [x] `black --check` passes
- [x] Verified `OpenAILike` import works with installed Agno version