### PR TITLE
Fix copy-paste bugs in language server init params

### DIFF
--- a/src/solidlsp/language_servers/ccls_language_server.py
+++ b/src/solidlsp/language_servers/ccls_language_server.py
@@ -118,7 +118,7 @@ class CCLS(SolidLanguageServer):
             "workspaceFolders": [
                 {
                     "uri": root_uri,
-                    "name": "$name",
+                    "name": os.path.basename(repository_absolute_path),
                 }
             ],
             # ccls supports initializationOptions but none are required for basic functionality

--- a/src/solidlsp/language_servers/clangd_language_server.py
+++ b/src/solidlsp/language_servers/clangd_language_server.py
@@ -228,7 +228,7 @@ class ClangdLanguageServer(SolidLanguageServer):
             "workspaceFolders": [
                 {
                     "uri": root_uri,
-                    "name": "$name",
+                    "name": os.path.basename(repository_absolute_path),
                 }
             ],
         }

--- a/src/solidlsp/language_servers/erlang_language_server.py
+++ b/src/solidlsp/language_servers/erlang_language_server.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import pathlib
 import shutil
 import subprocess
 import threading
@@ -134,7 +135,7 @@ class ErlangLanguageServer(SolidLanguageServer):
         initialize_params = {
             "processId": None,
             "rootPath": self.repository_root_path,
-            "rootUri": f"file://{self.repository_root_path}",
+            "rootUri": pathlib.Path(self.repository_root_path).as_uri(),
             "capabilities": {
                 "textDocument": {
                     "synchronization": {"didSave": True},

--- a/src/solidlsp/language_servers/fsharp_language_server.py
+++ b/src/solidlsp/language_servers/fsharp_language_server.py
@@ -166,7 +166,7 @@ class FSharpLanguageServer(SolidLanguageServer):
                     "documentHighlight": {"dynamicRegistration": True},
                     "documentSymbol": {
                         "dynamicRegistration": True,
-                        "symbolKind": {"valueSet": list(range(1, 26))},  # All SymbolKind values
+                        "symbolKind": {"valueSet": list(range(1, 27))},  # All SymbolKind values (1-26)
                         "hierarchicalDocumentSymbolSupport": True,
                     },
                     "codeAction": {


### PR DESCRIPTION
## Problem

Three copy-paste errors in language server initialization, each verifiable
by comparing against other LS implementations in the same repo:

1. **clangd + ccls** — workspace folder name is the literal string `"$name"`
   instead of the actual project name. Every other LS in the repo uses
   `os.path.basename(repository_absolute_path)`. This is not a template
   variable — Python sends the five characters $, n, a, m, e to
   the language server.

   To verify: open any other LS file (e.g. python, go, ruby) and check the
   workspace folder `name` field.

2. **Erlang** — `rootUri` uses `f"file://{path}"` instead of
   `pathlib.Path(...).as_uri()`. The f-string form doesn't percent-encode
   special characters and uses wrong slashes on Windows. Every other LS uses
   `pathlib.Path.as_uri()`.

3. **F#** — `symbolKind.valueSet` uses `range(1, 26)` which produces values
   1-25. The LSP spec defines SymbolKind values 1-26 (TypeParameter is 26).
   Every other LS in the repo uses `range(1, 27)`.

## Fix

- clangd/ccls: `os.path.basename(repository_absolute_path)`
- Erlang: `pathlib.Path(self.repository_root_path).as_uri()`
- F#: `range(1, 27)`