### PR TITLE
fix: add hierarchicalDocumentSymbolSupport capability for Dart LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Status of the `main` branch. Changes prior to the next official version change will appear here.
 
+* Language Servers:
+  - Fix Dart LSP returning only symbol name as body instead of full method body
+
 # 1.1.0
 
 * General:

--- a/src/solidlsp/language_servers/dart_language_server.py
+++ b/src/solidlsp/language_servers/dart_language_server.py
@@ -123,7 +123,13 @@ class DartLanguageServer(SolidLanguageServer):
         """
         root_uri = pathlib.Path(repository_absolute_path).as_uri()
         initialize_params = {
-            "capabilities": {},
+            "capabilities": {
+                "textDocument": {
+                    "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": True,
+                    }
+                }
+            },
             "initializationOptions": {
                 "onlyAnalyzeProjectsWithOpenFiles": False,
                 "closingLabels": False,

--- a/test/solidlsp/dart/test_dart_basic.py
+++ b/test/solidlsp/dart/test_dart_basic.py
@@ -375,3 +375,54 @@ class TestDartLanguageServer:
                 f"Found malformed symbols: {[format_symbol_for_assert(sym) for sym in malformed_symbols]}",
                 pytrace=False,
             )
+
+    @pytest.mark.parametrize("language_server", [Language.DART], indirect=True)
+    def test_symbol_body_contains_full_method(self, language_server: SolidLanguageServer) -> None:
+        """Test that document symbols return the full method body range, not just the identifier.
+
+        Regression test: when hierarchicalDocumentSymbolSupport was not declared in client
+        capabilities, the Dart LSP returned SymbolInformation[] (flat format) where
+        location.range only covered the identifier name (single line), causing find_symbol
+        with include_body=True to return just the symbol name instead of its implementation.
+        """
+        file_path = os.path.join("lib", "main.dart")
+        symbols = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+        symbol_list = symbols[0] if symbols and isinstance(symbols[0], list) else symbols
+
+        # Find the 'add' method — defined across multiple lines in main.dart:
+        #   int add(int a, int b) {
+        #     final result = a + b;
+        #     _history.add('$a + $b = $result');
+        #     return result;
+        #   }
+        add_symbol = None
+        for sym in symbol_list:
+            if sym.get("name") == "add":
+                add_symbol = sym
+                break
+            if sym.get("name") == "Calculator" and "children" in sym:
+                for child in sym["children"]:
+                    if child.get("name") == "add":
+                        add_symbol = child
+                        break
+                if add_symbol:
+                    break
+
+        assert add_symbol is not None, "Could not find 'add' method symbol in main.dart"
+
+        # The body range must span multiple lines (not just the identifier line).
+        # With hierarchicalDocumentSymbolSupport declared, the Dart LSP returns
+        # DocumentSymbol[] where range covers the full method body.
+        body_start = add_symbol["location"]["range"]["start"]["line"]
+        body_end = add_symbol["location"]["range"]["end"]["line"]
+        assert body_end > body_start, (
+            f"Expected multi-line body range for 'add' method, got start={body_start}, end={body_end}. "
+            f"This likely means hierarchicalDocumentSymbolSupport is not declared in client capabilities."
+        )
+
+        # The body text must contain the method implementation, not just the name.
+        if add_symbol.get("body"):
+            body_text = add_symbol["body"].get_text()
+            assert "return result" in body_text, (
+                f"Expected method body to contain implementation, got: {body_text!r}"
+            )

--- a/test/solidlsp/dart/test_dart_basic.py
+++ b/test/solidlsp/dart/test_dart_basic.py
@@ -423,6 +423,4 @@ class TestDartLanguageServer:
         # The body text must contain the method implementation, not just the name.
         if add_symbol.get("body"):
             body_text = add_symbol["body"].get_text()
-            assert "return result" in body_text, (
-                f"Expected method body to contain implementation, got: {body_text!r}"
-            )
+            assert "return result" in body_text, f"Expected method body to contain implementation, got: {body_text!r}"


### PR DESCRIPTION
Fixes #1308

**Bug description:**
When using `find_symbol` with `include_body=True` on Dart files, the returned `body` contains only the symbol name (the identifier), not the actual method/function body. The `body_location` reports a single-line range instead of the full symbol range.


**Example result:**
```
{
  "name_path": "_requiresCustomPerformanceInput",
  "kind": "Method",
  "body_location": { "start_line": 772, "end_line": 772 },
  "body": "_requiresCustomPerformanceInput"
}
```


**Expected:** `body` should contain the full method source code, and `body_location` should span the complete method range (start of signature to closing `}`).


**Root cause:**
The Dart language server client in `solidlsp/language_servers/dart_language_server.py` sends empty capabilities during initialization:
`"capabilities": {},`

Without declaring `textDocument.documentSymbol.hierarchicalDocumentSymbolSupport: true`, the Dart analysis server falls back to returning `SymbolInformation[]` (flat format) instead of `DocumentSymbol[]` (hierarchical format).

In the flat `SymbolInformation` format, `location.range` from the Dart analysis server contains only the identifier position (the symbol name, a single line), not the full body range.

`SymbolBodyFactory.create_symbol_body (ls.py:221)` then extracts text using location.range — getting just the name.

With hierarchical support declared, the server returns `DocumentSymbol[]` where range spans the full symbol body. The conversion at `ls.py:1299–1306` correctly assigns this full `range` to `location.range`.

Compare with gopls.py, eclipse_jdtls.py, csharp_language_server.py — they all declare hierarchicalDocumentSymbolSupport: True and work correctly.

**Fix**
Added `documentSymbol` capability to `DartLanguageServer._get_initialize_params` in `solidlsp/language_servers/dart_language_server.py`. 
Replaced:
`"capabilities": {},`
with

```
"capabilities": {
    "textDocument": {
        "documentSymbol": {
            "hierarchicalDocumentSymbolSupport": True,
        }
    }
},
```

**Result:**
The Dart analysis server now returns `DocumentSymbol[]` with correct full-body range values.

**Tested:**
After the fix, `find_symbol` with `include_body=True` returns the full method body:
```
{
  "name_path": "_ExerciseCardState/_requiresCustomPerformanceInput",
  "kind": "Method",
  "body_location": { "start_line": 1083, "end_line": 1088 },
  "body": "bool _requiresCustomPerformanceInput(\n    ExerciseAssignmentRenderModel assignment,\n  ) => ..."
}
```
