### PR TITLE
Fix HLSL language server crash on CRLF files pulled in via #include

### DIFF
--- a/src/solidlsp/language_servers/hlsl_language_server.py
+++ b/src/solidlsp/language_servers/hlsl_language_server.py
@@ -7,13 +7,22 @@ import logging
 import os
 import pathlib
 import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, cast
 
 import psutil
 from overrides import override
 
-from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
+from solidlsp.ls import (
+    LanguageServerDependencyProvider,
+    LanguageServerDependencyProviderSinglePath,
+    LSPFileBuffer,
+    SolidLanguageServer,
+)
 from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_exceptions import SolidLSPException
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -267,6 +276,92 @@ class HlslLanguageServer(SolidLanguageServer):
             except Exception as e:
                 log.debug(f"Error cleaning up shader-language-server process tree: {e}")
         super().stop(shutdown_timeout)
+
+    @contextmanager
+    def open_file(self, relative_file_path: str, open_in_ls: bool = True) -> Iterator[LSPFileBuffer]:
+        """Open a file for LSP, preserving on-disk CRLF line endings.
+
+        Workaround for an upstream bug in shader-language-server
+        (antaalt/shader-sense) where `watch_main_file` replaces an already-cached
+        module's content without re-parsing the tree-sitter tree. When a file is
+        first pulled into the server's cache via an `#include` from another
+        shader (where it's read via `std::fs::read_to_string`, preserving CRLF),
+        and then later opened directly via `textDocument/didOpen` with the
+        client-normalized LF text, the stored tree still references byte offsets
+        into the longer CRLF content. The next symbol query slices the new
+        (shorter) content with stale offsets and panics with
+        `byte index N is out of bounds` in `shader-sense/src/symbols/symbol_parser.rs`.
+
+        The root-cause fix belongs upstream (the server should call
+        `update_module` instead of assigning `content` raw). Until then, we
+        ensure the text we send in `didOpen` matches byte-for-byte what the
+        server reads from disk by preloading the file buffer with a
+        CRLF-preserving read before the LSP notification is sent.
+
+        This is the only place in Serena that overrides `open_file`; the fix is
+        deliberately scoped to the HLSL language server. It mirrors the base
+        class logic in `SolidLanguageServer.open_file` verbatim except for the
+        buffer construction branch, where creation is deferred (`open_in_ls=False`)
+        so the buffer's contents can be preloaded before `ensure_open_in_ls` runs.
+        """
+        if not self.server_started:
+            log.error("open_file called before Language Server started")
+            raise SolidLSPException("Language Server not started")
+
+        absolute_file_path = Path(self.repository_root_path, relative_file_path)
+        uri = absolute_file_path.as_uri()
+
+        if uri in self.open_file_buffers:
+            fb = self.open_file_buffers[uri]
+            assert fb.uri == uri
+            assert fb.ref_count >= 1
+
+            fb.ref_count += 1
+            if open_in_ls:
+                fb.ensure_open_in_ls()
+            yield fb
+            fb.ref_count -= 1
+        else:
+            version = 0
+            language_id = self._get_language_id_for_file(relative_file_path)
+            # Defer the didOpen so we can preload CRLF-preserved content first.
+            fb = LSPFileBuffer(
+                abs_path=absolute_file_path,
+                uri=uri,
+                encoding=self._encoding,
+                version=version,
+                language_id=language_id,
+                ref_count=1,
+                language_server=self,
+                open_in_ls=False,
+            )
+            self._preload_crlf_content(fb)
+            self.open_file_buffers[uri] = fb
+            if open_in_ls:
+                fb.ensure_open_in_ls()
+            yield fb
+            fb.ref_count -= 1
+
+        if self.open_file_buffers[uri].ref_count == 0:
+            self.open_file_buffers[uri].close()
+            del self.open_file_buffers[uri]
+
+    def _preload_crlf_content(self, fb: LSPFileBuffer) -> None:
+        """Populate an LSPFileBuffer with a CRLF-preserving read of its backing file.
+
+        Python's default text-mode open applies universal-newlines translation
+        (CRLF -> LF), which would desync the client's `didOpen` text from the
+        server-side `std::fs::read_to_string` view that parsed the dependency
+        tree. Passing `newline=""` disables the translation so bytes match.
+        """
+        with open(fb.abs_path, encoding=fb.encoding, newline="") as f:
+            raw = f.read()
+        # Set the buffer's cached state directly: the contents, the mtime
+        # (required by the contents property's staleness check), and clear the
+        # hash so it's recomputed against the new bytes.
+        fb._contents = raw
+        fb._read_file_modified_date = fb.abs_path.stat().st_mtime
+        fb._content_hash = None
 
     @override
     def is_ignored_dirname(self, dirname: str) -> bool:


### PR DESCRIPTION
## Summary

Fixes a 100%-reproducible crash in the HLSL language server on Windows when a shader file is first pulled into `shader-language-server`'s cache via an `#include` and then later opened directly. The LS process dies mid-request with `LanguageServerTerminatedException`, which in turn fails tools like `find_symbol` that traverse the workspace.

## Root cause

Upstream bug in [antaalt/shader-sense](https://github.com/antaalt/shader-sense) v1.3.0 at `shader-language-server/src/server/server_file_cache.rs` in `watch_main_file`:

```rust
cached_file.is_main_file = true;
debug_assert!(cached_file.shader_module.content == *text,
              "Server deps content different from client provided one.");
cached_file.shader_module.content = text.into();
```

When a `didOpen` arrives for a file that's already cached as an include-dependency, the server assigns the client-provided text to the module's `content` **without re-parsing the tree-sitter tree**. The `debug_assert!` encodes the maintainer's assumption that the two reads are byte-identical. In release builds it's silently violated.

The violation occurs when:

- The dependency-path read goes through `read_string_lossy` → `std::fs::read_to_string`, which preserves CRLF verbatim.
- The main-file-path text comes from Serena's `FileUtils.read_file`, which opens in Python text mode and performs universal-newlines translation (CRLF → LF), shrinking the content by 1 byte per line.

After assignment, `shader_module.content` is the shorter LF buffer but `shader_module.tree` still references byte offsets into the longer CRLF buffer. The next `query_file_symbols` walks the stale tree and calls `get_name` at `shader-sense/src/symbols/symbol_parser.rs:25`, which does `&shader_content[range.start_byte..range.end_byte]` → out-of-bounds panic → process exit.

### Arithmetic confirmation

In the failure I observed with `TerrainSDF.hlsl` (543 lines, CRLF):

| | |
|---|---|
| On-disk size (CRLF) | 19,390 bytes |
| After CRLF → LF normalization | 19,390 − 543 = **18,847** bytes |
| Panic index reported by the server | **18,849** (~2 past the new EOF) |

## Fix

Override `open_file` in `HlslLanguageServer` to preload the `LSPFileBuffer` with a CRLF-preserving read (`open(path, encoding=..., newline="")`) before `ensure_open_in_ls` sends the `didOpen` notification. The bytes Serena sends now match what the server reads from disk, so `watch_main_file`'s content assignment becomes a no-op and the stale-tree panic is avoided entirely.

The override mirrors `SolidLanguageServer.open_file` verbatim except that in the buffer-creation branch, construction is deferred (`open_in_ls=False`) so contents can be preloaded before the LSP notification fires.

**Scope:** the change is deliberately confined to `src/solidlsp/language_servers/hlsl_language_server.py`. No core files are modified, and no other language server is affected.

### Why not fix it upstream?

The root-cause fix belongs in shader-sense (`watch_main_file` should call `update_module` rather than assigning `.content` raw, or should bounds-check in `get_name` to degrade gracefully). I'll file that separately. This PR is the client-side workaround that unblocks Windows users today.

## Reproduction

Minimal 2-file repro:

1. `textDocument/didOpen` for a `.shader` file that `#include`s a `.hlsl` with CRLF line endings → returns OK.
2. `textDocument/didOpen` for that `.hlsl` directly → LS panics with `byte index N is out of bounds` in `symbol_parser.rs:25`.

## Verification

Tested against a Unity HDRP workspace with 28 shader files:

**Before:** crash on file 25 of the alphabetical traversal (`TerrainSDF.hlsl`, pulled in earlier by `TerrainRayMarch.shader`). Error: `LanguageServerTerminatedException: Language server stdout read process terminated unexpectedly`.

**After:** all 28 files return symbols cleanly. `TerrainRayMarch.shader` → 138 symbols, `TerrainSDF.hlsl` → 174 symbols, full sweep passes.

## Test plan

- [x] Minimal 2-file repro (parent `.shader` → child `.hlsl`) passes
- [x] Full 28-file shader sweep passes in the workspace where the crash was reproducible
- [x] `uv run poe format` clean
- [x] `uv run poe type-check` clean (mypy: no issues in 119 source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)