### PR TITLE
Fix agent shutdown lifecycle: no-op shutdown, orphaned LS processes, missing MCP cleanup

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -699,6 +699,11 @@ class SerenaAgent:
                 f"(2) Configure one MCP server per backend in your client."
             )
 
+        # shut down the previously active project to release its language server processes
+        if self._active_project is not None:
+            log.info(f"Shutting down previously active project '{self._active_project.project_name}' before switching")
+            self._active_project.shutdown()
+
         self._active_project = project
         project.set_agent(self)
 
@@ -845,7 +850,8 @@ class SerenaAgent:
         """
         Shuts down the agent, freeing resources and stopping background tasks.
         """
-        if not hasattr(self, "_is_initialized"):
+        # guard against __del__ being called on a partially constructed instance
+        if not hasattr(self, "_active_project"):
             return
         log.info("SerenaAgent is shutting down ...")
         if self._active_project is not None:

--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -341,8 +341,12 @@ class SerenaMCPFactory:
         openai_tool_compatible = self.context.name in ["chatgpt", "codex", "oaicompat-agent"]
         self._set_mcp_tools(mcp_server, openai_tool_compatible=openai_tool_compatible)
         log.info("MCP server lifetime setup complete")
-        yield
-        log.info("MCP server shutting down")
+        try:
+            yield
+        finally:
+            log.info("MCP server shutting down")
+            if self.agent is not None:
+                self.agent.shutdown()
 
     def _get_initial_instructions(self) -> str:
         assert self.agent is not None


### PR DESCRIPTION
## Problem

Three bugs prevent proper cleanup of language server processes:

1. **shutdown() is a no-op.** The early-return guard checks
   `hasattr(self, "_is_initialized")`, but `_is_initialized` is never
   assigned anywhere in the codebase. Every call to `shutdown()` returns
   immediately. All language server subprocesses leak on every session exit.

   To verify: search for `_is_initialized` in `src/` — it appears only in
   this guard, never as an assignment.

2. **_activate_project() orphans LS processes.** When switching projects,
   `self._active_project` is overwritten without shutting down the previous
   project first. The old project's language server processes are abandoned.

3. **MCP server exit skips cleanup.** `server_lifespan()` uses a bare
   `yield` — if the MCP server exits or crashes, `agent.shutdown()` is
   never called.

## Fix

1. Change guard to `hasattr(self, "_active_project")`, which is set during
   `__init__` and correctly distinguishes initialized vs partially
   constructed instances.

2. Call `self._active_project.shutdown()` before overwriting with the new
   project.

3. Wrap `yield` in `try/finally` to ensure `agent.shutdown()` runs on exit.

## Related issues

This fix is necessary (though may not be sufficient) for #1081 and #1087.
The no-op shutdown meant no language server processes were ever cleaned up,
including Kotlin LS. With this fix, all language servers receive proper
shutdown signals and process tree termination via `_shutdown()` →
`process.terminate()` → `process.kill()`. Kotlin-specific JVM issues may
require additional handling beyond this fix.