### PR TITLE
Use deterministic workspace dir for EclipseJDTLS to enable cache reuse

### DIFF
--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -3,12 +3,12 @@ Provides Java specific instantiation of the LanguageServer class. Contains vario
 """
 
 import dataclasses
+import hashlib
 import logging
 import os
 import pathlib
 import shutil
 import threading
-import hashlib
 from pathlib import PurePath
 from time import sleep
 from typing import cast


### PR DESCRIPTION
## Summary

Replace `uuid.uuid4().hex` with a deterministic hash of the project path for the JDTLS workspace directory. This allows the workspace cache (project index, shared index, configuration) to be reused across server restarts instead of rebuilding from scratch each time.

## Motivation

The random UUID was inherited from [`microsoft/monitors4codegen`](https://github.com/microsoft/monitors4codegen/commit/3b2074954b9314a617fab92fa410e834a9492f2b) → [`microsoft/multilspy`](https://github.com/microsoft/multilspy/commit/2c0ce922520c5e09f2e8d3b67c8d1e6be3b702d5) → [serena (`a43d0aa0`)](https://github.com/oraios/serena/commit/a43d0aa0), a research/testing library where ephemeral workspaces made sense for CI isolation. For Serena's use case — long-lived projects with repeated restarts — deterministic workspace paths can significantly reduce JDTLS startup time for large Java projects.

This is particularly impactful for Docker-based deployments where the container filesystem is recreated on restart but a named volume can persist `ls_resources_dir`.

## Change

- `uuid.uuid4().hex` → `hashlib.md5(project_path.encode()).hexdigest()`
- Both produce 32-character hex strings, so the directory naming format is unchanged
- The same project path always maps to the same workspace directory
- Different project paths map to different directories (collision probability is negligible with MD5)