### PR TITLE
Handle OSError when validating registered project paths on startup

### DIFF
--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -826,7 +826,12 @@ class SerenaConfig(SharedConfig):
         instance.projects = []
         for path in loaded_commented_yaml["projects"]:
             path = Path(path).resolve()
-            if not path.exists() or (path.is_dir() and not os.path.isfile(instance.get_project_yml_location(str(path)))):
+            try:
+                path_exists = path.exists()
+            except OSError as e:
+                log.warning(f"Project path {path} is not accessible ({e}), skipping.")
+                continue
+            if not path_exists or (path.is_dir() and not os.path.isfile(instance.get_project_yml_location(str(path)))):
                 log.warning(f"Project path {path} does not exist or no associated project configuration file found, skipping.")
                 continue
             if path.is_file():


### PR DESCRIPTION
## Summary

- When a registered project path points to a stale or unreachable filesystem (e.g. a disconnected SSHFS mount), `path.exists()` raises `OSError: [Errno 5] Input/output error` instead of returning `False`
- This uncaught exception crashes the entire MCP server on startup, making all Serena tools unavailable
- Wraps `path.exists()` in a `try/except OSError` so inaccessible paths are gracefully skipped with a warning, matching the existing behavior for non-existent paths

## Reproduction

1. Register a project path that points to a stale SSHFS mount (or any filesystem that returns I/O errors)
2. Start the MCP server — crashes with:
   ```
   OSError: [Errno 5] Input/output error: '/path/to/stale/mount'
   ```
   at `serena_config.py` line 829 (`path.exists()`)

## Fix

```python
# Before: crashes on stale mounts
if not path.exists() or ...

# After: gracefully skips inaccessible paths  
try:
    path_exists = path.exists()
except OSError as e:
    log.warning(f"Project path {path} is not accessible ({e}), skipping.")
    continue
if not path_exists or ...
```

## Test plan

- [ ] Verify MCP server starts normally with all valid project paths
- [ ] Verify stale/unreachable mount paths are skipped with a warning instead of crashing
- [ ] Verify existing behavior for non-existent paths is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)