### PR TITLE
fix: replace file-count-based cache saving with time-based during indexing

### DIFF
--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -706,7 +706,7 @@ class ProjectCommands(AutoRegisteringGroup):
             collected_exceptions: list[Exception] = []
             files_failed = []
             language_file_counts: dict[Language, int] = collections.defaultdict(lambda: 0)
-            last_save_time = time.time()
+            last_save_time = time.monotonic()
             for i, f in enumerate(tqdm(files, desc="Indexing")):
                 try:
                     ls = ls_mgr.get_language_server(f)
@@ -716,9 +716,10 @@ class ProjectCommands(AutoRegisteringGroup):
                     log.error(f"Failed to index {f}, continuing.")
                     collected_exceptions.append(e)
                     files_failed.append(f)
-                if time.time() - last_save_time >= 30:
+                now = time.monotonic()
+                if now - last_save_time >= 30:
                     ls_mgr.save_all_caches()
-                    last_save_time = time.time()
+                    last_save_time = now
             reported_language_file_counts = {k.value: v for k, v in language_file_counts.items()}
             click.echo(f"Indexed files per language: {dict_string(reported_language_file_counts, brackets=None)}")
             ls_mgr.save_all_caches()


### PR DESCRIPTION
## Problem

Saving cache every 10 files causes extremely slow indexing on large projects because `save_all_caches()` is an expensive operation. On a large project it gets triggered thousands of times during indexing, making the whole process take hours instead of minutes.

## Fix

Switch from a file-count-based trigger (every 10 files) to a time-based trigger (every 30 seconds). This keeps cache saves infrequent enough to not hurt performance, while still preserving progress regularly in case indexing is interrupted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced frequency of cache persistence during project indexing: saves are now time-throttled (at most once every 30 seconds) while maintaining a final flush at the end of indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->