### PR TITLE
Add `serena hook` CLI for Claude Code context drift prevention

### DIFF
--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Iterator, Sequence
 from logging import Logger
 from pathlib import Path
@@ -1089,6 +1090,109 @@ class PromptCommands(AutoRegisteringGroup):
         click.echo(f"Deleted override file '{prompt_yaml_name}'.")
 
 
+_HOOK_REMINDER_THRESHOLD_SECONDS = 60
+
+_HOOK_REMINDER_TEXT = (
+    "You have Serena's semantic tools available (find_symbol, get_symbols_overview, "
+    "search_for_pattern, find_referencing_symbols). Prefer these over Grep/Read/Bash "
+    "for code exploration — they provide structured, language-aware results."
+)
+
+
+def _hook_timestamp_path(session_id: str) -> str:
+    """Return the path to the session-scoped timestamp file."""
+    home = os.getenv("SERENA_HOME", "").strip()
+    if not home:
+        home = str(Path.home() / ".serena")
+    return os.path.join(home, f"hook_last_serena_call_{session_id}")
+
+
+def _session_id_from_stdin() -> str | None:
+    """Extract session_id from JSON piped to stdin by Claude Code hooks."""
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return None
+        data = json.loads(raw)
+        return data.get("session_id")
+    except (json.JSONDecodeError, ValueError, OSError):
+        return None
+
+
+def _resolve_session_id(session_id: str | None) -> str | None:
+    """Return the session_id from the option, falling back to stdin."""
+    if session_id:
+        return session_id
+    return _session_id_from_stdin()
+
+
+_SESSION_ID_OPTION = click.option(
+    "--session-id",
+    default=None,
+    help="Session ID. If omitted, reads from stdin JSON (Claude Code hook protocol).",
+)
+
+
+class HookCommands(AutoRegisteringGroup):
+    """Group for 'hook' subcommands providing Claude Code hook integration."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="hook",
+            help="Claude Code hook integration for context drift prevention. "
+            "You can run `serena hook <command> --help` for more info on each command.",
+        )
+
+    @staticmethod
+    @click.command("stamp", help="Record that a Serena tool was just used.")
+    @_SESSION_ID_OPTION
+    def stamp(session_id: str | None = None) -> None:
+        sid = _resolve_session_id(session_id)
+        if not sid:
+            return
+        path = _hook_timestamp_path(sid)
+        with open(path, "w") as f:
+            f.write(str(time.time()))
+
+    @staticmethod
+    @click.command("check", help="Check if Serena tools have been used recently. If not, emit a reminder.")
+    @_SESSION_ID_OPTION
+    def check(session_id: str | None = None) -> None:
+        sid = _resolve_session_id(session_id)
+        if not sid:
+            return
+        path = _hook_timestamp_path(sid)
+        if not os.path.exists(path):
+            return
+        try:
+            with open(path) as f:
+                last_stamp = float(f.read().strip())
+        except (ValueError, OSError):
+            return
+        if time.time() - last_stamp > _HOOK_REMINDER_THRESHOLD_SECONDS:
+            click.echo(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PostToolUse",
+                            "additionalContext": _HOOK_REMINDER_TEXT,
+                        }
+                    }
+                )
+            )
+
+    @staticmethod
+    @click.command("cleanup", help="Remove the session-scoped timestamp file.")
+    @_SESSION_ID_OPTION
+    def cleanup(session_id: str | None = None) -> None:
+        sid = _resolve_session_id(session_id)
+        if not sid:
+            return
+        path = _hook_timestamp_path(sid)
+        if os.path.exists(path):
+            os.remove(path)
+
+
 # Expose groups so we can reference them in pyproject.toml
 mode = ModeCommands()
 context = ContextCommands()
@@ -1096,13 +1200,14 @@ project = ProjectCommands()
 config = SerenaConfigCommands()
 tools = ToolCommands()
 prompts = PromptCommands()
+hooks = HookCommands()
 
 # Expose toplevel commands for the same reason
 top_level = TopLevelCommands()
 start_mcp_server = top_level.start_mcp_server
 
 # needed for the help script to work - register all subcommands to the top-level group
-for subgroup in (mode, context, project, config, tools, prompts):
+for subgroup in (mode, context, project, config, tools, prompts, hooks):
     top_level.add_command(subgroup)
 
 

--- a/test/serena/test_cli_hook_commands.py
+++ b/test/serena/test_cli_hook_commands.py
@@ -1,0 +1,129 @@
+"""Tests for CLI hook commands (stamp, check, cleanup)."""
+
+import json
+import os
+import shutil
+import tempfile
+import time
+
+import pytest
+from click.testing import CliRunner
+
+from serena.cli import HookCommands
+
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+
+
+@pytest.fixture
+def serena_home(monkeypatch):
+    """Override SERENA_HOME so tests use a temporary directory."""
+    tmpdir = tempfile.mkdtemp()
+    monkeypatch.setenv("SERENA_HOME", tmpdir)
+    try:
+        yield tmpdir
+    finally:
+        if os.name == "nt":
+            time.sleep(0.2)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture
+def cli_runner():
+    """Create a CliRunner for testing Click commands."""
+    return CliRunner()
+
+
+class TestHookStamp:
+    """Tests for 'hook stamp' command."""
+
+    def test_stamp_creates_file(self, cli_runner, serena_home):
+        """Stamp should create a timestamp file for the session."""
+        result = cli_runner.invoke(HookCommands.stamp, ["--session-id", "test-abc"])
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert result.output == ""
+        ts_path = os.path.join(serena_home, "hook_last_serena_call_test-abc")
+        assert os.path.exists(ts_path)
+        with open(ts_path) as f:
+            stamp = float(f.read().strip())
+        assert abs(stamp - time.time()) < 5
+
+    def test_stamp_updates_existing(self, cli_runner, serena_home):
+        """Stamping twice should update the timestamp."""
+        cli_runner.invoke(HookCommands.stamp, ["--session-id", "test-upd"])
+        ts_path = os.path.join(serena_home, "hook_last_serena_call_test-upd")
+        with open(ts_path) as f:
+            first = float(f.read().strip())
+        time.sleep(0.05)
+        cli_runner.invoke(HookCommands.stamp, ["--session-id", "test-upd"])
+        with open(ts_path) as f:
+            second = float(f.read().strip())
+        assert second >= first
+
+    def test_stamp_no_session_id(self, cli_runner, serena_home):
+        """Stamp with no session_id should exit silently."""
+        result = cli_runner.invoke(HookCommands.stamp, [])
+        assert result.exit_code == 0
+        assert result.output == ""
+        files = os.listdir(serena_home)
+        assert not any(f.startswith("hook_last_serena_call_") for f in files)
+
+
+class TestHookCheck:
+    """Tests for 'hook check' command."""
+
+    def test_check_no_file_silent(self, cli_runner, serena_home):
+        """Check with no timestamp file should produce no output."""
+        result = cli_runner.invoke(HookCommands.check, ["--session-id", "test-none"])
+        assert result.exit_code == 0
+        assert result.output == ""
+
+    def test_check_recent_silent(self, cli_runner, serena_home):
+        """Check immediately after stamp should produce no output (under threshold)."""
+        cli_runner.invoke(HookCommands.stamp, ["--session-id", "test-recent"])
+        result = cli_runner.invoke(HookCommands.check, ["--session-id", "test-recent"])
+        assert result.exit_code == 0
+        assert result.output == ""
+
+    def test_check_stale_emits_reminder(self, cli_runner, serena_home):
+        """Check with a stale timestamp should emit a reminder."""
+        ts_path = os.path.join(serena_home, "hook_last_serena_call_test-stale")
+        with open(ts_path, "w") as f:
+            f.write(str(time.time() - 120))
+        result = cli_runner.invoke(HookCommands.check, ["--session-id", "test-stale"])
+        assert result.exit_code == 0
+        assert result.output.strip() != ""
+        output = json.loads(result.output.strip())
+        assert "hookSpecificOutput" in output
+        assert output["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+        assert "Serena" in output["hookSpecificOutput"]["additionalContext"]
+
+    def test_check_output_is_valid_json(self, cli_runner, serena_home):
+        """The reminder output should be valid JSON with the correct structure."""
+        ts_path = os.path.join(serena_home, "hook_last_serena_call_test-json")
+        with open(ts_path, "w") as f:
+            f.write(str(time.time() - 120))
+        result = cli_runner.invoke(HookCommands.check, ["--session-id", "test-json"])
+        output = json.loads(result.output.strip())
+        assert output["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+        assert isinstance(output["hookSpecificOutput"]["additionalContext"], str)
+        assert len(output["hookSpecificOutput"]["additionalContext"]) > 0
+
+
+class TestHookCleanup:
+    """Tests for 'hook cleanup' command."""
+
+    def test_cleanup_removes_file(self, cli_runner, serena_home):
+        """Cleanup should remove the timestamp file."""
+        cli_runner.invoke(HookCommands.stamp, ["--session-id", "test-clean"])
+        ts_path = os.path.join(serena_home, "hook_last_serena_call_test-clean")
+        assert os.path.exists(ts_path)
+        result = cli_runner.invoke(HookCommands.cleanup, ["--session-id", "test-clean"])
+        assert result.exit_code == 0
+        assert result.output == ""
+        assert not os.path.exists(ts_path)
+
+    def test_cleanup_no_file_silent(self, cli_runner, serena_home):
+        """Cleanup with no file should exit silently."""
+        result = cli_runner.invoke(HookCommands.cleanup, ["--session-id", "test-noop"])
+        assert result.exit_code == 0
+        assert result.output == ""


### PR DESCRIPTION
## Problem

When using Claude Code with Serena, the agent tends to drift toward generic
tools (Grep, Read, Bash) instead of Serena's semantic tools. Issue #1201
proposes a hook-based nudge mechanism to counter this.

## Solution

Adds a `serena hook` CLI subcommand group with three commands:

- **`serena hook stamp`** — Records that a Serena tool was just used by
  writing a timestamp to `~/.serena/hook_last_serena_call_<session_id>`.

- **`serena hook check`** — Checks if Serena tools have been used in the
  last 60 seconds. If not, emits a PostToolUse JSON reminder. If they have,
  produces no output (zero-cost when the agent is behaving correctly).

- **`serena hook cleanup`** — Removes the session-scoped timestamp file.

Each command accepts `--session-id` as a CLI option or reads it from stdin
JSON (Claude Code hook protocol). The CLI option makes testing straightforward;
the stdin fallback supports the real hook invocation path.

## Hook Configuration

Wire these into Claude Code's `.claude/settings.json`:

```json
{
  "hooks": {
    "PostToolUse": [
      {
        "matcher": "mcp__serena__.*",
        "hooks": [{ "type": "command", "command": "serena hook stamp" }]
      },
      {
        "matcher": "Grep|Read|Bash",
        "hooks": [{ "type": "command", "command": "serena hook check" }]
      }
    ],
    "SessionEnd": [
      {
        "hooks": [{ "type": "command", "command": "serena hook cleanup" }]
      }
    ]
  }
}
```

## Tests

9 tests in `test/serena/test_cli_hook_commands.py` covering:
- Timestamp file creation, update, and cleanup
- Silent behavior when no session is active or tools were used recently
- Reminder emission with valid JSON structure when threshold exceeded
- Graceful handling of missing session_id

## Verification

```bash
uv run pytest test/serena/test_cli_hook_commands.py -v   # 9/9 pass
uv run poe format                                        # clean
uv run poe type-check                                    # clean
```

Closes #1201.