### PR TITLE
Support env and home expansion in Serena config paths

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -150,3 +150,17 @@ read_only_memory_patterns: []
 # line ending convention for file writes: unset (use global setting, "lf", "crlf", or "native" (platform default)
 # If not undefined, overrides the global setting in serena_config.yml
 line_ending:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -828,7 +828,7 @@ class SerenaConfig(SharedConfig):
             raise SerenaConfigError("`projects` key not found in Serena configuration. Please update your `serena_config.yml` file.")
         instance.projects = []
         for path in loaded_commented_yaml["projects"]:
-            path = Path(path).resolve()
+            path = Path(os.path.expandvars(os.path.expanduser(path))).resolve()
             try:
                 path_exists = path.exists()
             except OSError as e:
@@ -1055,7 +1055,7 @@ class SerenaConfig(SharedConfig):
     def _resolve_serena_folder_location(template: str, placeholders: dict[str, str]) -> str:
         """
         Resolves a folder location template by replacing known ``$placeholder`` tokens
-        and raising on any unrecognised ones.
+        and environment variable tokens, raising on any unrecognised ones.
 
         :param template: the template string (e.g. ``"$projectDir/.serena"``)
         :param placeholders: mapping from placeholder name (without ``$``) to replacement value
@@ -1064,15 +1064,21 @@ class SerenaConfig(SharedConfig):
         """
 
         def _replace(match: re.Match[str]) -> str:
-            name = match.group(1)
-            if name not in placeholders:
-                raise SerenaConfigError(
-                    f"Unknown placeholder '${name}' in project_serena_folder_location. "
-                    f"Supported placeholders: {', '.join('$' + k for k in placeholders)}"
-                )
-            return placeholders[name]
+            name = match.group(1) or match.group(2)
+            if name in placeholders:
+                return placeholders[name]
 
-        result = re.sub(r"\$([A-Za-z_]\w*)", _replace, template)
+            env_value = os.environ.get(name)
+            if env_value is not None:
+                return env_value
+
+            raise SerenaConfigError(
+                f"Unknown placeholder '${name}' in project_serena_folder_location. "
+                f"Supported placeholders: {', '.join('$' + k for k in placeholders)} "
+                "or existing environment variables."
+            )
+
+        result = re.sub(r"\$(?:{([A-Za-z_]\w*)}|([A-Za-z_]\w*))", _replace, template)
         return os.path.abspath(result)
 
     def get_configured_project_serena_folder(self, project_root: str | Path) -> str:

--- a/src/serena/resources/serena_config.template.yml
+++ b/src/serena/resources/serena_config.template.yml
@@ -149,4 +149,5 @@ symbol_info_budget: 10
 project_serena_folder_location: "$projectDir/.serena"
 
 # the list of registered project paths (updated automatically).
+# Supports environment variable and home expansion (e.g. "$HOME/work/my-project" or "~/work/my-project").
 projects: []

--- a/test/serena/config/test_serena_config.py
+++ b/test/serena/config/test_serena_config.py
@@ -145,6 +145,30 @@ class TestProjectConfig:
         assert is_complete, "Project template YAML is incomplete; all fields must be present (with descriptions)."
 
 
+class TestSerenaConfigProjectPathExpansion:
+    def test_from_config_file_expands_environment_variables_in_projects(self, monkeypatch: pytest.MonkeyPatch):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            project_root = temp_path / "project"
+            project_root.mkdir()
+
+            project_config = ProjectConfig(project_name="project", languages=[Language.PYTHON])
+            project_config.save(ProjectConfig.default_project_yml_path(str(project_root)))
+
+            config_file_path = temp_path / "serena_config.yml"
+            config_file_path.write_text('projects:\n  - "$SERENA_TEST_PROJECT_ROOT"\n', encoding="utf-8")
+
+            monkeypatch.setenv("SERENA_TEST_PROJECT_ROOT", str(project_root))
+            monkeypatch.setattr(
+                SerenaConfig,
+                "_determine_config_file_path",
+                classmethod(lambda cls: str(config_file_path)),
+            )
+
+            config = SerenaConfig.from_config_file()
+            assert config.project_paths == [str(project_root.resolve())]
+
+
 class TestProjectConfigLanguageBackend:
     """Tests for the per-project language_backend field."""
 


### PR DESCRIPTION
Allow project paths and project_serena_folder_location templates to resolve environment variables (${VAR}/$VAR) and ~ so shared configs work across machines. Update config templates and tests to cover the new expansion behavior and project-level settings fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ignored_memory_patterns` configuration to filter excluded memories from listing and activation
  * Added `ls_specific_settings` configuration for language-server options
  * Project paths now support environment variable expansion (`$VAR`, `${VAR}`) and home directory (`~`) syntax
  * Template placeholders support both `$NAME` and `${NAME}` formats with environment variable fallback

* **Tests**
  * Added tests for project path environment variable expansion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->