### PR TITLE
docs: fix missing 'not' in lessons_learned.md

### DIFF
--- a/lessons_learned.md
+++ b/lessons_learned.md
@@ -7,7 +7,7 @@ what works well and what doesn't.
 
 ### Separate Tool Logic From MCP Implementation
 
-MCP is just another protocol, one should let the details of it creep into the application logic.
+MCP is just another protocol, one should not let the details of it creep into the application logic.
 The official docs suggest using function annotations to define tools and prompts. While that may be
 useful for small projects to get going fast, it is not wise for more serious projects. In Serena,
 all tools are defined independently and then converted to instances of `MCPTool` using our `make_tool`


### PR DESCRIPTION
## Summary
This PR fixes a typo in `lessons_learned.md` where the word 'not' was missing, causing the sentence to convey the opposite of its intended meaning.

## Changes
- Changed 'one should let the details of it creep into the application logic' to 'one should **not** let the details of it creep into the application logic'

## Context
The section 'Separate Tool Logic From MCP Implementation' is explaining why it's important to keep MCP protocol details separate from application logic. The missing 'not' made it sound like you *should* let protocol details leak into business logic, which contradicts the entire point of the section.

Fixes #1314