### PR TITLE
Fix copy-paste error messages in log strings

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -483,7 +483,7 @@ class SerenaAgent:
         else:
             log_path = SerenaPaths().last_returned_log_file_path
             if log_path is not None:
-                return f"Find the current log file here: f{log_path}"
+                return f"Find the current log file here: {log_path}"
             else:
                 return "Unfortunately, logs are not available. We recommend enabling the web dashboard/logging in general."
 

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -817,7 +817,7 @@ class SolidLanguageServer(ABC):
         Delete text between the given start and end positions in the given file and return the deleted text.
         """
         if not self.server_started:
-            log.error("insert_text_at_position called before Language Server started")
+            log.error("delete_text_between_positions called before Language Server started")
             raise SolidLSPException("Language Server not started")
 
         absolute_file_path = str(PurePath(self.repository_root_path, relative_file_path))


### PR DESCRIPTION
## Problem

Two copy-paste errors in log/error messages:

1. `agent.py` — f-string contains a literal `f` before the variable:
   `f"...here: f{log_path}"` produces output like
   `Find the current log file here: f/Users/asher/...` with a stray `f`.

2. `ls.py` — `delete_text_between_positions` logs
   `"insert_text_at_position called before Language Server started"`,
   which is the wrong method name (copied from the method above).

## Fix

1. Remove the stray `f`: `{log_path}` instead of `f{log_path}`.
2. Correct the method name in the log message.