### PR TITLE
fix: allow adding experimental languages from dashboard

### DIFF
--- a/src/serena/dashboard.py
+++ b/src/serena/dashboard.py
@@ -543,7 +543,7 @@ class SerenaDashboardAPI:
         from solidlsp.ls_config import Language
 
         def run() -> ResponseAvailableLanguages:
-            all_languages = [lang.value for lang in Language.iter_all(include_experimental=False)]
+            all_languages = [lang.value for lang in Language.iter_all(include_experimental=True)]
 
             # Filter out already added languages for the active project
             project = self._agent.get_active_project()

--- a/test/serena/test_dashboard.py
+++ b/test/serena/test_dashboard.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from serena.dashboard import SerenaDashboardAPI
+from solidlsp.ls_config import Language
+
+
+class _DummyMemoryLogHandler:
+    def get_log_messages(self, from_idx: int = 0):  # pragma: no cover - simple stub
+        return SimpleNamespace(messages=[], max_idx=-1)
+
+    def clear_log_messages(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+class _DummyAgent:
+    def __init__(self, project: SimpleNamespace | None) -> None:
+        self._project = project
+
+    def execute_task(self, func, *, logged: bool | None = None, name: str | None = None):
+        del logged, name
+        return func()
+
+    def get_active_project(self):
+        return self._project
+
+
+def _make_dashboard(project_languages: list[Language] | None) -> SerenaDashboardAPI:
+    project = None
+    if project_languages is not None:
+        project = SimpleNamespace(project_config=SimpleNamespace(languages=project_languages))
+    agent = _DummyAgent(project)
+    return SerenaDashboardAPI(
+        memory_log_handler=_DummyMemoryLogHandler(),
+        tool_names=[],
+        agent=agent,
+        shutdown_callback=None,
+        tool_usage_stats=None,
+    )
+
+
+def test_available_languages_include_experimental_when_no_active_project():
+    dashboard = _make_dashboard(project_languages=None)
+    response = dashboard._get_available_languages()
+    expected = sorted(lang.value for lang in Language.iter_all(include_experimental=True))
+    assert response.languages == expected
+
+
+def test_available_languages_exclude_project_languages():
+    dashboard = _make_dashboard(project_languages=[Language.PYTHON, Language.MARKDOWN])
+    response = dashboard._get_available_languages()
+    available = set(response.languages)
+    assert Language.PYTHON.value not in available
+    assert Language.MARKDOWN.value not in available
+    # ensure experimental languages remain available for selection
+    assert Language.ANSIBLE.value in available


### PR DESCRIPTION
## Summary
- expose experimental language servers in the dashboard add-language list
- add a focused test covering the new selection logic

Fixes #1177

## Testing
- uv run pytest test/serena/test_dashboard.py