### PR TITLE
Use shlex.quote for shell argument escaping on POSIX

### DIFF
--- a/src/solidlsp/util/subprocess_util.py
+++ b/src/solidlsp/util/subprocess_util.py
@@ -1,4 +1,5 @@
 import platform
+import shlex
 import subprocess
 
 
@@ -15,8 +16,14 @@ def subprocess_kwargs() -> dict:
 
 def quote_arg(arg: str) -> str:
     """
-    Adds quotes around an argument if it contains spaces.
+    Quotes a shell argument to prevent interpretation of metacharacters.
+
+    Uses :func:`shlex.quote` on POSIX systems for proper escaping of all
+    shell-special characters. On Windows, wraps arguments containing spaces
+    in double quotes (Windows shell does not interpret single-quoted strings).
     """
-    if " " not in arg:
-        return arg
-    return f'"{arg}"'
+    if platform.system() == "Windows":
+        if " " not in arg:
+            return arg
+        return f'"{arg}"'
+    return shlex.quote(arg)


### PR DESCRIPTION
## Problem

`quote_arg()` wraps arguments containing spaces in double quotes. But
double quotes do not escape shell metacharacters — \$, backtick, ;,
|, &, and others are still interpreted by the shell.

This function is used to quote arguments in language server startup
commands. If any configured path or argument contains shell metacharacters,
they would be interpreted rather than passed literally.

The realistic risk is low (paths come from config files, not user input),
but the fix is trivial and uses the stdlib-standard approach.

## Fix

On POSIX, use `shlex.quote()` which single-quotes arguments, preventing
all shell interpretation. Retain the original Windows behavior since
`cmd.exe` does not interpret single-quoted strings.