### PR TITLE
fix: prevent deadlock when gitignore parsing fails

### DIFF
--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -310,35 +310,42 @@ class Project(ToStringMixin):
         threading.Thread(name=f"gather-ignorespec[{self.project_config.project_name}]", target=self._gather_ignorespec, daemon=True).start()
 
     def _gather_ignorespec(self) -> None:
-        with LogTime(f"Gathering ignore spec for project {self.project_config.project_name}", logger=log):
-            # gather ignored paths from the global configuration, project configuration, and gitignore files
-            global_ignored_paths = self.serena_config.ignored_paths
-            ignored_patterns = list(global_ignored_paths) + list(self.project_config.ignored_paths)
-            if len(global_ignored_paths) > 0:
-                log.info(f"Using {len(global_ignored_paths)} ignored paths from the global configuration.")
-                log.debug(f"Global ignored paths: {list(global_ignored_paths)}")
-            if len(self.project_config.ignored_paths) > 0:
-                log.info(f"Using {len(self.project_config.ignored_paths)} ignored paths from the project configuration.")
-                log.debug(f"Project ignored paths: {self.project_config.ignored_paths}")
-            log.debug(f"Combined ignored patterns: {ignored_patterns}")
-            if self.project_config.ignore_all_files_in_gitignore:
-                gitignore_parser = GitignoreParser(self.project_root)
-                for spec in gitignore_parser.get_ignore_specs():
-                    log.debug(f"Adding {len(spec.patterns)} patterns from {spec.file_path} to the ignored paths.")
-                    ignored_patterns.extend(spec.patterns)
-            self.__ignored_patterns = ignored_patterns
+        try:
+            with LogTime(f"Gathering ignore spec for project {self.project_config.project_name}", logger=log):
+                # gather ignored paths from the global configuration, project configuration, and gitignore files
+                global_ignored_paths = self.serena_config.ignored_paths
+                ignored_patterns = list(global_ignored_paths) + list(self.project_config.ignored_paths)
+                if len(global_ignored_paths) > 0:
+                    log.info(f"Using {len(global_ignored_paths)} ignored paths from the global configuration.")
+                    log.debug(f"Global ignored paths: {list(global_ignored_paths)}")
+                if len(self.project_config.ignored_paths) > 0:
+                    log.info(f"Using {len(self.project_config.ignored_paths)} ignored paths from the project configuration.")
+                    log.debug(f"Project ignored paths: {self.project_config.ignored_paths}")
+                log.debug(f"Combined ignored patterns: {ignored_patterns}")
+                if self.project_config.ignore_all_files_in_gitignore:
+                    gitignore_parser = GitignoreParser(self.project_root)
+                    for spec in gitignore_parser.get_ignore_specs():
+                        log.debug(f"Adding {len(spec.patterns)} patterns from {spec.file_path} to the ignored paths.")
+                        ignored_patterns.extend(spec.patterns)
+                self.__ignored_patterns = ignored_patterns
 
-            # Set up the pathspec matcher for the ignored paths
-            # for all absolute paths in ignored_paths, convert them to relative paths
-            processed_patterns = []
-            for pattern in ignored_patterns:
-                # Normalize separators (pathspec expects forward slashes)
-                pattern = pattern.replace(os.path.sep, "/")
-                processed_patterns.append(pattern)
-            log.debug(f"Processing {len(processed_patterns)} ignored paths")
-            self.__ignore_spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, processed_patterns)
-
-        self._ignore_spec_available.set()
+                # Set up the pathspec matcher for the ignored paths
+                # for all absolute paths in ignored_paths, convert them to relative paths
+                processed_patterns = []
+                for pattern in ignored_patterns:
+                    # Normalize separators (pathspec expects forward slashes)
+                    pattern = pattern.replace(os.path.sep, "/")
+                    processed_patterns.append(pattern)
+                log.debug(f"Processing {len(processed_patterns)} ignored paths")
+                self.__ignore_spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, processed_patterns)
+        except Exception:
+            log.exception(
+                f"Failed to gather ignore spec for project {self.project_config.project_name}; proceeding with empty ignore patterns"
+            )
+            self.__ignored_patterns = list(self.serena_config.ignored_paths) + list(self.project_config.ignored_paths)
+            self.__ignore_spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, [])
+        finally:
+            self._ignore_spec_available.set()
 
     def _tostring_includes(self) -> list[str]:
         return []


### PR DESCRIPTION
## Summary

- `_gather_ignorespec()` hangs Serena indefinitely when `.gitignore` parsing throws an exception (e.g. `os.scandir` `PermissionError` on Windows)
- Root cause: `_ignore_spec_available.set()` is placed after the `LogTime` with-block — if an exception escapes, the `threading.Event` is never set, and `init_language_server_manager` waits forever
- Fix: wrap in `try/except/finally` so the event is always set, with a safe fallback to config-only ignore patterns on failure

## Problem

```
ERROR [gather-ignorespec[project]] Loading of .gitignore files failed after 0.015 seconds
ERROR [gather-ignorespec[project]] Gathering ignore spec for project failed after 0.015 seconds
INFO  [Task-1:init_language_server_manager] Waiting for ignored patterns to become available ...
# (hangs forever)
```

The deadlock chain:
1. `_gather_ignorespec` runs in a daemon thread (`project.py#L310`)
2. `GitignoreParser.__init__` → `_iter_gitignore_files` → `os.scandir` throws (no exception handling at `file_system.py#L167`)
3. `LogTime.__exit__` logs "failed" but re-raises the exception
4. `_ignore_spec_available.set()` at line 341 is never reached
5. `create_language_server_manager` → `_ignored_patterns` → `_ignore_spec_available.wait()` → infinite hang

This is intermittent — `os.scandir` may fail due to transient file locks or permission issues (observed on Windows 11 with CJK-named files). In one session, 4 out of 5 Serena startups hung; the 5th succeeded.

## Fix

```python
def _gather_ignorespec(self) -> None:
    try:
        with LogTime(...):
            # ... existing logic unchanged ...
    except Exception:
        log.exception("Failed to gather ignore spec; proceeding with empty ignore patterns")
        self.__ignored_patterns = list(...)
        self.__ignore_spec = pathspec.PathSpec.from_lines(...)
    finally:
        self._ignore_spec_available.set()
```

The `except` block ensures `__ignored_patterns` and `__ignore_spec` are always assigned (preventing `AttributeError` in waiters), and `finally` ensures the event is always set.

## Verification

- `poe format` — all checks passed, 251 files unchanged
- `poe type-check` — mypy: no issues found in 118 source files

## Note

A related but separate issue: `GitignoreParser._iter_gitignore_files()` at `file_system.py#L167` lacks the `PermissionError` handling that the nearby `scan_directory()` helper already has (`file_system.py#L48-L86`). Fixing that would prevent the exception from being thrown in the first place, but is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)