### PR TITLE
fix: avoid ignoring root path in gitignore checks

### DIFF
--- a/src/serena/util/file_system.py
+++ b/src/serena/util/file_system.py
@@ -341,6 +341,9 @@ def match_path(relative_path: str, path_spec: PathSpec, root_path: str = "") -> 
     :param root_path: the root path from which the relative path is derived
     :return:
     """
+    if str(relative_path) in {"", "."}:
+        return False
+
     normalized_path = str(relative_path).replace(os.path.sep, "/")
 
     # We can have patterns like /src/..., which would only match corresponding paths from the repo root

--- a/test/serena/util/test_file_system.py
+++ b/test/serena/util/test_file_system.py
@@ -4,7 +4,9 @@ import tempfile
 from pathlib import Path
 
 # Assuming the gitignore parser code is in a module named 'gitignore_parser'
-from serena.util.file_system import GitignoreParser, GitignoreSpec
+from pathspec import PathSpec
+
+from serena.util.file_system import GitignoreParser, GitignoreSpec, match_path
 
 
 class TestGitignoreParser:
@@ -190,6 +192,13 @@ test.log
         # Files that should NOT be ignored
         assert not parser.should_ignore("file1.txt")
         assert not parser.should_ignore("src/main.py")
+
+    def test_match_path_root_directory(self):
+        """Root directory should never be ignored by pathspec patterns."""
+        spec = PathSpec.from_lines("gitwildmatch", ["/.*/"])
+
+        assert not match_path(".", spec, root_path=str(self.repo_path))
+        assert not match_path("", spec, root_path=str(self.repo_path))
 
     def test_should_ignore_subdirectory_patterns(self):
         """Test ignoring files based on subdirectory .gitignore files."""


### PR DESCRIPTION
Fixes #1054

Prevent pathspec matching from treating the project root (".") as an ignored path, which can cause find_symbol to skip the entire tree when .gitignore contains '/.*/'.

Tests: not run (missing local deps: sensai).