### PR TITLE
Add cloud-sync: optional R2 / S3 / Azure sync for memories and config

### DIFF
--- a/docs/cloud-sync-feature-plan.md
+++ b/docs/cloud-sync-feature-plan.md
@@ -1,0 +1,601 @@
+# Serena Cloud Sync — Feature Plan
+
+> **Status:** DESIGN — approved by Buddy design-review on 2026-04-13. Not yet implemented.
+> **Experimental flag required in MVP.** No automatic background sync in MVP.
+
+## 1. Problem
+
+Serena stores project memories (`.serena/memories/**.md`) and configuration
+(`~/.serena/serena_config.yml`, per-project `project.yml`, global contexts/modes)
+on a single machine. A developer working on multiple machines cannot share these
+without an ad-hoc rsync or Git repo. Existing similar tools in this ecosystem:
+
+- `qdrant-mcp-pp` ships a tar.gz R2 push/pull (snapshot-based, last-writer wins).
+- Pointerpro's `memory-sync.php` syncs `.agent/` and `.serena/memories/` per-file
+  via pure-PHP sigv4 against R2 (`pp-file-memory/` prefix, skip-existing).
+
+We want the same capability first-class inside Serena — **provider-agnostic**,
+**additive**, **UI-exposed**, and **byte-safe**.
+
+## 2. Requirements (from user brief)
+
+1. Upload all Serena **memories and configuration** to the cloud.
+2. Be **provider-agnostic**: Cloudflare R2 (we have creds), Amazon S3, Azure
+   Blob Storage — pluggable.
+3. Implement the **Dependency Inversion Principle** (SOLID) and the **Strategy
+   pattern** for providers.
+4. Expose the sync function in the Serena **dashboard UI**, including a form to
+   input credentials.
+5. **Bidirectional additive reconciliation**: push only what cloud lacks, pull
+   only what local lacks.
+6. **Byte-level integrity** on compare (no lost memory/config).
+7. Credentials stored **via env**, in the safest reasonable way.
+
+## 3. Non-goals (MVP)
+
+- **No delete propagation.** Removing a file locally does not delete it remotely
+  and vice versa. Additive union only.
+- **No rename detection.** A rename = one `LOCAL_ONLY` (new path) + one
+  `REMOTE_ONLY` (old path). Both get synced, user cleans up on one side.
+- **No automatic / background scheduler.** User-triggered only (CLI or
+  dashboard button).
+- **No client-side encryption** beyond provider defaults. Object bodies rely on
+  provider TLS + SSE-S3 / SSE-Blob at rest. (Deferred to Phase 3.)
+- **No full mirror / two-way merge.** Divergent content is preserved, not
+  merged.
+
+Users must understand that Serena Cloud Sync is a **safe union**, not a
+Dropbox-style mirror. This is called out on the dashboard and in `--help`.
+
+## 4. Architecture
+
+### 4.1 Module layout
+
+Additive under `src/serena/cloud_sync/`. No churn in existing modules beyond
+one import in `dashboard.py` to register the Flask blueprint.
+
+```
+src/serena/cloud_sync/
+├── __init__.py
+├── provider.py              # CloudStorageProvider ABC  (DIP seam)
+├── providers/
+│   ├── __init__.py
+│   ├── base_s3.py           # Shared S3-compatible impl via boto3
+│   ├── r2.py                # R2 = base_s3 + Cloudflare endpoint override
+│   ├── s3.py                # Amazon S3 = base_s3 + AWS default endpoint
+│   └── azure.py             # Azure Blob via azure-storage-blob (Phase 2)
+├── factory.py               # build_provider(settings) -> CloudStorageProvider
+├── settings.py              # Pydantic model for provider config
+├── credentials.py           # dotenv-based read/write ~/.serena/cloud-sync.env
+├── inventory.py             # LocalInventory walks scope dirs -> ObjectMeta map
+├── scope.py                 # IncludePaths / ExcludePatterns (pathspec)
+├── diff.py                  # Reconciler: union + conflict classifier
+├── sync.py                  # CloudSyncService (accepts provider via ctor)
+├── hash_util.py             # chunked sha256 + optional byte-compare
+├── dashboard_routes.py      # Flask blueprint
+└── exceptions.py
+```
+
+Dashboard assets:
+```
+src/serena/resources/dashboard/cloud-sync.html     # settings panel
+src/serena/resources/dashboard/cloud-sync.js       # loaded from dashboard.js
+```
+
+### 4.2 Dependency inversion
+
+```python
+# provider.py
+class CloudStorageProvider(ABC):
+    @abstractmethod
+    def list_objects(self, prefix: str) -> Iterator["RemoteObjectMeta"]: ...
+    @abstractmethod
+    def head_object(self, key: str) -> Optional["RemoteObjectMeta"]: ...
+    @abstractmethod
+    def get_object(self, key: str) -> bytes: ...
+    @abstractmethod
+    def put_object(self, key: str, data: bytes, sha256_hex: str,
+                   content_type: str = "application/octet-stream") -> None: ...
+    @abstractmethod
+    def put_object_if_absent(self, key: str, data: bytes,
+                             sha256_hex: str) -> bool: ...   # additive primitive
+    @abstractmethod
+    def delete_object(self, key: str) -> None: ...            # guarded, never called by default push/pull
+
+    # Capability flags for future-proofing (Buddy amendment)
+    supports_multipart: bool = False
+    supports_conditional_put: bool = True
+    supports_object_metadata: bool = True
+    supports_server_side_copy: bool = False
+```
+
+```python
+# sync.py
+class CloudSyncService:
+    def __init__(self,
+                 provider: CloudStorageProvider,
+                 inventory: LocalInventory,
+                 scope: ScopeFilter,
+                 log: logging.Logger):
+        ...
+    def push(self, *, dry_run: bool, force: bool) -> SyncReport: ...
+    def pull(self, *, dry_run: bool, force: bool) -> SyncReport: ...
+    def status(self) -> StatusReport: ...
+```
+
+`CloudSyncService` and `diff.py` have **zero** imports from `boto3` or
+`azure.storage.blob`. All SDK usage is isolated in `providers/*`. Tests inject a
+`FakeCloudProvider` (in-memory dict) to exercise every branch of diff and sync
+without network.
+
+### 4.3 Strategy pattern
+
+Each concrete provider implements `CloudStorageProvider`:
+
+- `providers/base_s3.py` — boto3-based implementation of all primitives.
+  Uses `If-None-Match: "*"` on PutObject for the `put_object_if_absent`
+  primitive. Stores custom metadata under `x-amz-meta-serena-sync-sha256`
+  and `x-amz-meta-serena-sync-size`.
+- `providers/r2.py` — thin subclass of `BaseS3Provider`; overrides
+  `endpoint_url` to `https://<account_id>.r2.cloudflarestorage.com`, disables
+  checksum algorithms that R2 doesn't support, uses `auto` region.
+- `providers/s3.py` — thin subclass of `BaseS3Provider`; no endpoint override,
+  uses configured AWS region.
+- `providers/azure.py` — `azure-storage-blob` based. `put_object_if_absent`
+  uses `If-None-Match: *`. Custom metadata via the `metadata={}` kwarg on
+  `upload_blob`. (Phase 2.)
+
+A `factory.build_provider(settings)` returns the correct concrete instance
+based on `settings.provider_type` ∈ {`r2`, `s3`, `azure`}.
+
+### 4.4 Remote key layout
+
+```
+<bucket>/<root_prefix>/global/<relpath>
+<bucket>/<root_prefix>/projects/<project_slug>/<relpath>
+```
+
+- `root_prefix` defaults to `serena-sync/` (configurable).
+- `project_slug` = deterministic slug of project absolute path
+  (`sha256(abs_path)[:12]` + `-` + basename). Collision-resistant, stable
+  across machines, hides local home dir in the key space.
+- Paths inside the remote key are POSIX (`/`), UTF-8 NFC normalized.
+
+### 4.5 Data model
+
+#### LocalInventory entry
+```
+path:              POSIX relpath under scope root, UTF-8 NFC
+size:              int (bytes)
+sha256:            hex string (chunked 1 MiB reads)
+mtime_ns:          int (nanoseconds since epoch, for diagnostics only)
+scope_origin:      "global" | f"project:{slug}"
+```
+
+#### RemoteObjectMeta
+```
+key:               POSIX remote key
+size:              int
+sha256:            Optional[str]  (None if remote metadata missing)
+etag:              str            (provider-specific, diagnostic)
+version_id:        Optional[str]  (if provider exposes it)
+last_modified:     datetime
+metadata_present:  bool           (True only if our x-*-meta-serena-sync-sha256 is present)
+```
+
+Inventory records are provider-neutral — the struct is identical across R2, S3,
+and Azure. The `providers/` layer translates its SDK response into
+`RemoteObjectMeta`.
+
+## 5. Diff & reconciliation algorithm
+
+Byte-equivalent via SHA-256 (cryptographic collision resistance ≈ byte compare
+for our purposes), with an opt-in paranoid byte-by-byte verifier.
+
+```
+LOCAL_MAP  = inventory.build_local()       # {key: LocalMeta}
+REMOTE_MAP = inventory.build_remote()      # {key: RemoteMeta}
+
+classify(k):
+    l = LOCAL_MAP.get(k)
+    r = REMOTE_MAP.get(k)
+    if l and not r:     return UPLOAD
+    if r and not l:     return DOWNLOAD
+    if not l and not r: return SKIP           # impossible
+    # both exist
+    if r.sha256 is None:
+        r.sha256 = stream_hash(provider, k)   # fallback for legacy objects
+    if l.sha256 == r.sha256 and l.size == r.size:
+        if opts.byte_compare:                 # paranoid opt-in
+            if not stream_byte_compare(provider, k, local_path(k)):
+                return CONFLICT               # sha collision or corruption
+        return SKIP
+    return CONFLICT
+```
+
+### Actions
+
+| Class | Push mode | Pull mode |
+|---|---|---|
+| `UPLOAD` | `put_object_if_absent(k, ...)` — if 412 returned, demote to CONFLICT | (no-op) |
+| `DOWNLOAD` | (no-op) | atomic write via tmp+fsync+rename; chmod user-owned |
+| `CONFLICT` | Log + report. Do **not** overwrite remote. Require `--force-push`. | Log + save remote as `<path>.cloud-<iso8601>` sibling. Leave local intact. Require `--force-pull` to overwrite. |
+| `SKIP` | No-op | No-op |
+
+### Dry-run-first UX contract (Buddy amendment)
+
+Both `push` and `pull` always produce a **classified plan** before any I/O
+mutation. The dashboard surfaces this same plan — "3 uploads, 1 download, 0
+conflicts" — and the user confirms before execution. `--dry-run` on CLI shows
+the plan and exits.
+
+## 6. Scope
+
+### INCLUDE (default)
+
+```
+~/.serena/serena_config.yml
+~/.serena/contexts/**/*.yml
+~/.serena/modes/**/*.yml
+~/.serena/memories/**/*              # global memories (if used)
+
+<project>/.serena/project.yml
+<project>/.serena/memories/**/*.md
+<project>/.serena/memories/**/*.json # rare, but include anything under memories/
+```
+
+### EXCLUDE (always, not overridable)
+
+```
+~/.serena/logs/**                    # noisy, privacy
+~/.serena/cache/**                   # derivable
+<project>/.serena/ls-cache/**        # LS symbol cache, derivable
+**/*.env                             # defensive: never sync credential files
+**/*.secret
+**/*.key                             # private keys
+**/*Zone.Identifier                  # Windows sidecar
+symlinks                             # never follow
+files > 5 MiB                        # hard cap (likely not a memory file)
+```
+
+### OPT-IN (warned)
+
+```
+<project>/.serena/project.local.yml  # may contain machine-specific values
+```
+Dashboard shows a prominent warning when `project.local.yml` is in scope,
+because it can hold paths / credentials specific to one machine.
+
+## 7. Security model
+
+### 7.1 Credential storage
+
+Single file: `~/.serena/cloud-sync.env` (chmod `600`, owner-only).
+
+- Written **atomically**: write tmp file → `fsync` → `rename` → `chmod 600`.
+- On startup, read with `python-dotenv`. If file perms are wider than `600`,
+  log a loud warning and refuse to start sync until user runs
+  `serena cloud-sync fix-perms`.
+- On overwrite, backup existing file to `cloud-sync.env.bak` (also `600`).
+- Git-check at configure time: if `~/.serena/` is inside a git repo and the
+  env file is tracked, refuse and print remediation.
+
+### 7.2 Env schema (provider-prefixed, one shared file)
+
+```
+# Active provider (r2 | s3 | azure)
+CLOUD_SYNC_PROVIDER=r2
+
+# Common
+CLOUD_SYNC_BUCKET=serena-sync
+CLOUD_SYNC_ROOT_PREFIX=serena-sync/
+
+# R2
+R2_ACCOUNT_ID=63cc5315...
+R2_ACCESS_KEY_ID=...
+R2_SECRET_ACCESS_KEY=...
+R2_ENDPOINT_URL=https://63cc5315....r2.cloudflarestorage.com   # derived by default
+
+# S3
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=eu-west-1
+
+# Azure
+AZURE_STORAGE_ACCOUNT=...
+AZURE_STORAGE_ACCOUNT_KEY=...
+AZURE_CONTAINER=serena-sync
+```
+
+Why one file with prefixes (Buddy-approved):
+- Operationally simple: one file to back up / copy / rotate.
+- Clear which provider is "active" via `CLOUD_SYNC_PROVIDER`.
+- Unused provider's keys can remain in the file (stale but inert).
+- Avoids proliferation of `cloud-sync-r2.env`, `cloud-sync-s3.env`, etc.
+
+### 7.3 Dashboard secret handling
+
+- `GET /api/cloud-sync/config` returns all fields **masked** (e.g. `****abcd`
+  — last 4 chars only). Never returns full secrets.
+- `POST /api/cloud-sync/config` accepts partial updates. If a field value is
+  `"****"`, it's treated as "unchanged" and NOT overwritten.
+- No secret values pass through browser `fetch` response bodies after save.
+- Sync-layer `logging.Filter` redacts `AWS_SECRET_ACCESS_KEY`,
+  `R2_SECRET_ACCESS_KEY`, `AZURE_STORAGE_ACCOUNT_KEY`, and any value matching
+  a high-entropy base64-like pattern in log records.
+- Tracebacks from boto3 / azure-storage-blob are caught at the sync-layer
+  boundary and reformatted without credential material.
+
+### 7.4 Process isolation
+
+SDK clients constructed with explicit kwargs from the `Settings` pydantic
+model. Never `os.environ` side-channel so a stale shell env cannot override.
+
+## 8. Dashboard UX
+
+New navigation item **Cloud Sync** in `index.html`. Page is loaded from
+`cloud-sync.html` + `cloud-sync.js`. Layout:
+
+```
+┌── Cloud Sync ────────────────────────────────────────────────┐
+│                                                              │
+│  Provider: [ R2 ▾ ]                                          │
+│                                                              │
+│  Credentials                                                 │
+│    Account ID     [ 63cc5315...                        ]     │
+│    Access Key ID  [ ****abcd                           ]     │
+│    Secret         [ ****                               ]     │
+│    Bucket         [ serena-sync                        ]     │
+│    Root prefix    [ serena-sync/                       ]     │
+│                                                              │
+│  [ Test connection ]   [ Save ]                              │
+│                                                              │
+│  Actions                                                     │
+│    [ Dry-run Push ]  [ Dry-run Pull ]                        │
+│    [ Push ]          [ Pull ]       [ Full Sync ]            │
+│                                                              │
+│  Status                                                      │
+│    Local inventory:   52 files  (2.1 MB)                     │
+│    Remote inventory:  48 files  (1.9 MB)                     │
+│    Last push:         2026-04-13T14:22Z  OK  (4 uploaded)    │
+│    Last pull:         2026-04-13T12:01Z  OK  (0 downloaded)  │
+│                                                              │
+│  Dry-run plan (click an action above)                        │
+│    UPLOAD   3                                                │
+│    DOWNLOAD 1                                                │
+│    CONFLICT 0                                                │
+│    SKIP     48                                               │
+│                                                              │
+│  [ Warning: project.local.yml is included.                   │
+│    It may contain machine-specific values. Uncheck to omit. ]│
+└──────────────────────────────────────────────────────────────┘
+```
+
+- Experimental badge top-right.
+- Every destructive action ("Push", "Pull", "Full Sync") **requires a
+  dry-run preview** to be rendered within the last 60 seconds (UI enforces).
+- Action buttons disable while a sync is running; a live progress area streams
+  log lines via Server-Sent Events.
+
+## 9. CLI surface
+
+```
+serena cloud-sync configure                 # interactive credential prompt
+serena cloud-sync test                      # PUT/HEAD/GET/DELETE probe
+serena cloud-sync status                    # inventory counts + last sync markers
+serena cloud-sync push [--dry-run] [--force-push] [--byte-compare]
+serena cloud-sync pull [--dry-run] [--force-pull] [--byte-compare]
+serena cloud-sync fix-perms                 # chmod 600 env file
+serena cloud-sync --provider r2|s3|azure    # override active provider for this run
+```
+
+- `configure` prompts only for the selected provider's fields; unchanged
+  values keep previous (masked input "****" means leave as-is).
+- `test` writes a probe object at `<root_prefix>.self-test/<ts>-<host>`,
+  HEADs it, GETs it back, compares sha256, then DELETEs it. Only endpoint
+  that invokes `delete_object`.
+
+## 10. Dependencies
+
+Add to `pyproject.toml`:
+
+```
+"boto3==1.40.x",                 # R2 + S3 (Cloudflare R2 is S3-compatible via endpoint_url)
+"azure-storage-blob==12.25.x",   # Phase 2 provider (can be lazy-loaded)
+```
+
+Existing deps that cover the rest:
+- `flask` — dashboard blueprint
+- `python-dotenv` / `dotenv` — env read/write
+- `pydantic` — `Settings` typed model
+- `cryptography` — reserved for Phase 3 envelope encryption
+- `pathspec` — scope include/exclude matching
+- `filelock` — local lock on push
+- `urllib3` — already TLS-verified
+
+Azure SDK is **lazy-imported** — not required for R2/S3 users in MVP.
+
+## 11. Testing strategy
+
+Clear seam between unit and integration:
+
+### Unit (fast, offline, no SDK calls)
+- `tests/cloud_sync/test_scope.py` — include/exclude matrix, symlink reject,
+  size cap, Zone.Identifier reject.
+- `tests/cloud_sync/test_inventory.py` — sha256 chunked hashing, UTF-8 NFC
+  normalization, path-traversal hardening.
+- `tests/cloud_sync/test_diff.py` — classify every branch with a
+  `FakeCloudProvider` (in-memory dict). Includes CONFLICT detection, sha256
+  fallback path, paranoid byte-compare.
+- `tests/cloud_sync/test_credentials.py` — atomic write, chmod 600, masked
+  read, perms warning, env-file-in-git-repo refusal.
+- `tests/cloud_sync/test_sync.py` — `CloudSyncService` push/pull with
+  FakeCloudProvider; dry-run plan matches execution.
+
+### Integration (LocalStack for S3-compatible, Azurite for Azure)
+- `tests/cloud_sync/integration/test_s3_provider.py` — full round-trip
+  against LocalStack S3.
+- `tests/cloud_sync/integration/test_r2_provider.py` — round-trip against
+  LocalStack S3 configured with R2-shaped endpoint override (R2 specifics
+  validated manually against a real R2 token, gated by env var).
+- Azure deferred to Phase 2 (Azurite emulator).
+
+### Contract tests
+Parametrized test that runs the `put_object_if_absent` semantics against
+every available provider and asserts: first PUT succeeds, second PUT with
+different body returns `ProviderConflictError` (mapped from 412).
+
+## 12. Phased rollout
+
+### Phase 1 (MVP)
+- `CloudStorageProvider` ABC + `base_s3`, `r2`, `s3` providers.
+- `CloudSyncService`, `LocalInventory`, `ScopeFilter`, `CredentialsStore`.
+- CLI: `configure`, `test`, `status`, `push`, `pull`, `fix-perms`.
+- Dashboard: config form, test button, status cards, dry-run + push + pull
+  actions.
+- Unit tests + LocalStack integration test.
+- Experimental flag in dashboard + `--experimental` CLI gate until 1 release
+  cycle of field testing.
+
+### Phase 2
+- `providers/azure.py` with `azure-storage-blob`.
+- Paranoid `--byte-compare` mode.
+- Log redactor filter (belt-and-suspenders; basic redaction already in P1).
+- Conflict UI: render `.cloud-<ts>` sibling as a diff against local in the
+  dashboard.
+- Azurite-backed contract + integration tests.
+
+### Phase 3
+- Client-side envelope encryption (age via `pyrage` or AES-GCM via
+  `cryptography` with a keyring-backed master key).
+- Background scheduler (cron-like, opt-in).
+- Multi-bucket federation (sync across 2+ clouds for redundancy).
+- Rename detection via content-hash lookup.
+
+## 13. Safety / UX commitments
+
+- **Dry-run-first** always.
+- **Never silently overwrite divergent content.** `.cloud-<ts>` sibling on
+  pull conflicts; refuse push on conflicts without `--force-push`.
+- **Mask all secret reads** over HTTP.
+- **chmod 600** on credential file, with loud warning if permissions drift.
+- **Experimental badge** until field-tested.
+- **Additive only.** Documented in dashboard, `--help`, and this doc.
+- **`.env`, `.secret`, `.key`** files are never uploaded — hard rule in
+  `scope.py` that cannot be overridden by config.
+
+## 14. Known MVP limitations (explicit)
+
+| Area | Limitation | Mitigation / Phase |
+|---|---|---|
+| Deletes | Not propagated | User deletes on both sides manually; future tombstone design |
+| Renames | Not detected (double-counts) | User cleans up the side with the old name |
+| Large files | 5 MiB cap | Intended: memory/config files are tiny. Raise cap via Phase 2 if needed |
+| Full two-way merge | Not supported | Additive only; CONFLICT preserves both versions |
+| At-rest encryption | Provider-default SSE | Client-side envelope encryption in Phase 3 |
+| Background sync | User-triggered only | Scheduler in Phase 3 |
+| Azure | Deferred | Phase 2 |
+
+## 15. References / prior art
+
+- **Pointerpro `memory-sync.php`** (qdrant memory id `2f431691`) — the
+  reference semantics: per-file additive, HEAD-then-PUT-if-404, atomic writes,
+  path-traversal hardening, `self-test` probe pattern. This plan is a
+  Python-native port into Serena with a proper DIP seam + strategy pattern for
+  the three target providers.
+- **qdrant-mcp-pp R2 sync** (qdrant memory id `401c13c4`) — snapshot-based R2
+  transport; architecturally different (tar.gz snapshots, last-writer wins).
+  Not a model for this feature because we explicitly want additive union.
+- **Cloudflare R2 S3 compatibility**: R2 supports most S3 APIs via
+  `endpoint_url` override in boto3. Known incompatibilities (checksum
+  algorithms, specific ACLs) are handled in `providers/r2.py`.
+
+## 16. Acceptance criteria
+
+- [ ] `serena cloud-sync configure` writes `~/.serena/cloud-sync.env` with
+      mode `0600`; re-reading returns masked values.
+- [ ] `serena cloud-sync test` against R2 (using provided creds) round-trips
+      a probe object and cleans it up.
+- [ ] `serena cloud-sync push --dry-run` on a populated test project prints a
+      classified plan without mutating remote state.
+- [ ] `serena cloud-sync push` uploads exactly the files in `UPLOAD` class;
+      remote `x-amz-meta-serena-sync-sha256` present on every uploaded
+      object.
+- [ ] `serena cloud-sync pull` into a freshly-deleted local Serena tree
+      restores byte-identical files (sha256 verified).
+- [ ] Induced conflict (different body for same key on two machines) is
+      classified `CONFLICT`; neither side is overwritten; `.cloud-<ts>`
+      sibling appears on pull.
+- [ ] Dashboard **Cloud Sync** panel renders; config save writes env atomically;
+      masked secrets never leave the server; live action streams progress.
+- [ ] Unit test suite: FakeCloudProvider tests for diff / scope / credentials
+      all green; LocalStack integration test green.
+- [ ] No new import of `boto3` or `azure.storage.blob` outside `providers/`.
+
+## 17. Remote inventory consistency (MVP contract)
+
+For the diff algorithm to be stable across providers, implementation honors
+one source-of-truth model:
+
+- **Object key presence** via `ListObjectsV2` (S3/R2) / `list_blobs` (Azure)
+  is authoritative for "does this object exist".
+- **sha256** comes first from `serena-sync-sha256` in custom metadata (set by
+  every upload this tool performs). If absent (legacy / alien object), fall
+  back to a streaming hash during diff. Stream-hash results are cached in a
+  local `~/.serena/cloud-sync.inventory-cache.json` keyed on
+  `(key, etag, last_modified)` so subsequent runs don't re-stream.
+- **ETag** is diagnostic only; not a correctness signal. R2 and S3 compute
+  ETag differently for multipart uploads; we do not rely on it.
+- **version_id** captured when the provider exposes it (S3 with versioning
+  enabled) and recorded in `RemoteObjectMeta`, but MVP does not branch on
+  version_id. Future phase may use it for time-travel pull.
+- **last_modified** captured for reporting, not for diff.
+- When a provider returns no object-metadata in listing, the inventory builder
+  HEADs each candidate before diff (bounded concurrency). This makes first-run
+  inventory slower but correct.
+
+## 18. Failure & idempotency contract
+
+Uploads and downloads are always **interruption-safe** and **idempotent**:
+
+### Upload
+- `put_object_if_absent` uses `If-None-Match: "*"`. Server accepts or rejects
+  atomically; partial objects don't leak (providers commit only on body-end).
+- Multipart is disabled in MVP (5 MiB cap covers all memory/config files).
+- On `ProviderConflictError` (412): re-classify the key as CONFLICT, record
+  the remote meta, continue the batch.
+- On network error: retry with exponential backoff (boto3 default 5 retries;
+  Azure explicit retry policy). If all retries fail, that single key is
+  reported `FAILED` in the sync report, sync continues for other keys.
+
+### Download
+- Write to `<target>.cloud-sync.tmp.<pid>.<rand>` in the same dir, `fsync`,
+  `rename` → atomic publication. Temp files cleaned in a `finally`.
+- If download is interrupted mid-body, no partial file becomes visible
+  because the rename is the commit.
+- `.cloud-<ts>` conflict siblings use the same atomic write pattern.
+
+### Retry boundaries
+- All provider methods idempotent by construction (`put_if_absent`, GET,
+  HEAD, LIST). Retrying a failed op never mutates state beyond what was
+  intended.
+- Local inventory caching is atomic via tmp+rename; a torn cache file is
+  detected on next run (bad JSON) and rebuilt.
+
+### Interrupted sync
+- The sync report is written as it progresses to
+  `~/.serena/cloud-sync.progress.json`. A Ctrl-C between file k and k+1
+  leaves a consistent state on disk: what was done is committed; what
+  wasn't done is simply not done.
+
+## 19. Open questions
+
+1. **Should Phase 1 include `azurite`-based integration tests for Azure even
+   though the Azure adapter itself ships in Phase 2?** Trade-off: extra CI
+   time vs. lower Phase-2 risk.
+2. **Should `configure` accept an S3-compatible custom endpoint for
+   self-hosted MinIO / Ceph RGW?** Trivial to support (already a field in
+   R2), but expands MVP test surface.
+3. **Should we publish the Serena cloud-sync wire format (object key layout,
+   metadata keys) as a stable contract so third-party tools can interop?**
+   Recommendation: mark unstable in MVP, stabilize after Phase 2 feedback.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,11 @@ dependencies = [
   "cryptography==46.0.7",
   "regex==2026.2.28",
   "pythonnet==3.1.0-rc0 ; sys_platform == 'win32'",
+  # Cloud sync (EXPERIMENTAL): S3/R2 via boto3, Azure via azure-storage-blob.
+  # azure-storage-blob is lazy-imported inside serena.cloud_sync.providers.azure
+  # so users on R2/S3 don't pay the import cost until they actively select Azure.
+  "boto3==1.40.54",
+  "azure-storage-blob==12.26.0",
 ]
 
 

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -1162,9 +1162,13 @@ _config = SerenaConfigCommands()
 _tools = ToolCommands()
 _prompts = PromptCommands()
 
+# Import the cloud-sync group lazily-compatible: the module itself only pulls
+# boto3 when a subcommand actually builds a provider (see factory.py).
+from serena.cloud_sync.cli import cloud_sync_group as _cloud_sync  # noqa: E402
+
 # Expose so we can use this as an entrypoint
 top_level = TopLevelCommands()
 
 # needed for the help script to work - register all subcommands to the top-level group
-for subgroup in (_mode, _context, _project, _config, _tools, _prompts):
+for subgroup in (_mode, _context, _project, _config, _tools, _prompts, _cloud_sync):
     top_level.add_command(subgroup)

--- a/src/serena/cloud_sync/__init__.py
+++ b/src/serena/cloud_sync/__init__.py
@@ -1,0 +1,35 @@
+"""Serena Cloud Sync — cross-machine sync of memories and configuration.
+
+EXPERIMENTAL in MVP. Additive union semantics: never overwrites divergent content
+silently. See docs/cloud-sync-feature-plan.md for the full contract.
+
+The public surface intentionally keeps SDK deps (boto3, azure-storage-blob) out
+of the business-logic layer. Concrete provider adapters live under
+``serena.cloud_sync.providers``; the abstract seam is ``provider.CloudStorageProvider``.
+"""
+from serena.cloud_sync.exceptions import (
+    CloudSyncError,
+    CredentialError,
+    ProviderConflictError,
+    ProviderError,
+    ScopeError,
+)
+from serena.cloud_sync.provider import CloudStorageProvider, RemoteObjectMeta
+from serena.cloud_sync.settings import CloudSyncSettings, ProviderType
+from serena.cloud_sync.sync import CloudSyncService, SyncAction, SyncPlan, SyncReport
+
+__all__ = [
+    "CloudStorageProvider",
+    "CloudSyncError",
+    "CloudSyncService",
+    "CloudSyncSettings",
+    "CredentialError",
+    "ProviderConflictError",
+    "ProviderError",
+    "ProviderType",
+    "RemoteObjectMeta",
+    "ScopeError",
+    "SyncAction",
+    "SyncPlan",
+    "SyncReport",
+]

--- a/src/serena/cloud_sync/cli.py
+++ b/src/serena/cloud_sync/cli.py
@@ -1,0 +1,326 @@
+"""CLI subcommand group for ``serena cloud-sync``.
+
+This module keeps CLI logic out of ``serena.cli`` and out of ``sync.py``.
+``serena.cli`` registers the group via a tiny one-liner at its bottom.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+import click
+
+from serena.cloud_sync.credentials import (
+    ENV_PATH,
+    K_AZ_ACCOUNT,
+    K_AZ_CONTAINER,
+    K_AZ_ENDPOINT_SUFFIX,
+    K_AZ_KEY,
+    K_PROVIDER,
+    K_R2_ACCESS_KEY_ID,
+    K_R2_ACCOUNT_ID,
+    K_R2_BUCKET,
+    K_R2_ENDPOINT_URL,
+    K_R2_SECRET_ACCESS_KEY,
+    K_ROOT_PREFIX,
+    K_S3_ACCESS_KEY_ID,
+    K_S3_BUCKET,
+    K_S3_ENDPOINT_URL,
+    K_S3_REGION,
+    K_S3_SECRET_ACCESS_KEY,
+    check_not_in_git,
+    check_perms,
+    ensure_home,
+    fix_perms,
+    install_redactor,
+    load_settings,
+    save_env,
+)
+from serena.cloud_sync.exceptions import CloudSyncError, CredentialError
+from serena.cloud_sync.factory import build_provider
+from serena.cloud_sync.scope import DEFAULT_GLOBAL_INCLUDES, DEFAULT_PROJECT_INCLUDES, ScopeFilter, ScopeRoot
+from serena.cloud_sync.settings import CloudSyncSettings, DEFAULT_ROOT_PREFIX, ProviderType
+from serena.cloud_sync.sync import CloudSyncService, SyncReport
+from serena.util.cli_util import AutoRegisteringGroup
+
+log = logging.getLogger(__name__)
+
+_MAX_CONTENT_WIDTH = 120
+
+
+def _discover_project_roots(cwd: Path | None = None) -> list[ScopeRoot]:
+    """Discover the set of local roots to sync.
+
+    Currently:
+    - Global: $SERENA_HOME (default ~/.serena)
+    - Project: any ancestor of cwd that contains a .serena dir.
+    """
+    from serena.config.serena_config import SerenaPaths
+    home = Path(SerenaPaths().serena_user_home_dir)
+    roots: list[ScopeRoot] = [
+        ScopeRoot(local_root=home, remote_subprefix="global"),
+    ]
+    cwd = cwd or Path.cwd()
+    for parent in [cwd, *cwd.parents]:
+        dotser = parent / ".serena"
+        if dotser.is_dir():
+            slug = _project_slug(parent)
+            roots.append(ScopeRoot(local_root=dotser, remote_subprefix=f"projects/{slug}"))
+            break
+    return roots
+
+
+def _project_slug(abs_path: Path) -> str:
+    """Deterministic, collision-resistant, privacy-preserving project slug."""
+    import hashlib
+    h = hashlib.sha256(str(abs_path.resolve()).encode("utf-8")).hexdigest()[:12]
+    basename = abs_path.name or "root"
+    return f"{h}-{basename}"
+
+
+def _build_scope(opt_in_local_yml: bool) -> ScopeFilter:
+    includes = list(DEFAULT_GLOBAL_INCLUDES) + list(DEFAULT_PROJECT_INCLUDES)
+    return ScopeFilter(
+        include_patterns=tuple(includes),
+        opt_in_project_local_yml=opt_in_local_yml,
+    )
+
+
+def _build_service(
+    settings: CloudSyncSettings,
+    *,
+    opt_in_local_yml: bool,
+) -> tuple[CloudSyncService, list[ScopeRoot]]:
+    provider = build_provider(settings)
+    scope = _build_scope(opt_in_local_yml)
+    roots = _discover_project_roots()
+    progress_path = Path(os.path.expanduser("~/.serena")) / "cloud-sync.progress.json"
+    return (
+        CloudSyncService(
+            provider=provider,
+            scope=scope,
+            roots=roots,
+            root_prefix=settings.root_prefix,
+            progress_path=progress_path,
+        ),
+        roots,
+    )
+
+
+def _load_or_exit() -> CloudSyncSettings:
+    try:
+        settings = load_settings()
+    except CredentialError as e:
+        click.echo(f"error: {e}", err=True)
+        sys.exit(2)
+    install_redactor(log, settings)
+    install_redactor(logging.getLogger("serena.cloud_sync"), settings)
+    return settings
+
+
+def _print_report(report: SyncReport, *, fmt: str) -> None:
+    if fmt == "json":
+        click.echo(json.dumps(report.to_dict(), indent=2))
+        return
+    if report.plan is not None:
+        click.echo(f"plan: {report.plan.counts}")
+    click.echo(
+        f"{report.mode} {'(dry-run) ' if report.dry_run else ''}"
+        f"uploaded={len(report.uploaded)} "
+        f"downloaded={len(report.downloaded)} "
+        f"conflicts={len(report.conflicts)} "
+        f"skipped={len(report.skipped)} "
+        f"failed={len(report.failed)}"
+    )
+    for c in report.conflicts:
+        click.echo(f"  conflict: {c['key']} -> {c['resolution']}", err=True)
+    for f in report.failed:
+        click.echo(f"  failed: {f['key']} -> {f['error']}", err=True)
+
+
+class CloudSyncCommands(AutoRegisteringGroup):
+    """Group for ``serena cloud-sync`` subcommands (EXPERIMENTAL)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="cloud-sync",
+            help=(
+                "EXPERIMENTAL. Sync serena memories + config to a cloud backend "
+                "(Cloudflare R2, Amazon S3, Azure Blob). Additive only — never "
+                "silently overwrites divergent content."
+            ),
+        )
+
+    # ---- configure --------------------------------------------------------
+
+    @staticmethod
+    @click.command("configure", help="Interactive credential configuration.",
+                   context_settings={"max_content_width": _MAX_CONTENT_WIDTH})
+    @click.option("--provider", type=click.Choice([p.value for p in ProviderType]),
+                  default=None, help="Active provider.")
+    @click.option("--from-stdin", is_flag=True, help="Read JSON {key:value} from stdin (scriptable).")
+    def configure(provider: str | None, from_stdin: bool) -> None:
+        ensure_home()
+        if from_stdin:
+            raw = json.loads(sys.stdin.read() or "{}")
+            save_env(raw)
+            fix_perms()
+            check_not_in_git()
+            click.echo(f"wrote {ENV_PATH}")
+            return
+
+        values: dict[str, str] = {}
+        if provider:
+            values[K_PROVIDER] = provider
+        else:
+            current = _current_provider_value()
+            values[K_PROVIDER] = click.prompt(
+                "Provider (r2/s3/azure)", default=current or "r2",
+                type=click.Choice([p.value for p in ProviderType]),
+            )
+        values[K_ROOT_PREFIX] = click.prompt(
+            "Root prefix", default=DEFAULT_ROOT_PREFIX
+        )
+        p = values[K_PROVIDER]
+        if p == "r2":
+            values[K_R2_ACCOUNT_ID] = click.prompt("R2 account ID")
+            values[K_R2_ACCESS_KEY_ID] = click.prompt("R2 access key ID")
+            values[K_R2_SECRET_ACCESS_KEY] = click.prompt(
+                "R2 secret access key", hide_input=True
+            )
+            values[K_R2_BUCKET] = click.prompt("R2 bucket")
+            values[K_R2_ENDPOINT_URL] = click.prompt(
+                "R2 endpoint URL (leave blank to derive from account id)", default="",
+            )
+        elif p == "s3":
+            values[K_S3_ACCESS_KEY_ID] = click.prompt("AWS access key ID")
+            values[K_S3_SECRET_ACCESS_KEY] = click.prompt(
+                "AWS secret access key", hide_input=True
+            )
+            values[K_S3_BUCKET] = click.prompt("AWS bucket")
+            values[K_S3_REGION] = click.prompt("AWS region", default="us-east-1")
+            values[K_S3_ENDPOINT_URL] = click.prompt(
+                "Custom endpoint URL (MinIO/Ceph; leave blank for AWS)", default="",
+            )
+        elif p == "azure":
+            values[K_AZ_ACCOUNT] = click.prompt("Azure storage account name")
+            values[K_AZ_KEY] = click.prompt(
+                "Azure storage account key", hide_input=True
+            )
+            values[K_AZ_CONTAINER] = click.prompt("Azure container")
+            values[K_AZ_ENDPOINT_SUFFIX] = click.prompt(
+                "Azure endpoint suffix", default="core.windows.net"
+            )
+        save_env(values)
+        fix_perms()
+        check_not_in_git()
+        click.echo(f"wrote {ENV_PATH} (chmod 600)")
+
+    # ---- test -------------------------------------------------------------
+
+    @staticmethod
+    @click.command("test", help="Round-trip a probe object to validate credentials.")
+    @click.option("--json", "as_json", is_flag=True, help="Emit JSON result.")
+    def test(as_json: bool) -> None:
+        settings = _load_or_exit()
+        provider = build_provider(settings)
+        probe_key = f"{settings.root_prefix.rstrip('/')}/.self-test/{int(time.time())}-{socket.gethostname()}"
+        body = f"serena cloud-sync self-test {time.time()}".encode("utf-8")
+        from serena.cloud_sync.hash_util import sha256_bytes
+        sha = sha256_bytes(body)
+        result = {"probe_key": probe_key, "ok": False}
+        try:
+            provider.put_object_if_absent(probe_key, body, sha)
+            got = provider.get_object(probe_key)
+            result["round_trip_ok"] = got == body
+            provider.delete_object(probe_key)
+            result["ok"] = True
+        except CloudSyncError as e:
+            result["error"] = str(e)
+        finally:
+            provider.close()
+        if as_json:
+            click.echo(json.dumps(result, indent=2))
+        else:
+            click.echo(f"probe: {probe_key}  ok={result['ok']}")
+        sys.exit(0 if result["ok"] else 1)
+
+    # ---- status -----------------------------------------------------------
+
+    @staticmethod
+    @click.command("status", help="Show inventory counts and last sync markers.")
+    @click.option("--include-project-local-yml", is_flag=True)
+    def status(include_project_local_yml: bool) -> None:
+        settings = _load_or_exit()
+        service, roots = _build_service(settings, opt_in_local_yml=include_project_local_yml)
+        local, remote, diff = service.build_plan()
+        out = {
+            "provider": settings.provider.value,
+            "root_prefix": settings.root_prefix,
+            "roots": [{"path": str(r.local_root), "remote_subprefix": r.remote_subprefix} for r in roots],
+            "local_count": len(local),
+            "remote_count": len(remote),
+            "plan_counts": diff.counts(),
+        }
+        click.echo(json.dumps(out, indent=2))
+
+    # ---- push -------------------------------------------------------------
+
+    @staticmethod
+    @click.command("push", help="Upload local files that are absent or classified as upload.")
+    @click.option("--dry-run", is_flag=True)
+    @click.option("--force-push", "force", is_flag=True,
+                  help="Overwrite remote on CONFLICT. Use with care.")
+    @click.option("--byte-compare", is_flag=True, help="Paranoid byte-by-byte compare after sha256 match.")
+    @click.option("--include-project-local-yml", is_flag=True)
+    @click.option("--json", "as_json", is_flag=True)
+    def push(dry_run: bool, force: bool, byte_compare: bool,
+             include_project_local_yml: bool, as_json: bool) -> None:
+        settings = _load_or_exit()
+        service, _ = _build_service(settings, opt_in_local_yml=include_project_local_yml)
+        report = service.push(dry_run=dry_run, force=force, byte_compare=byte_compare)
+        _print_report(report, fmt="json" if as_json else "text")
+        sys.exit(1 if report.failed else 0)
+
+    # ---- pull -------------------------------------------------------------
+
+    @staticmethod
+    @click.command("pull", help="Download remote files that are absent locally.")
+    @click.option("--dry-run", is_flag=True)
+    @click.option("--force-pull", "force", is_flag=True,
+                  help="Overwrite local on CONFLICT. Use with care.")
+    @click.option("--byte-compare", is_flag=True)
+    @click.option("--include-project-local-yml", is_flag=True)
+    @click.option("--json", "as_json", is_flag=True)
+    def pull(dry_run: bool, force: bool, byte_compare: bool,
+             include_project_local_yml: bool, as_json: bool) -> None:
+        settings = _load_or_exit()
+        service, _ = _build_service(settings, opt_in_local_yml=include_project_local_yml)
+        report = service.pull(dry_run=dry_run, force=force, byte_compare=byte_compare)
+        _print_report(report, fmt="json" if as_json else "text")
+        sys.exit(1 if report.failed else 0)
+
+    # ---- fix-perms --------------------------------------------------------
+
+    @staticmethod
+    @click.command("fix-perms", help="Fix credentials file permissions (chmod 0600).")
+    def fix_perms_cmd() -> None:
+        fix_perms()
+        check_perms()
+        click.echo(f"{ENV_PATH} is 0600")
+
+
+def _current_provider_value() -> str | None:
+    try:
+        return load_settings().provider.value
+    except Exception:
+        return None
+
+
+cloud_sync_group = CloudSyncCommands()

--- a/src/serena/cloud_sync/credentials.py
+++ b/src/serena/cloud_sync/credentials.py
@@ -1,0 +1,279 @@
+"""Dotenv-based credential store with chmod-600 atomic writes.
+
+Single file ``~/.serena/cloud-sync.env`` with provider-prefixed keys; never
+inlined in any YAML that could be committed.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from serena.cloud_sync.exceptions import CredentialError
+from serena.cloud_sync.settings import (
+    AzureSettings,
+    CloudSyncSettings,
+    DEFAULT_ROOT_PREFIX,
+    ProviderType,
+    R2Settings,
+    S3Settings,
+)
+
+log = logging.getLogger(__name__)
+
+ENV_FILENAME = "cloud-sync.env"
+SERENA_HOME = Path(os.environ.get("SERENA_HOME", os.path.expanduser("~/.serena"))).resolve()
+ENV_PATH = SERENA_HOME / ENV_FILENAME
+ENV_BACKUP_PATH = SERENA_HOME / (ENV_FILENAME + ".bak")
+
+# Keys we read from the env file.
+K_PROVIDER = "CLOUD_SYNC_PROVIDER"
+K_ROOT_PREFIX = "CLOUD_SYNC_ROOT_PREFIX"
+
+# R2
+K_R2_ACCOUNT_ID = "R2_ACCOUNT_ID"
+K_R2_ACCESS_KEY_ID = "R2_ACCESS_KEY_ID"
+K_R2_SECRET_ACCESS_KEY = "R2_SECRET_ACCESS_KEY"
+K_R2_BUCKET = "R2_BUCKET"
+K_R2_ENDPOINT_URL = "R2_ENDPOINT_URL"
+
+# S3
+K_S3_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
+K_S3_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
+K_S3_BUCKET = "AWS_BUCKET"
+K_S3_REGION = "AWS_REGION"
+K_S3_ENDPOINT_URL = "AWS_ENDPOINT_URL"
+
+# Azure
+K_AZ_ACCOUNT = "AZURE_STORAGE_ACCOUNT"
+K_AZ_KEY = "AZURE_STORAGE_ACCOUNT_KEY"
+K_AZ_CONTAINER = "AZURE_CONTAINER"
+K_AZ_ENDPOINT_SUFFIX = "AZURE_ENDPOINT_SUFFIX"
+
+SECRET_KEYS: frozenset[str] = frozenset({
+    K_R2_SECRET_ACCESS_KEY,
+    K_S3_SECRET_ACCESS_KEY,
+    K_AZ_KEY,
+})
+
+
+def env_path() -> Path:
+    return ENV_PATH
+
+
+def ensure_home() -> None:
+    SERENA_HOME.mkdir(parents=True, exist_ok=True)
+
+
+def env_exists() -> bool:
+    return ENV_PATH.is_file()
+
+
+def check_perms(path: Path = ENV_PATH) -> None:
+    """Raise CredentialError if perms are wider than 0600 on a POSIX filesystem."""
+    if os.name != "posix":
+        return
+    if not path.exists():
+        return
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode & 0o077:
+        raise CredentialError(
+            f"credentials file {path} has mode 0{mode:o}; must be 0600. "
+            f"Run: serena cloud-sync fix-perms"
+        )
+
+
+def fix_perms(path: Path = ENV_PATH) -> None:
+    if os.name != "posix":
+        return
+    if not path.exists():
+        return
+    os.chmod(path, 0o600)
+
+
+def check_not_in_git(path: Path = ENV_PATH) -> None:
+    """Loud warning (not a hard error) if the env file sits inside a git repo.
+
+    We check with ``git rev-parse --show-toplevel``. Silent if git is absent.
+    """
+    if not path.exists():
+        return
+    try:
+        res = subprocess.run(
+            ["git", "-C", str(path.parent), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True, text=True, timeout=3,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return
+    if res.returncode == 0 and res.stdout.strip() == "true":
+        log.warning(
+            "cloud-sync credentials file at %s is inside a git working tree; "
+            "make sure it is .gitignore'd before committing anything", path
+        )
+
+
+def load_settings(path: Path = ENV_PATH) -> CloudSyncSettings:
+    """Load settings from the env file. Raises CredentialError if file missing
+    or if the active provider's required keys are absent."""
+    if not path.exists():
+        raise CredentialError(
+            f"no cloud-sync credentials at {path}; run `serena cloud-sync configure`"
+        )
+    check_perms(path)
+    raw = dotenv_values(path)
+
+    provider_value = (raw.get(K_PROVIDER) or "").strip().lower()
+    if not provider_value:
+        raise CredentialError(f"{K_PROVIDER} not set in {path}")
+    try:
+        provider = ProviderType(provider_value)
+    except ValueError as e:
+        raise CredentialError(
+            f"{K_PROVIDER}={provider_value!r} is not one of {[p.value for p in ProviderType]}"
+        ) from e
+
+    root_prefix = (raw.get(K_ROOT_PREFIX) or DEFAULT_ROOT_PREFIX).strip() or DEFAULT_ROOT_PREFIX
+
+    r2 = _parse_r2(raw)
+    s3 = _parse_s3(raw)
+    az = _parse_azure(raw)
+
+    settings = CloudSyncSettings(
+        provider=provider,
+        root_prefix=root_prefix,
+        r2=r2,
+        s3=s3,
+        azure=az,
+    )
+    # Validate active provider is populated (raises a clear error otherwise)
+    settings.active_provider_settings()
+    return settings
+
+
+def _parse_r2(raw: dict[str, str | None]) -> R2Settings | None:
+    acc = raw.get(K_R2_ACCOUNT_ID)
+    akid = raw.get(K_R2_ACCESS_KEY_ID)
+    sk = raw.get(K_R2_SECRET_ACCESS_KEY)
+    bucket = raw.get(K_R2_BUCKET)
+    if not any((acc, akid, sk, bucket)):
+        return None
+    if not (acc and akid and sk and bucket):
+        raise CredentialError("R2 settings partially configured; fill all of R2_ACCOUNT_ID/R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY/R2_BUCKET")
+    return R2Settings(
+        account_id=acc, access_key_id=akid, secret_access_key=sk,
+        bucket=bucket, endpoint_url=raw.get(K_R2_ENDPOINT_URL) or None,
+    )
+
+
+def _parse_s3(raw: dict[str, str | None]) -> S3Settings | None:
+    akid = raw.get(K_S3_ACCESS_KEY_ID)
+    sk = raw.get(K_S3_SECRET_ACCESS_KEY)
+    bucket = raw.get(K_S3_BUCKET)
+    if not any((akid, sk, bucket)):
+        return None
+    if not (akid and sk and bucket):
+        raise CredentialError("S3 settings partially configured; fill AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_BUCKET")
+    return S3Settings(
+        access_key_id=akid, secret_access_key=sk, bucket=bucket,
+        region=raw.get(K_S3_REGION) or "us-east-1",
+        endpoint_url=raw.get(K_S3_ENDPOINT_URL) or None,
+    )
+
+
+def _parse_azure(raw: dict[str, str | None]) -> AzureSettings | None:
+    acct = raw.get(K_AZ_ACCOUNT)
+    key = raw.get(K_AZ_KEY)
+    container = raw.get(K_AZ_CONTAINER)
+    if not any((acct, key, container)):
+        return None
+    if not (acct and key and container):
+        raise CredentialError("Azure settings partially configured; fill AZURE_STORAGE_ACCOUNT/AZURE_STORAGE_ACCOUNT_KEY/AZURE_CONTAINER")
+    return AzureSettings(
+        account_name=acct, account_key=key, container=container,
+        endpoint_suffix=raw.get(K_AZ_ENDPOINT_SUFFIX) or "core.windows.net",
+    )
+
+
+def save_env(values: dict[str, str], path: Path = ENV_PATH) -> None:
+    """Atomically write the env file and chmod it 0600.
+
+    ``values`` with value ``'****'`` are treated as 'unchanged' and preserved
+    from the existing file on disk.
+    """
+    ensure_home()
+    existing: dict[str, str] = {}
+    if path.exists():
+        check_perms(path)
+        existing = {k: v or "" for k, v in dotenv_values(path).items()}
+        shutil.copy2(path, ENV_BACKUP_PATH)
+        if os.name == "posix":
+            os.chmod(ENV_BACKUP_PATH, 0o600)
+
+    # Merge: keep previous secrets when the incoming value is the mask sentinel.
+    merged: dict[str, str] = dict(existing)
+    for k, v in values.items():
+        if v is None:
+            continue
+        if v == "****":
+            continue  # keep existing (or leave absent)
+        merged[k] = v
+
+    # Atomic write.
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=str(path.parent), delete=False,
+    )
+    try:
+        for k in sorted(merged.keys()):
+            v = merged[k]
+            # quote values that contain whitespace or special chars
+            if any(c in v for c in " \t#\"'`$"):
+                v = '"' + v.replace('\\', '\\\\').replace('"', '\\"') + '"'
+            tmp.write(f"{k}={v}\n")
+        tmp.flush()
+        os.fsync(tmp.fileno())
+    finally:
+        tmp.close()
+    os.replace(tmp.name, path)
+    if os.name == "posix":
+        os.chmod(path, 0o600)
+
+
+class SecretRedactingFilter(logging.Filter):
+    """Redact any SECRET_KEYS values from log records.
+
+    Installed on the cloud-sync logger. Defence-in-depth against accidental
+    ``repr(settings)`` or SDK traceback leaks.
+    """
+
+    def __init__(self, secret_values: frozenset[str] | None = None) -> None:
+        super().__init__()
+        self._secret_values = frozenset(v for v in (secret_values or frozenset()) if v)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage()
+        redacted = msg
+        for sv in self._secret_values:
+            if sv and sv in redacted:
+                redacted = redacted.replace(sv, "****REDACTED****")
+        if redacted != msg:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+def install_redactor(logger: logging.Logger, settings: CloudSyncSettings) -> None:
+    """Attach a SecretRedactingFilter derived from settings onto ``logger``."""
+    secrets = set()
+    if settings.r2:
+        secrets.add(settings.r2.secret_access_key)
+    if settings.s3:
+        secrets.add(settings.s3.secret_access_key)
+    if settings.azure:
+        secrets.add(settings.azure.account_key)
+    logger.addFilter(SecretRedactingFilter(frozenset(secrets)))

--- a/src/serena/cloud_sync/dashboard_routes.py
+++ b/src/serena/cloud_sync/dashboard_routes.py
@@ -1,0 +1,248 @@
+"""Flask blueprint for the cloud-sync dashboard panel.
+
+Registered from ``serena.dashboard`` at app-construction time. All routes
+return JSON; secret values are masked on GET and treated as 'unchanged' on
+POST when the sentinel ``****`` is submitted.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from pathlib import Path
+from typing import Any
+
+from flask import Blueprint, jsonify, request, abort
+
+from serena.cloud_sync.credentials import (
+    ENV_PATH,
+    K_AZ_ACCOUNT,
+    K_AZ_CONTAINER,
+    K_AZ_ENDPOINT_SUFFIX,
+    K_AZ_KEY,
+    K_PROVIDER,
+    K_R2_ACCESS_KEY_ID,
+    K_R2_ACCOUNT_ID,
+    K_R2_BUCKET,
+    K_R2_ENDPOINT_URL,
+    K_R2_SECRET_ACCESS_KEY,
+    K_ROOT_PREFIX,
+    K_S3_ACCESS_KEY_ID,
+    K_S3_BUCKET,
+    K_S3_ENDPOINT_URL,
+    K_S3_REGION,
+    K_S3_SECRET_ACCESS_KEY,
+    check_not_in_git,
+    check_perms,
+    ensure_home,
+    env_exists,
+    fix_perms,
+    install_redactor,
+    load_settings,
+    save_env,
+)
+from serena.cloud_sync.exceptions import CloudSyncError, CredentialError
+from serena.cloud_sync.factory import build_provider
+from serena.cloud_sync.hash_util import sha256_bytes
+from serena.cloud_sync.scope import DEFAULT_GLOBAL_INCLUDES, DEFAULT_PROJECT_INCLUDES, ScopeFilter
+from serena.cloud_sync.settings import CloudSyncSettings, DEFAULT_ROOT_PREFIX, ProviderType
+from serena.cloud_sync.sync import CloudSyncService, SyncReport
+
+log = logging.getLogger(__name__)
+
+bp = Blueprint("cloud_sync", __name__, url_prefix="/api/cloud-sync")
+
+# Local-process defense against CSRF from other processes on localhost.
+# The token is generated once per process and returned only to requests from
+# 127.0.0.1/::1 on the bootstrap endpoint. Every other endpoint requires the
+# token in X-Cloud-Sync-Token. This is defense-in-depth — the dashboard is
+# already bound to 127.0.0.1 — but prevents same-origin-ish mischief from
+# other local processes that can reach localhost.
+_LOCAL_TOKEN: str = secrets.token_urlsafe(32)
+_LOCAL_ADDRS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def _require_local() -> None:
+    if request.remote_addr not in _LOCAL_ADDRS:
+        abort(403, "cloud-sync endpoints are local-only")
+
+
+@bp.before_request
+def _check_token() -> Any:
+    # Bootstrap endpoint is exempt; it's what the UI uses to fetch the token.
+    if request.endpoint and request.endpoint.endswith(".get_bootstrap_token"):
+        return None
+    _require_local()
+    supplied = request.headers.get("X-Cloud-Sync-Token", "")
+    if not supplied or not secrets.compare_digest(supplied, _LOCAL_TOKEN):
+        abort(403, "missing or invalid X-Cloud-Sync-Token")
+    return None
+
+
+@bp.get("/bootstrap-token")
+def get_bootstrap_token():
+    """Return the per-process token to same-origin local callers.
+
+    The dashboard JS fetches this once on load and attaches the result to every
+    subsequent request. Non-local callers get 403.
+    """
+    _require_local()
+    return jsonify({"token": _LOCAL_TOKEN})
+
+
+# Keys accepted on POST /config. Missing keys mean "no change".
+_POSTABLE_KEYS: tuple[str, ...] = (
+    K_PROVIDER, K_ROOT_PREFIX,
+    K_R2_ACCOUNT_ID, K_R2_ACCESS_KEY_ID, K_R2_SECRET_ACCESS_KEY,
+    K_R2_BUCKET, K_R2_ENDPOINT_URL,
+    K_S3_ACCESS_KEY_ID, K_S3_SECRET_ACCESS_KEY,
+    K_S3_BUCKET, K_S3_REGION, K_S3_ENDPOINT_URL,
+    K_AZ_ACCOUNT, K_AZ_KEY, K_AZ_CONTAINER, K_AZ_ENDPOINT_SUFFIX,
+)
+
+
+@bp.get("/config")
+def get_config():
+    if not env_exists():
+        return jsonify({
+            "configured": False,
+            "env_path": str(ENV_PATH),
+            "default_root_prefix": DEFAULT_ROOT_PREFIX,
+            "providers": [p.value for p in ProviderType],
+        })
+    try:
+        settings = load_settings()
+    except CredentialError as e:
+        return jsonify({"configured": False, "error": str(e)}), 400
+    return jsonify({
+        "configured": True,
+        "env_path": str(ENV_PATH),
+        "settings": settings.masked(),
+    })
+
+
+@bp.post("/config")
+def post_config():
+    payload = request.get_json(silent=True) or {}
+    values: dict[str, str] = {}
+    for k in _POSTABLE_KEYS:
+        v = payload.get(k)
+        if v is None:
+            continue
+        if not isinstance(v, str):
+            v = str(v)
+        values[k] = v
+    ensure_home()
+    save_env(values)
+    fix_perms()
+    check_not_in_git()
+    try:
+        settings = load_settings()
+    except CredentialError as e:
+        return jsonify({"ok": False, "error": str(e)}), 400
+    return jsonify({"ok": True, "settings": settings.masked()})
+
+
+@bp.post("/test")
+def post_test():
+    try:
+        settings = _load()
+    except CredentialError as e:
+        return jsonify({"ok": False, "error": str(e)}), 400
+    provider = build_provider(settings)
+    import socket
+    import time
+
+    probe_key = (
+        f"{settings.root_prefix.rstrip('/')}/.self-test/"
+        f"{int(time.time())}-{socket.gethostname()}"
+    )
+    body = f"serena cloud-sync dashboard probe {time.time()}".encode("utf-8")
+    sha = sha256_bytes(body)
+    try:
+        provider.put_object_if_absent(probe_key, body, sha)
+        got = provider.get_object(probe_key)
+        provider.delete_object(probe_key)
+        return jsonify({"ok": True, "round_trip_ok": got == body, "probe_key": probe_key})
+    except CloudSyncError as e:
+        return jsonify({"ok": False, "error": str(e), "probe_key": probe_key}), 500
+    finally:
+        provider.close()
+
+
+@bp.get("/status")
+def get_status():
+    try:
+        settings = _load()
+    except CredentialError as e:
+        return jsonify({"configured": False, "error": str(e)}), 400
+    include_local = _flag(request.args.get("include_project_local_yml"))
+    service, roots_info = _build_service(settings, include_local)
+    local, remote, diff = service.build_plan()
+    return jsonify({
+        "provider": settings.provider.value,
+        "root_prefix": settings.root_prefix,
+        "roots": roots_info,
+        "local_count": len(local),
+        "remote_count": len(remote),
+        "plan_counts": diff.counts(),
+    })
+
+
+@bp.post("/push")
+def post_push():
+    return _run("push")
+
+
+@bp.post("/pull")
+def post_pull():
+    return _run("pull")
+
+
+def _run(mode: str):
+    try:
+        settings = _load()
+    except CredentialError as e:
+        return jsonify({"ok": False, "error": str(e)}), 400
+    body = request.get_json(silent=True) or {}
+    dry_run = bool(body.get("dry_run", True))  # UI default is dry-run-first
+    force = bool(body.get("force", False))
+    byte_compare = bool(body.get("byte_compare", False))
+    include_local = bool(body.get("include_project_local_yml", False))
+    service, _ = _build_service(settings, include_local)
+    report: SyncReport
+    if mode == "push":
+        report = service.push(dry_run=dry_run, force=force, byte_compare=byte_compare)
+    else:
+        report = service.pull(dry_run=dry_run, force=force, byte_compare=byte_compare)
+    return jsonify({"ok": True, "report": report.to_dict()})
+
+
+def _load() -> CloudSyncSettings:
+    settings = load_settings()
+    install_redactor(log, settings)
+    install_redactor(logging.getLogger("serena.cloud_sync"), settings)
+    return settings
+
+
+def _build_service(settings: CloudSyncSettings, include_local_yml: bool):
+    # Dashboard process is long-running; we discover roots from the server cwd.
+    from serena.cloud_sync.cli import _discover_project_roots
+    roots = _discover_project_roots()
+    scope = ScopeFilter(
+        include_patterns=tuple(list(DEFAULT_GLOBAL_INCLUDES) + list(DEFAULT_PROJECT_INCLUDES)),
+        opt_in_project_local_yml=include_local_yml,
+    )
+    progress_path = Path(str(ENV_PATH.parent / "cloud-sync.progress.json"))
+    service = CloudSyncService(
+        provider=build_provider(settings),
+        scope=scope,
+        roots=roots,
+        root_prefix=settings.root_prefix,
+        progress_path=progress_path,
+    )
+    roots_info = [{"path": str(r.local_root), "remote_subprefix": r.remote_subprefix} for r in roots]
+    return service, roots_info
+
+
+def _flag(v: Any) -> bool:
+    return str(v or "").lower() in ("1", "true", "yes", "on")

--- a/src/serena/cloud_sync/diff.py
+++ b/src/serena/cloud_sync/diff.py
@@ -1,0 +1,73 @@
+"""Diff / reconciliation classifier.
+
+Pure, SDK-free. Given a LocalInventory and a RemoteInventory, classify every
+key into one of the ``SyncAction`` values.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from serena.cloud_sync.inventory import LocalInventory, LocalObjectMeta, RemoteInventory
+from serena.cloud_sync.provider import RemoteObjectMeta
+
+
+class SyncAction(str, Enum):
+    UPLOAD = "upload"
+    DOWNLOAD = "download"
+    SKIP = "skip"
+    CONFLICT = "conflict"
+
+
+@dataclass(frozen=True)
+class DiffEntry:
+    key: str
+    action: SyncAction
+    local: LocalObjectMeta | None = None
+    remote: RemoteObjectMeta | None = None
+    reason: str = ""
+
+
+@dataclass
+class DiffPlan:
+    entries: list[DiffEntry] = field(default_factory=list)
+
+    def by_action(self, action: SyncAction) -> list[DiffEntry]:
+        return [e for e in self.entries if e.action is action]
+
+    def counts(self) -> dict[str, int]:
+        c = {a.value: 0 for a in SyncAction}
+        for e in self.entries:
+            c[e.action.value] += 1
+        return c
+
+
+def classify(
+    local: LocalInventory,
+    remote: RemoteInventory,
+) -> DiffPlan:
+    keys = set(local.entries.keys()) | set(remote.entries.keys())
+    plan = DiffPlan()
+    for k in sorted(keys):
+        lm = local.get(k)
+        rm = remote.get(k)
+        if lm is not None and rm is None:
+            plan.entries.append(DiffEntry(k, SyncAction.UPLOAD, lm, None, "local-only"))
+            continue
+        if rm is not None and lm is None:
+            plan.entries.append(DiffEntry(k, SyncAction.DOWNLOAD, None, rm, "remote-only"))
+            continue
+        assert lm is not None and rm is not None  # key set guarantees
+        if rm.sha256 is None:
+            # Remote sha256 missing despite hash_fallback=True — treat as
+            # unknown. Classify as CONFLICT so the user sees it; safer than
+            # silent overwrite in either direction.
+            plan.entries.append(DiffEntry(k, SyncAction.CONFLICT, lm, rm,
+                                          "remote missing sha256 metadata"))
+            continue
+        if lm.sha256 == rm.sha256 and lm.size == rm.size:
+            plan.entries.append(DiffEntry(k, SyncAction.SKIP, lm, rm, "identical"))
+            continue
+        plan.entries.append(DiffEntry(k, SyncAction.CONFLICT, lm, rm,
+                                      f"sha256 mismatch (local={lm.sha256[:8]} remote={rm.sha256[:8]})"))
+    return plan

--- a/src/serena/cloud_sync/exceptions.py
+++ b/src/serena/cloud_sync/exceptions.py
@@ -1,0 +1,40 @@
+"""Exception hierarchy for the cloud-sync subsystem.
+
+All sync-layer code raises one of these. Providers translate SDK errors into
+the appropriate ``ProviderError`` subclass so that business logic never has to
+catch ``botocore.exceptions.ClientError`` or ``azure.core.exceptions.*``.
+"""
+from __future__ import annotations
+
+
+class CloudSyncError(Exception):
+    """Base class for every cloud-sync error."""
+
+
+class ProviderError(CloudSyncError):
+    """Generic provider failure (network, auth, server 5xx). Retryable-or-not
+    is indicated by ``retryable`` attribute."""
+
+    def __init__(self, message: str, *, retryable: bool = False,
+                 provider_code: str | None = None) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+        self.provider_code = provider_code
+
+
+class ProviderConflictError(ProviderError):
+    """Conditional put (``put_object_if_absent``) returned 412 Precondition Failed
+    — the object already exists with different content. The sync layer maps this
+    to the CONFLICT diff class and preserves both sides."""
+
+    def __init__(self, message: str, *, provider_code: str | None = None) -> None:
+        super().__init__(message, retryable=False, provider_code=provider_code)
+
+
+class CredentialError(CloudSyncError):
+    """Credentials missing, malformed, or unsafe (file perms wider than 0600)."""
+
+
+class ScopeError(CloudSyncError):
+    """Tried to sync a path excluded by the hard scope rules (credential files,
+    oversize binaries, symlinks, etc)."""

--- a/src/serena/cloud_sync/factory.py
+++ b/src/serena/cloud_sync/factory.py
@@ -1,0 +1,26 @@
+"""Factory that instantiates the right concrete provider from settings.
+
+This is the only module other than ``providers/*`` that's allowed to pull in
+SDK-dependent concrete classes.
+"""
+from __future__ import annotations
+
+from serena.cloud_sync.provider import CloudStorageProvider
+from serena.cloud_sync.settings import CloudSyncSettings, ProviderType
+
+
+def build_provider(settings: CloudSyncSettings) -> CloudStorageProvider:
+    p = settings.provider
+    if p is ProviderType.R2:
+        from serena.cloud_sync.providers.r2 import R2Provider
+        assert settings.r2 is not None
+        return R2Provider(settings.r2)
+    if p is ProviderType.S3:
+        from serena.cloud_sync.providers.s3 import S3Provider
+        assert settings.s3 is not None
+        return S3Provider(settings.s3)
+    if p is ProviderType.AZURE:
+        from serena.cloud_sync.providers.azure import AzureBlobProvider
+        assert settings.azure is not None
+        return AzureBlobProvider(settings.azure)
+    raise ValueError(f"unknown provider: {p!r}")

--- a/src/serena/cloud_sync/hash_util.py
+++ b/src/serena/cloud_sync/hash_util.py
@@ -1,0 +1,60 @@
+"""SHA-256 helpers used as the byte-equivalent compare primitive."""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import BinaryIO, Iterable
+
+CHUNK_SIZE = 1024 * 1024  # 1 MiB
+
+
+def sha256_file(path: str | Path) -> str:
+    """Compute hex sha256 of a file via chunked reads."""
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(CHUNK_SIZE), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_stream(chunks: Iterable[bytes]) -> str:
+    h = hashlib.sha256()
+    for chunk in chunks:
+        h.update(chunk)
+    return h.hexdigest()
+
+
+def byte_compare_file_to_stream(path: str | Path, chunks: Iterable[bytes]) -> bool:
+    """Paranoid byte-by-byte compare between a local file and a remote byte stream.
+
+    Returns True if the local file is byte-identical to the concatenation of
+    ``chunks``. Short-circuits on the first divergence for efficiency.
+    """
+    with open(path, "rb") as fh:
+        remaining = b""
+        for rchunk in chunks:
+            while rchunk:
+                if not remaining:
+                    remaining = fh.read(len(rchunk))
+                    if not remaining:
+                        return False
+                n = min(len(remaining), len(rchunk))
+                if remaining[:n] != rchunk[:n]:
+                    return False
+                remaining = remaining[n:]
+                rchunk = rchunk[n:]
+        if fh.read(1):
+            return False
+    return True
+
+
+def _stream_file(fh: BinaryIO) -> Iterable[bytes]:
+    while True:
+        chunk = fh.read(CHUNK_SIZE)
+        if not chunk:
+            return
+        yield chunk

--- a/src/serena/cloud_sync/inventory.py
+++ b/src/serena/cloud_sync/inventory.py
@@ -1,0 +1,127 @@
+"""Local + remote inventory builders.
+
+Inventory entries are provider-neutral; the provider adapter translates its
+SDK response into ``RemoteObjectMeta`` records already.
+"""
+from __future__ import annotations
+
+import logging
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from serena.cloud_sync.hash_util import sha256_file, sha256_stream
+from serena.cloud_sync.provider import CloudStorageProvider, RemoteObjectMeta
+from serena.cloud_sync.scope import ScopeFilter, ScopeRoot
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LocalObjectMeta:
+    """Local-side inventory entry for a single file."""
+    remote_key: str
+    abs_path: Path
+    size: int
+    sha256: str
+    scope_origin: str  # "global" or "project:<slug>"
+
+
+@dataclass
+class LocalInventory:
+    """Map from remote-key -> LocalObjectMeta."""
+    entries: dict[str, LocalObjectMeta] = field(default_factory=dict)
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    def __iter__(self):
+        return iter(self.entries.values())
+
+    def get(self, key: str) -> LocalObjectMeta | None:
+        return self.entries.get(key)
+
+
+@dataclass
+class RemoteInventory:
+    """Map from remote-key -> RemoteObjectMeta."""
+    entries: dict[str, RemoteObjectMeta] = field(default_factory=dict)
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    def __iter__(self):
+        return iter(self.entries.values())
+
+    def get(self, key: str) -> RemoteObjectMeta | None:
+        return self.entries.get(key)
+
+
+def build_local_inventory(
+    scope: ScopeFilter,
+    roots: Iterable[ScopeRoot],
+    root_prefix: str,
+) -> LocalInventory:
+    """Walk all ``roots``, honoring ``scope``, and hash every included file."""
+    inv = LocalInventory()
+    for root, abs_path, rel in scope.iter_files(list(roots)):
+        rel_norm = _norm_rel(rel)
+        key = _compose_key(root_prefix, root.remote_subprefix, rel_norm)
+        size = abs_path.stat().st_size
+        digest = sha256_file(abs_path)
+        inv.entries[key] = LocalObjectMeta(
+            remote_key=key,
+            abs_path=abs_path,
+            size=size,
+            sha256=digest,
+            scope_origin=root.remote_subprefix.strip("/") or "global",
+        )
+    return inv
+
+
+def build_remote_inventory(
+    provider: CloudStorageProvider,
+    prefix: str,
+    *,
+    hash_fallback: bool = False,
+) -> RemoteInventory:
+    """List ``prefix`` on ``provider`` and build the remote inventory.
+
+    If ``hash_fallback=True``, any object missing our sha256 metadata will be
+    stream-hashed (once per run; caching is in a future enhancement).
+    """
+    inv = RemoteInventory()
+    for meta in provider.list_objects(prefix):
+        # ListObjects rarely returns metadata; HEAD to fetch it.
+        if not meta.metadata_present:
+            full = provider.head_object(meta.key)
+            if full is not None:
+                meta = full
+        if meta.sha256 is None and hash_fallback:
+            digest = sha256_stream(provider.iter_object(meta.key))
+            meta = RemoteObjectMeta(
+                key=meta.key,
+                size=meta.size,
+                sha256=digest,
+                etag=meta.etag,
+                version_id=meta.version_id,
+                last_modified=meta.last_modified,
+                metadata_present=False,
+                raw_metadata=meta.raw_metadata,
+            )
+        inv.entries[meta.key] = meta
+    return inv
+
+
+def _norm_rel(rel_posix: str) -> str:
+    """POSIX-style, Unicode NFC normalized relpath for a stable remote key."""
+    return unicodedata.normalize("NFC", rel_posix.replace("\\", "/").lstrip("/"))
+
+
+def _compose_key(root_prefix: str, subprefix: str, rel_norm: str) -> str:
+    rp = root_prefix.rstrip("/") + "/"
+    sub = subprefix.strip("/")
+    if sub:
+        return f"{rp}{sub}/{rel_norm}"
+    return f"{rp}{rel_norm}"

--- a/src/serena/cloud_sync/provider.py
+++ b/src/serena/cloud_sync/provider.py
@@ -1,0 +1,99 @@
+"""DIP seam for cloud sync.
+
+``CloudStorageProvider`` is the abstract interface. Concrete implementations
+live under ``serena.cloud_sync.providers``. The sync service depends on this
+interface only — it never imports ``boto3`` or ``azure.storage.blob``.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterator
+
+META_SHA256 = "serena-sync-sha256"
+META_SIZE = "serena-sync-size"
+
+
+@dataclass(frozen=True)
+class RemoteObjectMeta:
+    """Provider-neutral description of a remote object."""
+    key: str
+    size: int
+    sha256: str | None = None
+    """Populated from x-*-meta-serena-sync-sha256 when present. None for legacy
+    objects; stream-hash fallback will fill it at diff time."""
+
+    etag: str | None = None
+    version_id: str | None = None
+    last_modified: datetime | None = None
+    metadata_present: bool = False
+    """True when our serena-sync metadata keys are present on the object."""
+
+    raw_metadata: dict[str, str] = field(default_factory=dict)
+
+
+class CloudStorageProvider(ABC):
+    """Abstract cloud storage provider.
+
+    Implementations translate between these primitives and their native SDK.
+    The sync layer calls only these methods.
+    """
+
+    # ---- capability flags -------------------------------------------------
+    supports_multipart: bool = False
+    supports_conditional_put: bool = True
+    supports_object_metadata: bool = True
+    supports_server_side_copy: bool = False
+
+    # ---- primitives -------------------------------------------------------
+    @abstractmethod
+    def list_objects(self, prefix: str) -> Iterator[RemoteObjectMeta]:
+        """Yield every object whose key starts with ``prefix``. Must be
+        eager-safe (no infinite pagination loops)."""
+
+    @abstractmethod
+    def head_object(self, key: str) -> RemoteObjectMeta | None:
+        """Return metadata for ``key``, or None if absent."""
+
+    @abstractmethod
+    def get_object(self, key: str) -> bytes:
+        """Return the object body. Small files only (MVP cap 5 MiB)."""
+
+    @abstractmethod
+    def iter_object(self, key: str, chunk_size: int = 1024 * 1024):
+        """Stream the object body in chunks (for byte-by-byte compare)."""
+
+    @abstractmethod
+    def put_object(
+        self,
+        key: str,
+        data: bytes,
+        sha256_hex: str,
+        content_type: str = "application/octet-stream",
+    ) -> None:
+        """Unconditional upload. Rarely used; ``put_object_if_absent`` is preferred."""
+
+    @abstractmethod
+    def put_object_if_absent(
+        self,
+        key: str,
+        data: bytes,
+        sha256_hex: str,
+        content_type: str = "application/octet-stream",
+    ) -> bool:
+        """Conditional upload: succeed only if no object exists at ``key``.
+
+        Return True if written, False if a prior object exists. On content
+        conflict (412 on a provider that returns Precondition Failed), raise
+        ``ProviderConflictError`` so the sync layer classifies it as CONFLICT.
+        """
+
+    @abstractmethod
+    def delete_object(self, key: str) -> None:
+        """Guarded. Only used by ``serena cloud-sync test`` to clean up its probe."""
+
+    # ---- convenience ------------------------------------------------------
+    def close(self) -> None:
+        """Release any provider-held resources (connection pools, etc)."""
+        return None

--- a/src/serena/cloud_sync/providers/__init__.py
+++ b/src/serena/cloud_sync/providers/__init__.py
@@ -1,0 +1,6 @@
+"""Concrete provider adapters for CloudStorageProvider.
+
+Business logic MUST NOT import from this package. Only
+``serena.cloud_sync.factory`` is allowed to pull in SDK-dependent concrete
+providers.
+"""

--- a/src/serena/cloud_sync/providers/azure.py
+++ b/src/serena/cloud_sync/providers/azure.py
@@ -1,0 +1,168 @@
+"""Azure Blob Storage provider.
+
+``azure-storage-blob`` is lazy-imported — users on R2/S3 don't pay the cost.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterator
+
+from serena.cloud_sync.exceptions import ProviderConflictError, ProviderError
+from serena.cloud_sync.provider import META_SHA256, META_SIZE, CloudStorageProvider, RemoteObjectMeta
+from serena.cloud_sync.settings import AzureSettings
+
+log = logging.getLogger(__name__)
+
+
+class AzureBlobProvider(CloudStorageProvider):
+    """Azure Blob Storage via azure-storage-blob."""
+
+    supports_multipart = True
+    supports_conditional_put = True
+    supports_object_metadata = True
+    supports_server_side_copy = True
+
+    def __init__(self, s: AzureSettings) -> None:
+        # Lazy import — keep Azure SDK out of the import graph when users
+        # are on R2/S3.
+        try:
+            from azure.storage.blob import BlobServiceClient
+        except ImportError as e:  # pragma: no cover - optional dep
+            raise ProviderError(
+                "azure-storage-blob not installed; install serena with the "
+                "`azure` extra (`uv pip install serena[azure]`)"
+            ) from e
+
+        self._container_name = s.container
+        account_url = f"https://{s.account_name}.blob.{s.endpoint_suffix}"
+        self._service = BlobServiceClient(account_url=account_url, credential=s.account_key)
+        self._container = self._service.get_container_client(s.container)
+
+    # ---- primitives -------------------------------------------------------
+
+    def list_objects(self, prefix: str) -> Iterator[RemoteObjectMeta]:
+        try:
+            for blob in self._container.list_blobs(name_starts_with=prefix, include=["metadata"]):
+                meta = dict(blob.metadata or {})
+                sha = meta.get(META_SHA256)
+                yield RemoteObjectMeta(
+                    key=blob.name,
+                    size=int(blob.size or 0),
+                    sha256=sha,
+                    etag=getattr(blob, "etag", None),
+                    version_id=getattr(blob, "version_id", None),
+                    last_modified=getattr(blob, "last_modified", None),
+                    metadata_present=sha is not None,
+                    raw_metadata=meta,
+                )
+        except Exception as e:  # azure.core.exceptions.HttpResponseError
+            raise _wrap(e, "list_blobs")
+
+    def head_object(self, key: str) -> RemoteObjectMeta | None:
+        try:
+            from azure.core.exceptions import ResourceNotFoundError
+        except ImportError:  # pragma: no cover
+            ResourceNotFoundError = Exception
+        try:
+            b = self._container.get_blob_client(key)
+            props = b.get_blob_properties()
+        except ResourceNotFoundError:
+            return None
+        except Exception as e:
+            raise _wrap(e, "get_blob_properties")
+        meta = dict(props.metadata or {})
+        sha = meta.get(META_SHA256)
+        return RemoteObjectMeta(
+            key=key,
+            size=int(props.size or 0),
+            sha256=sha,
+            etag=props.etag,
+            version_id=getattr(props, "version_id", None),
+            last_modified=props.last_modified,
+            metadata_present=sha is not None,
+            raw_metadata=meta,
+        )
+
+    def get_object(self, key: str) -> bytes:
+        try:
+            b = self._container.get_blob_client(key)
+            return b.download_blob().readall()
+        except Exception as e:
+            raise _wrap(e, "download_blob")
+
+    def iter_object(self, key: str, chunk_size: int = 1024 * 1024):
+        try:
+            b = self._container.get_blob_client(key)
+            stream = b.download_blob()
+        except Exception as e:
+            raise _wrap(e, "download_blob")
+        for chunk in stream.chunks():
+            yield chunk
+
+    def put_object(self, key: str, data: bytes, sha256_hex: str,
+                   content_type: str = "application/octet-stream") -> None:
+        try:
+            from azure.storage.blob import ContentSettings
+        except ImportError as e:  # pragma: no cover
+            raise ProviderError("azure-storage-blob not installed") from e
+        try:
+            b = self._container.get_blob_client(key)
+            b.upload_blob(
+                data,
+                overwrite=True,
+                content_settings=ContentSettings(content_type=content_type),
+                metadata={META_SHA256: sha256_hex, META_SIZE: str(len(data))},
+            )
+        except Exception as e:
+            raise _wrap(e, "upload_blob")
+
+    def put_object_if_absent(self, key: str, data: bytes, sha256_hex: str,
+                             content_type: str = "application/octet-stream") -> bool:
+        try:
+            from azure.core.exceptions import ResourceExistsError
+            from azure.storage.blob import ContentSettings
+        except ImportError as e:  # pragma: no cover
+            raise ProviderError("azure-storage-blob not installed") from e
+        try:
+            b = self._container.get_blob_client(key)
+            b.upload_blob(
+                data,
+                overwrite=False,  # Azure's native "if-absent"
+                content_settings=ContentSettings(content_type=content_type),
+                metadata={META_SHA256: sha256_hex, META_SIZE: str(len(data))},
+            )
+            return True
+        except ResourceExistsError as e:
+            existing = self.head_object(key)
+            if existing is not None and existing.sha256 == sha256_hex:
+                return False
+            raise ProviderConflictError(
+                f"blob {key!r} already exists with different content",
+                provider_code="BlobAlreadyExists",
+            ) from e
+        except Exception as e:
+            raise _wrap(e, "upload_blob")
+
+    def delete_object(self, key: str) -> None:
+        try:
+            self._container.get_blob_client(key).delete_blob()
+        except Exception as e:
+            raise _wrap(e, "delete_blob")
+
+    def close(self) -> None:
+        try:
+            self._service.close()
+        except Exception:
+            pass
+
+
+def _wrap(e: Exception, op: str) -> ProviderError:
+    status = getattr(e, "status_code", None) or getattr(e, "response", None)
+    retryable = False
+    try:
+        status_int = int(status) if isinstance(status, (int, str)) and str(status).isdigit() else None
+    except Exception:
+        status_int = None
+    if status_int is not None and 500 <= status_int < 600:
+        retryable = True
+    return ProviderError(f"Azure {op} failed: {e}", retryable=retryable, provider_code=str(status_int or ""))

--- a/src/serena/cloud_sync/providers/base_s3.py
+++ b/src/serena/cloud_sync/providers/base_s3.py
@@ -1,0 +1,194 @@
+"""Shared S3-compatible provider implementation (boto3).
+
+Used directly by AWS S3 and subclassed by R2 with an ``endpoint_url`` override.
+Can also be used for any S3-compatible backend (MinIO, Ceph RGW, SeaweedFS).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Iterator
+
+import boto3
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError
+
+from serena.cloud_sync.exceptions import ProviderConflictError, ProviderError
+from serena.cloud_sync.provider import META_SHA256, META_SIZE, CloudStorageProvider, RemoteObjectMeta
+
+log = logging.getLogger(__name__)
+
+
+class BaseS3Provider(CloudStorageProvider):
+    """S3-compatible provider via boto3.
+
+    Subclasses typically only override the constructor to set ``endpoint_url``
+    and region defaults (see ``r2.py``, ``s3.py``).
+    """
+
+    supports_multipart = True
+    supports_conditional_put = True
+    supports_object_metadata = True
+    supports_server_side_copy = True
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        access_key_id: str,
+        secret_access_key: str,
+        region: str = "us-east-1",
+        endpoint_url: str | None = None,
+        signature_version: str = "s3v4",
+    ) -> None:
+        self._bucket = bucket
+        cfg = BotoConfig(
+            signature_version=signature_version,
+            retries={"max_attempts": 5, "mode": "standard"},
+            s3={"addressing_style": "path"},
+        )
+        self._client = boto3.client(
+            "s3",
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            region_name=region,
+            endpoint_url=endpoint_url,
+            config=cfg,
+        )
+
+    # ---- primitives -------------------------------------------------------
+
+    def list_objects(self, prefix: str) -> Iterator[RemoteObjectMeta]:
+        paginator = self._client.get_paginator("list_objects_v2")
+        try:
+            for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
+                for obj in page.get("Contents", []):
+                    # HEAD is needed for metadata; defer it and do HEAD per-key when
+                    # diff needs sha256. This lets quick status queries be cheap.
+                    yield RemoteObjectMeta(
+                        key=obj["Key"],
+                        size=int(obj.get("Size", 0)),
+                        etag=(obj.get("ETag") or "").strip('"') or None,
+                        last_modified=obj.get("LastModified"),
+                        metadata_present=False,  # set after HEAD
+                    )
+        except ClientError as e:
+            raise _wrap(e, "list_objects_v2")
+
+    def head_object(self, key: str) -> RemoteObjectMeta | None:
+        try:
+            res = self._client.head_object(Bucket=self._bucket, Key=key)
+        except ClientError as e:
+            code = _err_code(e)
+            if code in ("404", "NoSuchKey", "NotFound"):
+                return None
+            raise _wrap(e, "head_object")
+        meta = res.get("Metadata") or {}
+        sha = meta.get(META_SHA256)
+        size = int(res.get("ContentLength") or 0)
+        return RemoteObjectMeta(
+            key=key,
+            size=size,
+            sha256=sha,
+            etag=(res.get("ETag") or "").strip('"') or None,
+            version_id=res.get("VersionId"),
+            last_modified=res.get("LastModified"),
+            metadata_present=sha is not None,
+            raw_metadata=meta,
+        )
+
+    def get_object(self, key: str) -> bytes:
+        try:
+            res = self._client.get_object(Bucket=self._bucket, Key=key)
+        except ClientError as e:
+            raise _wrap(e, "get_object")
+        return res["Body"].read()
+
+    def iter_object(self, key: str, chunk_size: int = 1024 * 1024):
+        try:
+            res = self._client.get_object(Bucket=self._bucket, Key=key)
+        except ClientError as e:
+            raise _wrap(e, "get_object")
+        body = res["Body"]
+        while True:
+            chunk = body.read(chunk_size)
+            if not chunk:
+                return
+            yield chunk
+
+    def put_object(self, key: str, data: bytes, sha256_hex: str,
+                   content_type: str = "application/octet-stream") -> None:
+        try:
+            self._client.put_object(
+                Bucket=self._bucket,
+                Key=key,
+                Body=data,
+                ContentType=content_type,
+                Metadata={META_SHA256: sha256_hex, META_SIZE: str(len(data))},
+            )
+        except ClientError as e:
+            raise _wrap(e, "put_object")
+
+    def put_object_if_absent(self, key: str, data: bytes, sha256_hex: str,
+                             content_type: str = "application/octet-stream") -> bool:
+        """Atomic conditional upload using ``If-None-Match: *``.
+
+        Most S3-compatible backends (incl. R2) honor this header on PutObject.
+        For backends that don't, the sync layer's fallback path is:
+            HEAD key -> if present return False; else unconditional PUT.
+        This fallback races, which is exactly why we prefer conditional put.
+        """
+        try:
+            self._client.put_object(
+                Bucket=self._bucket,
+                Key=key,
+                Body=data,
+                ContentType=content_type,
+                Metadata={META_SHA256: sha256_hex, META_SIZE: str(len(data))},
+                IfNoneMatch="*",
+            )
+            return True
+        except ClientError as e:
+            code = _err_code(e)
+            if code in ("412", "PreconditionFailed"):
+                # Key already exists. Classify by content: if sha256 on remote
+                # equals ours, it's a no-op (SKIP); otherwise CONFLICT.
+                existing = self.head_object(key)
+                if existing is not None and existing.sha256 == sha256_hex:
+                    return False
+                raise ProviderConflictError(
+                    f"object {key!r} already exists with different content",
+                    provider_code="412",
+                ) from e
+            # Some providers (older MinIO) don't support IfNoneMatch and
+            # return 501 / 400. Fall back to HEAD-then-PUT.
+            if code in ("NotImplemented", "501", "InvalidArgument", "400"):
+                log.warning(
+                    "provider does not support If-None-Match; falling back to HEAD-then-PUT (race window)"
+                )
+                if self.head_object(key) is not None:
+                    return False
+                self.put_object(key, data, sha256_hex, content_type)
+                return True
+            raise _wrap(e, "put_object_if_absent")
+
+    def delete_object(self, key: str) -> None:
+        try:
+            self._client.delete_object(Bucket=self._bucket, Key=key)
+        except ClientError as e:
+            raise _wrap(e, "delete_object")
+
+    def close(self) -> None:
+        # boto3 clients manage their own pool; nothing to close explicitly.
+        return None
+
+
+def _err_code(e: ClientError) -> str:
+    return str(e.response.get("Error", {}).get("Code", ""))
+
+
+def _wrap(e: ClientError, op: str) -> ProviderError:
+    code = _err_code(e)
+    # Retryable on 5xx and throttling codes
+    retryable = code in {"500", "502", "503", "504", "SlowDown", "RequestTimeout"}
+    return ProviderError(f"S3 {op} failed: {code}", retryable=retryable, provider_code=code)

--- a/src/serena/cloud_sync/providers/r2.py
+++ b/src/serena/cloud_sync/providers/r2.py
@@ -1,0 +1,22 @@
+"""Cloudflare R2 provider.
+
+R2 is S3-compatible via an ``endpoint_url`` override; R2 uses region ``auto``
+and rejects some AWS-specific signing extensions.
+"""
+from __future__ import annotations
+
+from serena.cloud_sync.providers.base_s3 import BaseS3Provider
+from serena.cloud_sync.settings import R2Settings
+
+
+class R2Provider(BaseS3Provider):
+    """Cloudflare R2 via boto3."""
+
+    def __init__(self, s: R2Settings) -> None:
+        super().__init__(
+            bucket=s.bucket,
+            access_key_id=s.access_key_id,
+            secret_access_key=s.secret_access_key,
+            region="auto",
+            endpoint_url=s.resolved_endpoint(),
+        )

--- a/src/serena/cloud_sync/providers/s3.py
+++ b/src/serena/cloud_sync/providers/s3.py
@@ -1,0 +1,22 @@
+"""Amazon S3 (and S3-compatible) provider.
+
+The ``endpoint_url`` field is optional; when set, it enables MinIO / Ceph RGW /
+SeaweedFS / LocalStack targets using the same protocol surface.
+"""
+from __future__ import annotations
+
+from serena.cloud_sync.providers.base_s3 import BaseS3Provider
+from serena.cloud_sync.settings import S3Settings
+
+
+class S3Provider(BaseS3Provider):
+    """Amazon S3 (or any S3-compatible backend)."""
+
+    def __init__(self, s: S3Settings) -> None:
+        super().__init__(
+            bucket=s.bucket,
+            access_key_id=s.access_key_id,
+            secret_access_key=s.secret_access_key,
+            region=s.region,
+            endpoint_url=s.resolved_endpoint(),
+        )

--- a/src/serena/cloud_sync/scope.py
+++ b/src/serena/cloud_sync/scope.py
@@ -1,0 +1,134 @@
+"""Scope filters — what gets synced, what's hard-excluded.
+
+Inclusion is composable via settings; exclusion is a hard rule enforced
+regardless of configuration (credential files, oversize binaries, symlinks).
+The scope layer is the safety net that prevents accidentally uploading
+``.env`` or ``id_rsa`` no matter how the user configures paths.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator
+
+import pathspec
+
+from serena.cloud_sync.exceptions import ScopeError
+from serena.cloud_sync.settings import MAX_OBJECT_SIZE_BYTES
+
+HARD_EXCLUDE_PATTERNS: tuple[str, ...] = (
+    "**/logs/**",
+    "**/cache/**",
+    "**/ls-cache/**",
+    "**/*.env",
+    "**/*.env.*",
+    "**/*.secret",
+    "**/*.secret.*",
+    "**/*.key",
+    "**/*.pem",
+    "**/id_rsa",
+    "**/id_rsa.pub",
+    "**/*:Zone.Identifier",
+)
+
+
+@dataclass(frozen=True)
+class ScopeRoot:
+    """A root directory to scan, with a remote-key prefix under the sync root.
+
+    ``remote_subprefix`` is joined after ``root_prefix`` from settings. For
+    example, a global root produces keys ``serena-sync/global/<relpath>``.
+    """
+    local_root: Path
+    remote_subprefix: str
+    opt_in_local_yml: bool = False
+    """If False, project.local.yml is hard-excluded from this root."""
+
+
+@dataclass
+class ScopeFilter:
+    include_patterns: tuple[str, ...]
+    opt_in_project_local_yml: bool = False
+
+    _hard_exclude: pathspec.PathSpec = field(init=False)
+    _include: pathspec.PathSpec = field(init=False)
+
+    def __post_init__(self) -> None:
+        hard = list(HARD_EXCLUDE_PATTERNS)
+        if not self.opt_in_project_local_yml:
+            hard.append("**/project.local.yml")
+        self._hard_exclude = pathspec.PathSpec.from_lines(
+            pathspec.patterns.GitWildMatchPattern, hard
+        )
+        self._include = pathspec.PathSpec.from_lines(
+            pathspec.patterns.GitWildMatchPattern, list(self.include_patterns)
+        )
+
+    def is_hard_excluded(self, rel_posix: str) -> bool:
+        return self._hard_exclude.match_file(rel_posix)
+
+    def is_included(self, rel_posix: str) -> bool:
+        return self._include.match_file(rel_posix) and not self._hard_exclude.match_file(rel_posix)
+
+    def iter_files(self, roots: Iterable[ScopeRoot]) -> Iterator[tuple[ScopeRoot, Path, str]]:
+        """Yield (root, absolute_path, posix_relpath) for every file that passes
+        all scope rules (include + hard-exclude + size cap + symlink reject).
+        """
+        for root in roots:
+            if not root.local_root.exists():
+                continue
+            for p in _walk_files(root.local_root):
+                rel = p.relative_to(root.local_root).as_posix()
+                if not self.is_included(rel):
+                    continue
+                try:
+                    st = p.lstat()
+                except OSError:
+                    continue
+                if _is_symlink(st):
+                    continue
+                if st.st_size > MAX_OBJECT_SIZE_BYTES:
+                    continue
+                yield root, p, rel
+
+
+def _walk_files(root: Path) -> Iterator[Path]:
+    """os.walk wrapper that tolerates a permission error on any subdir."""
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False, onerror=lambda _e: None):
+        base = Path(dirpath)
+        for fn in filenames:
+            yield base / fn
+
+
+def _is_symlink(st: os.stat_result) -> bool:
+    from stat import S_ISLNK
+    return S_ISLNK(st.st_mode)
+
+
+def enforce_no_credential_files(rel_posix: str) -> None:
+    """Defensive check used at upload time. Raises ScopeError if the path is
+    a credential file pattern even if include rules would have permitted it."""
+    # Normalize a bare relpath into a pseudo-path pathspec can match
+    probe = pathspec.PathSpec.from_lines(
+        pathspec.patterns.GitWildMatchPattern, list(HARD_EXCLUDE_PATTERNS)
+    )
+    if probe.match_file(rel_posix):
+        raise ScopeError(f"refusing to sync credential-family path: {rel_posix}")
+
+
+DEFAULT_GLOBAL_INCLUDES: tuple[str, ...] = (
+    "serena_config.yml",
+    "contexts/**/*.yml",
+    "contexts/**/*.yaml",
+    "modes/**/*.yml",
+    "modes/**/*.yaml",
+    "memories/**/*",
+)
+
+DEFAULT_PROJECT_INCLUDES: tuple[str, ...] = (
+    "project.yml",
+    "project.local.yml",  # filtered out unless opt-in flag flips it on
+    "memories/**/*.md",
+    "memories/**/*.json",
+)

--- a/src/serena/cloud_sync/settings.py
+++ b/src/serena/cloud_sync/settings.py
@@ -1,0 +1,133 @@
+"""Typed settings for cloud-sync providers.
+
+Values are loaded from the credentials env file by ``credentials.load_env_settings``.
+Pydantic is used for validation + masked JSON output.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ProviderType(str, Enum):
+    R2 = "r2"
+    S3 = "s3"
+    AZURE = "azure"
+
+
+DEFAULT_ROOT_PREFIX = "serena-sync/"
+MAX_OBJECT_SIZE_BYTES = 5 * 1024 * 1024
+"""Hard per-object cap. Memory/config files are tiny; anything larger is almost
+certainly out of scope for sync."""
+
+
+class R2Settings(BaseModel):
+    account_id: str = Field(..., min_length=1)
+    access_key_id: str = Field(..., min_length=1)
+    secret_access_key: str = Field(..., min_length=1)
+    bucket: str = Field(..., min_length=1)
+    endpoint_url: str | None = Field(
+        default=None,
+        description="Defaults to https://<account_id>.r2.cloudflarestorage.com when omitted.",
+    )
+
+    def resolved_endpoint(self) -> str:
+        if self.endpoint_url:
+            return self.endpoint_url.rstrip("/")
+        return f"https://{self.account_id}.r2.cloudflarestorage.com"
+
+
+class S3Settings(BaseModel):
+    access_key_id: str = Field(..., min_length=1)
+    secret_access_key: str = Field(..., min_length=1)
+    bucket: str = Field(..., min_length=1)
+    region: str = Field(default="us-east-1")
+    endpoint_url: str | None = Field(
+        default=None,
+        description=(
+            "Optional override for S3-compatible backends (MinIO, Ceph RGW, "
+            "SeaweedFS). Leave empty for AWS S3."
+        ),
+    )
+
+    def resolved_endpoint(self) -> str | None:
+        if not self.endpoint_url:
+            return None
+        return self.endpoint_url.rstrip("/")
+
+
+class AzureSettings(BaseModel):
+    account_name: str = Field(..., min_length=1)
+    account_key: str = Field(..., min_length=1)
+    container: str = Field(..., min_length=1)
+    endpoint_suffix: str = Field(default="core.windows.net")
+
+
+class CloudSyncSettings(BaseModel):
+    provider: ProviderType
+    root_prefix: str = Field(default=DEFAULT_ROOT_PREFIX)
+    r2: R2Settings | None = None
+    s3: S3Settings | None = None
+    azure: AzureSettings | None = None
+
+    @field_validator("root_prefix")
+    @classmethod
+    def _normalize_prefix(cls, v: str) -> str:
+        # Always POSIX-style, trailing slash exactly once.
+        v = v.strip().replace("\\", "/").lstrip("/")
+        if not v:
+            v = DEFAULT_ROOT_PREFIX
+        if not v.endswith("/"):
+            v += "/"
+        return v
+
+    def active_provider_settings(self) -> R2Settings | S3Settings | AzureSettings:
+        if self.provider is ProviderType.R2:
+            if self.r2 is None:
+                raise ValueError("provider=r2 but [r2] settings missing")
+            return self.r2
+        if self.provider is ProviderType.S3:
+            if self.s3 is None:
+                raise ValueError("provider=s3 but [s3] settings missing")
+            return self.s3
+        if self.provider is ProviderType.AZURE:
+            if self.azure is None:
+                raise ValueError("provider=azure but [azure] settings missing")
+            return self.azure
+        raise AssertionError(f"unknown provider: {self.provider!r}")
+
+    def masked(self) -> dict:
+        """Masked dict for dashboard responses. Secret values become ``****<last4>``."""
+        def mask(v: str | None) -> str:
+            if not v:
+                return ""
+            if len(v) <= 4:
+                return "****"
+            return "****" + v[-4:]
+
+        d: dict = {"provider": self.provider.value, "root_prefix": self.root_prefix}
+        if self.r2:
+            d["r2"] = {
+                "account_id": self.r2.account_id,
+                "access_key_id": mask(self.r2.access_key_id),
+                "secret_access_key": mask(self.r2.secret_access_key),
+                "bucket": self.r2.bucket,
+                "endpoint_url": self.r2.endpoint_url,
+            }
+        if self.s3:
+            d["s3"] = {
+                "access_key_id": mask(self.s3.access_key_id),
+                "secret_access_key": mask(self.s3.secret_access_key),
+                "bucket": self.s3.bucket,
+                "region": self.s3.region,
+                "endpoint_url": self.s3.endpoint_url,
+            }
+        if self.azure:
+            d["azure"] = {
+                "account_name": self.azure.account_name,
+                "account_key": mask(self.azure.account_key),
+                "container": self.azure.container,
+                "endpoint_suffix": self.azure.endpoint_suffix,
+            }
+        return d

--- a/src/serena/cloud_sync/sync.py
+++ b/src/serena/cloud_sync/sync.py
@@ -1,0 +1,307 @@
+"""CloudSyncService — the orchestrator.
+
+Receives the provider via constructor injection (DIP). Contains only business
+logic; never imports ``boto3`` or ``azure.storage.blob``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from serena.cloud_sync.diff import DiffEntry, DiffPlan, SyncAction, classify
+from serena.cloud_sync.exceptions import ProviderConflictError
+from serena.cloud_sync.hash_util import byte_compare_file_to_stream
+from serena.cloud_sync.inventory import (
+    LocalInventory,
+    RemoteInventory,
+    build_local_inventory,
+    build_remote_inventory,
+)
+from serena.cloud_sync.provider import CloudStorageProvider
+from serena.cloud_sync.scope import ScopeFilter, ScopeRoot, enforce_no_credential_files
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class SyncPlan:
+    """Dry-run result. Used by both CLI and dashboard as the "confirm" surface."""
+    counts: dict[str, int]
+    entries: list[dict]
+
+    @classmethod
+    def from_diff(cls, diff: DiffPlan) -> "SyncPlan":
+        return cls(
+            counts=diff.counts(),
+            entries=[
+                {
+                    "key": e.key,
+                    "action": e.action.value,
+                    "local_size": e.local.size if e.local else None,
+                    "remote_size": e.remote.size if e.remote else None,
+                    "reason": e.reason,
+                }
+                for e in diff.entries
+            ],
+        )
+
+
+@dataclass
+class SyncReport:
+    """Post-execution outcome."""
+    mode: str  # "push" | "pull"
+    started_at: str
+    finished_at: str | None = None
+    uploaded: list[str] = field(default_factory=list)
+    downloaded: list[str] = field(default_factory=list)
+    conflicts: list[dict] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    failed: list[dict] = field(default_factory=list)
+    dry_run: bool = False
+    plan: SyncPlan | None = None
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        if self.plan is not None:
+            d["plan"] = {"counts": self.plan.counts, "entries": self.plan.entries}
+        return d
+
+
+class CloudSyncService:
+    """Push / pull orchestrator. The provider is injected via the constructor."""
+
+    def __init__(
+        self,
+        provider: CloudStorageProvider,
+        scope: ScopeFilter,
+        roots: Iterable[ScopeRoot],
+        root_prefix: str,
+        progress_path: Path | None = None,
+    ) -> None:
+        self._provider = provider
+        self._scope = scope
+        self._roots = list(roots)
+        self._root_prefix = root_prefix.rstrip("/") + "/"
+        self._progress_path = progress_path
+
+    # ---- plan building ----------------------------------------------------
+
+    def build_plan(self, *, hash_fallback: bool = True) -> tuple[LocalInventory, RemoteInventory, DiffPlan]:
+        local = build_local_inventory(self._scope, self._roots, self._root_prefix)
+        remote = build_remote_inventory(
+            self._provider, self._root_prefix, hash_fallback=hash_fallback,
+        )
+        diff = classify(local, remote)
+        return local, remote, diff
+
+    # ---- push -------------------------------------------------------------
+
+    def push(self, *, dry_run: bool = False, force: bool = False,
+             byte_compare: bool = False) -> SyncReport:
+        local, remote, diff = self.build_plan()
+        report = SyncReport(
+            mode="push",
+            started_at=_iso_utc(),
+            dry_run=dry_run,
+            plan=SyncPlan.from_diff(diff),
+        )
+        if dry_run:
+            report.finished_at = _iso_utc()
+            return report
+
+        for entry in diff.entries:
+            try:
+                if entry.action is SyncAction.UPLOAD:
+                    self._do_upload(entry, report)
+                elif entry.action is SyncAction.SKIP:
+                    if byte_compare:
+                        self._do_byte_compare(entry, report)
+                    else:
+                        report.skipped.append(entry.key)
+                elif entry.action is SyncAction.CONFLICT:
+                    if force:
+                        self._do_force_upload(entry, report)
+                    else:
+                        report.conflicts.append(self._conflict_record(entry, resolution="kept-remote"))
+                # DOWNLOAD entries are no-ops on push.
+            except Exception as exc:  # pragma: no cover - logged + recorded
+                log.error("push failed for %s: %s", entry.key, exc, exc_info=exc)
+                report.failed.append({"key": entry.key, "error": str(exc)})
+            self._write_progress(report)
+
+        report.finished_at = _iso_utc()
+        self._write_progress(report)
+        return report
+
+    def _do_upload(self, entry: DiffEntry, report: SyncReport) -> None:
+        assert entry.local is not None
+        enforce_no_credential_files(entry.local.abs_path.name)
+        with open(entry.local.abs_path, "rb") as fh:
+            data = fh.read()
+        try:
+            written = self._provider.put_object_if_absent(
+                entry.key, data, entry.local.sha256
+            )
+            if written:
+                report.uploaded.append(entry.key)
+            else:
+                report.skipped.append(entry.key)
+        except ProviderConflictError:
+            report.conflicts.append(self._conflict_record(entry, resolution="kept-remote"))
+
+    def _do_force_upload(self, entry: DiffEntry, report: SyncReport) -> None:
+        assert entry.local is not None
+        enforce_no_credential_files(entry.local.abs_path.name)
+        with open(entry.local.abs_path, "rb") as fh:
+            data = fh.read()
+        self._provider.put_object(entry.key, data, entry.local.sha256)
+        report.uploaded.append(entry.key)
+
+    # ---- pull -------------------------------------------------------------
+
+    def pull(self, *, dry_run: bool = False, force: bool = False,
+             byte_compare: bool = False) -> SyncReport:
+        local, remote, diff = self.build_plan()
+        report = SyncReport(
+            mode="pull",
+            started_at=_iso_utc(),
+            dry_run=dry_run,
+            plan=SyncPlan.from_diff(diff),
+        )
+        if dry_run:
+            report.finished_at = _iso_utc()
+            return report
+
+        for entry in diff.entries:
+            try:
+                if entry.action is SyncAction.DOWNLOAD:
+                    self._do_download(entry, report)
+                elif entry.action is SyncAction.SKIP:
+                    if byte_compare:
+                        self._do_byte_compare(entry, report)
+                    else:
+                        report.skipped.append(entry.key)
+                elif entry.action is SyncAction.CONFLICT:
+                    if force:
+                        self._do_force_download(entry, report, overwrite=True)
+                    else:
+                        self._do_conflict_sibling(entry, report)
+                # UPLOAD entries are no-ops on pull.
+            except Exception as exc:  # pragma: no cover
+                log.error("pull failed for %s: %s", entry.key, exc, exc_info=exc)
+                report.failed.append({"key": entry.key, "error": str(exc)})
+            self._write_progress(report)
+
+        report.finished_at = _iso_utc()
+        self._write_progress(report)
+        return report
+
+    def _do_download(self, entry: DiffEntry, report: SyncReport) -> None:
+        assert entry.remote is not None
+        # Resolve target path: find matching scope root, strip the key prefix
+        target = self._key_to_local_path(entry.key)
+        if target is None:
+            report.failed.append({"key": entry.key, "error": "no matching scope root"})
+            return
+        target.parent.mkdir(parents=True, exist_ok=True)
+        data = self._provider.get_object(entry.key)
+        _atomic_write(target, data)
+        report.downloaded.append(entry.key)
+
+    def _do_force_download(self, entry: DiffEntry, report: SyncReport, *, overwrite: bool) -> None:
+        assert entry.remote is not None
+        target = self._key_to_local_path(entry.key)
+        if target is None:
+            report.failed.append({"key": entry.key, "error": "no matching scope root"})
+            return
+        target.parent.mkdir(parents=True, exist_ok=True)
+        data = self._provider.get_object(entry.key)
+        _atomic_write(target, data)
+        report.downloaded.append(entry.key)
+
+    def _do_conflict_sibling(self, entry: DiffEntry, report: SyncReport) -> None:
+        assert entry.remote is not None
+        target = self._key_to_local_path(entry.key)
+        if target is None:
+            report.failed.append({"key": entry.key, "error": "no matching scope root"})
+            return
+        target.parent.mkdir(parents=True, exist_ok=True)
+        data = self._provider.get_object(entry.key)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        sibling = target.with_name(target.name + f".cloud-{ts}")
+        _atomic_write(sibling, data)
+        report.conflicts.append(self._conflict_record(entry, resolution=f"remote-saved-as:{sibling.name}"))
+
+    def _do_byte_compare(self, entry: DiffEntry, report: SyncReport) -> None:
+        if entry.local is None or entry.remote is None:
+            report.skipped.append(entry.key)
+            return
+        chunks = self._provider.iter_object(entry.key)
+        if byte_compare_file_to_stream(entry.local.abs_path, chunks):
+            report.skipped.append(entry.key)
+        else:
+            # Diverged despite sha256 match: record as conflict without action.
+            report.conflicts.append(self._conflict_record(entry, resolution="byte-compare-mismatch"))
+
+    # ---- helpers ----------------------------------------------------------
+
+    def _key_to_local_path(self, key: str) -> Path | None:
+        """Reverse the _compose_key mapping to find the correct local path."""
+        for root in self._roots:
+            rp = self._root_prefix
+            sub = root.remote_subprefix.strip("/")
+            prefix = rp + (sub + "/" if sub else "")
+            if key.startswith(prefix):
+                rel = key[len(prefix):]
+                return root.local_root / rel
+        return None
+
+    def _conflict_record(self, entry: DiffEntry, *, resolution: str) -> dict:
+        return {
+            "key": entry.key,
+            "resolution": resolution,
+            "local_sha256": entry.local.sha256 if entry.local else None,
+            "remote_sha256": entry.remote.sha256 if entry.remote else None,
+            "reason": entry.reason,
+        }
+
+    def _write_progress(self, report: SyncReport) -> None:
+        if self._progress_path is None:
+            return
+        try:
+            self._progress_path.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write(self._progress_path, json.dumps(report.to_dict(), indent=2).encode("utf-8"))
+        except Exception as exc:
+            log.debug("progress write failed: %s", exc)
+
+
+def _iso_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    """Atomic write: tmp + fsync + rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmpname = tempfile.mkstemp(
+        prefix=path.name + ".cloud-sync.tmp.",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmpname, path)
+    except Exception:
+        try:
+            os.unlink(tmpname)
+        except OSError:
+            pass
+        raise

--- a/src/serena/dashboard.py
+++ b/src/serena/dashboard.py
@@ -150,6 +150,14 @@ class SerenaDashboardAPI:
         self._loaded_news: dict[str, str] = {}
         self._news_ready = threading.Event()
         self._setup_routes()
+        # Register the cloud-sync API blueprint (EXPERIMENTAL). Import is deferred
+        # so that boto3 and azure-storage-blob are pulled in lazily only when a
+        # user actually opens the Cloud Sync panel or calls the CLI.
+        try:
+            from serena.cloud_sync.dashboard_routes import bp as _cloud_sync_bp
+            self._app.register_blueprint(_cloud_sync_bp)
+        except Exception as _exc:  # pragma: no cover - defensive
+            log.warning("cloud_sync blueprint not registered: %s", _exc)
         # Fetch remote news in background on startup (non-blocking)
         threading.Thread(target=self._fetch_news, daemon=True).start()
 

--- a/src/serena/resources/dashboard/cloud-sync.css
+++ b/src/serena/resources/dashboard/cloud-sync.css
@@ -1,0 +1,151 @@
+.experimental-badge {
+    display: inline-block;
+    font-size: 10px;
+    padding: 2px 6px;
+    background: var(--log-warning, #FF8C00);
+    color: #fff;
+    border-radius: 3px;
+    vertical-align: middle;
+    margin-left: 8px;
+}
+
+.cs-main {
+    max-width: 800px;
+    margin: 20px auto;
+    padding: 0 20px;
+}
+
+.cs-card {
+    background: var(--bg-secondary, #fff);
+    border: 1px solid var(--border-color, #ddd);
+    border-radius: var(--border-radius, 5px);
+    padding: 16px 20px;
+    margin-bottom: 16px;
+    box-shadow: var(--shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
+}
+
+.cs-card h2 {
+    margin: 0 0 12px;
+    font-size: 16px;
+    color: var(--text-primary, #000);
+}
+
+.cs-card label {
+    display: block;
+    margin-bottom: 10px;
+    font-size: 13px;
+    color: var(--text-secondary, #333);
+}
+
+.cs-card label small {
+    color: var(--text-muted, #666);
+    font-weight: normal;
+    margin-left: 4px;
+}
+
+.cs-card input[type="text"],
+.cs-card input[type="password"],
+.cs-card select {
+    display: block;
+    width: 100%;
+    padding: 6px 8px;
+    margin-top: 4px;
+    border: 1px solid var(--border-color, #ddd);
+    border-radius: 3px;
+    font-size: 13px;
+    background: var(--bg-primary, #f5f5f5);
+    color: var(--text-primary, #000);
+    box-sizing: border-box;
+}
+
+.cs-inline {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.cs-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-top: 12px;
+}
+
+.cs-actions button {
+    padding: 6px 12px;
+    border: 1px solid var(--border-color, #ddd);
+    background: var(--bg-primary, #f5f5f5);
+    color: var(--text-primary, #000);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.cs-actions button:hover {
+    background: var(--btn-hover, #dca662);
+    color: #fff;
+}
+
+.cs-actions button.primary {
+    background: var(--btn-primary, #eaa45d);
+    color: #fff;
+    border-color: var(--btn-primary, #eaa45d);
+}
+
+.cs-actions button:disabled {
+    background: var(--btn-disabled, #6c757d);
+    color: #ccc;
+    cursor: not-allowed;
+}
+
+.cs-env-path {
+    font-size: 11px;
+    color: var(--text-muted, #666);
+    font-family: monospace;
+}
+
+.cs-hint {
+    font-size: 12px;
+    color: var(--text-muted, #666);
+    margin: 8px 0 0;
+}
+
+#cs-status-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+#cs-status-cards .card {
+    background: var(--bg-primary, #f5f5f5);
+    border: 1px solid var(--border-color, #ddd);
+    padding: 10px;
+    border-radius: 4px;
+    text-align: center;
+}
+
+#cs-status-cards .card .label {
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--text-muted, #666);
+}
+
+#cs-status-cards .card .value {
+    font-size: 22px;
+    font-weight: bold;
+    color: var(--text-primary, #000);
+}
+
+#cs-plan-output {
+    max-height: 350px;
+    overflow: auto;
+    background: var(--bg-primary, #f5f5f5);
+    border: 1px solid var(--border-color, #ddd);
+    padding: 10px;
+    font-size: 11px;
+    font-family: monospace;
+    white-space: pre-wrap;
+}

--- a/src/serena/resources/dashboard/cloud-sync.html
+++ b/src/serena/resources/dashboard/cloud-sync.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Serena Cloud Sync</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="serena-icon-32.png">
+    <link rel="stylesheet" href="dashboard.css">
+    <link rel="stylesheet" href="cloud-sync.css">
+    <script src="jquery.min.js"></script>
+</head>
+<body>
+<div id="frame">
+    <header class="header">
+        <div class="header-left">
+            <div class="logo-container">
+                <img class="theme-aware-img" src="serena-logo.svg" alt="Serena">
+            </div>
+            <h1>Cloud Sync <span class="experimental-badge">EXPERIMENTAL</span></h1>
+        </div>
+        <nav class="header-nav">
+            <a href="/dashboard/">&larr; Dashboard</a>
+        </nav>
+    </header>
+
+    <main class="cs-main">
+        <section class="cs-card">
+            <h2>Provider</h2>
+            <label>Active provider
+                <select id="cs-provider">
+                    <option value="r2">Cloudflare R2</option>
+                    <option value="s3">Amazon S3 (or S3-compatible)</option>
+                    <option value="azure">Azure Blob Storage</option>
+                </select>
+            </label>
+            <label>Root prefix
+                <input id="cs-root-prefix" type="text" placeholder="serena-sync/">
+            </label>
+        </section>
+
+        <section class="cs-card cs-provider-r2">
+            <h2>R2 credentials</h2>
+            <label>Account ID <input id="cs-r2-account" type="text" autocomplete="off"></label>
+            <label>Access key ID <input id="cs-r2-akid" type="text" autocomplete="off"></label>
+            <label>Secret access key <input id="cs-r2-secret" type="password" autocomplete="off"></label>
+            <label>Bucket <input id="cs-r2-bucket" type="text" autocomplete="off"></label>
+            <label>Endpoint URL <small>(optional — derived from account ID if blank)</small>
+                <input id="cs-r2-endpoint" type="text" autocomplete="off">
+            </label>
+        </section>
+
+        <section class="cs-card cs-provider-s3" hidden>
+            <h2>S3 credentials</h2>
+            <label>Access key ID <input id="cs-s3-akid" type="text" autocomplete="off"></label>
+            <label>Secret access key <input id="cs-s3-secret" type="password" autocomplete="off"></label>
+            <label>Bucket <input id="cs-s3-bucket" type="text" autocomplete="off"></label>
+            <label>Region <input id="cs-s3-region" type="text" value="us-east-1" autocomplete="off"></label>
+            <label>Endpoint URL <small>(optional — for MinIO / Ceph / SeaweedFS)</small>
+                <input id="cs-s3-endpoint" type="text" autocomplete="off">
+            </label>
+        </section>
+
+        <section class="cs-card cs-provider-azure" hidden>
+            <h2>Azure credentials</h2>
+            <label>Storage account <input id="cs-az-account" type="text" autocomplete="off"></label>
+            <label>Account key <input id="cs-az-key" type="password" autocomplete="off"></label>
+            <label>Container <input id="cs-az-container" type="text" autocomplete="off"></label>
+            <label>Endpoint suffix <input id="cs-az-suffix" type="text" value="core.windows.net" autocomplete="off"></label>
+        </section>
+
+        <section class="cs-actions">
+            <button id="cs-save">Save</button>
+            <button id="cs-test">Test connection</button>
+            <span class="cs-env-path" id="cs-env-path"></span>
+        </section>
+
+        <section class="cs-card">
+            <h2>Sync</h2>
+            <label class="cs-inline">
+                <input type="checkbox" id="cs-include-local-yml">
+                Include <code>project.local.yml</code>
+                <small>may contain machine-specific values</small>
+            </label>
+            <label class="cs-inline">
+                <input type="checkbox" id="cs-byte-compare">
+                Paranoid byte-by-byte compare
+            </label>
+            <div class="cs-actions">
+                <button id="cs-plan-push">Dry-run Push</button>
+                <button id="cs-plan-pull">Dry-run Pull</button>
+                <button id="cs-push" class="primary">Push</button>
+                <button id="cs-pull" class="primary">Pull</button>
+            </div>
+            <p class="cs-hint">
+                Dry-run shows what would change. <b>Push</b> and <b>Pull</b> run
+                the plan; divergent files are preserved, never overwritten.
+            </p>
+        </section>
+
+        <section class="cs-card">
+            <h2>Status</h2>
+            <div id="cs-status-cards"></div>
+            <pre id="cs-plan-output"></pre>
+        </section>
+    </main>
+</div>
+
+<script src="cloud-sync.js"></script>
+</body>
+</html>

--- a/src/serena/resources/dashboard/cloud-sync.js
+++ b/src/serena/resources/dashboard/cloud-sync.js
@@ -1,0 +1,220 @@
+/*
+ * Serena Cloud Sync dashboard panel.
+ *
+ * Contract with the server (see serena/cloud_sync/dashboard_routes.py):
+ *   GET  /api/cloud-sync/config   -> masked settings ({ ****abcd })
+ *   POST /api/cloud-sync/config   -> accepts partial updates; "****" means unchanged
+ *   POST /api/cloud-sync/test     -> round-trip probe
+ *   GET  /api/cloud-sync/status   -> inventory counts + plan counts
+ *   POST /api/cloud-sync/push     -> dry_run defaults to true (dry-run-first UX)
+ *   POST /api/cloud-sync/pull     -> same
+ */
+
+"use strict";
+
+(function () {
+    const $ = window.jQuery;
+
+    // Per-process token for defense-in-depth against other local processes.
+    // Fetched once on load and attached to every mutating request.
+    let CLOUD_SYNC_TOKEN = null;
+
+    function withToken(settings) {
+        settings = settings || {};
+        settings.headers = Object.assign({}, settings.headers, {
+            "X-Cloud-Sync-Token": CLOUD_SYNC_TOKEN || "",
+        });
+        return settings;
+    }
+
+    // Patch $.ajax so every cloud-sync call carries the token.
+    const originalAjax = $.ajax;
+    $.ajax = function (urlOrSettings, settings) {
+        if (typeof urlOrSettings === "string") {
+            settings = settings || {};
+            settings.url = urlOrSettings;
+        } else {
+            settings = urlOrSettings || {};
+        }
+        if ((settings.url || "").indexOf("/api/cloud-sync/") === 0 &&
+            (settings.url || "").indexOf("/api/cloud-sync/bootstrap-token") !== 0) {
+            settings = withToken(settings);
+        }
+        return originalAjax.call(this, settings);
+    };
+
+    function fetchToken() {
+        return originalAjax({
+            url: "/api/cloud-sync/bootstrap-token",
+            method: "GET",
+        }).done(function (d) {
+            CLOUD_SYNC_TOKEN = d && d.token;
+        });
+    }
+
+    const secretFields = new Set([
+        "R2_SECRET_ACCESS_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "AZURE_STORAGE_ACCOUNT_KEY",
+    ]);
+
+    function showProvider(provider) {
+        $(".cs-provider-r2, .cs-provider-s3, .cs-provider-azure").attr("hidden", true);
+        $(`.cs-provider-${provider}`).removeAttr("hidden");
+    }
+
+    function loadConfig() {
+        return $.get("/api/cloud-sync/config").done(function (d) {
+            if (d.env_path) $("#cs-env-path").text(d.env_path + " (chmod 600)");
+            if (!d.configured) {
+                showProvider($("#cs-provider").val() || "r2");
+                return;
+            }
+            const s = d.settings || {};
+            $("#cs-provider").val(s.provider || "r2");
+            $("#cs-root-prefix").val(s.root_prefix || "serena-sync/");
+            if (s.r2) {
+                $("#cs-r2-account").val(s.r2.account_id || "");
+                $("#cs-r2-akid").val(s.r2.access_key_id || "");
+                $("#cs-r2-secret").val(s.r2.secret_access_key || "");
+                $("#cs-r2-bucket").val(s.r2.bucket || "");
+                $("#cs-r2-endpoint").val(s.r2.endpoint_url || "");
+            }
+            if (s.s3) {
+                $("#cs-s3-akid").val(s.s3.access_key_id || "");
+                $("#cs-s3-secret").val(s.s3.secret_access_key || "");
+                $("#cs-s3-bucket").val(s.s3.bucket || "");
+                $("#cs-s3-region").val(s.s3.region || "us-east-1");
+                $("#cs-s3-endpoint").val(s.s3.endpoint_url || "");
+            }
+            if (s.azure) {
+                $("#cs-az-account").val(s.azure.account_name || "");
+                $("#cs-az-key").val(s.azure.account_key || "");
+                $("#cs-az-container").val(s.azure.container || "");
+                $("#cs-az-suffix").val(s.azure.endpoint_suffix || "core.windows.net");
+            }
+            showProvider(s.provider || "r2");
+        });
+    }
+
+    function collectPayload() {
+        const payload = {
+            CLOUD_SYNC_PROVIDER: $("#cs-provider").val(),
+            CLOUD_SYNC_ROOT_PREFIX: $("#cs-root-prefix").val() || "serena-sync/",
+        };
+        function addField(key, val) {
+            if (val === undefined || val === null) return;
+            payload[key] = val;
+        }
+        addField("R2_ACCOUNT_ID", $("#cs-r2-account").val());
+        addField("R2_ACCESS_KEY_ID", $("#cs-r2-akid").val());
+        addField("R2_SECRET_ACCESS_KEY", $("#cs-r2-secret").val());
+        addField("R2_BUCKET", $("#cs-r2-bucket").val());
+        addField("R2_ENDPOINT_URL", $("#cs-r2-endpoint").val());
+        addField("AWS_ACCESS_KEY_ID", $("#cs-s3-akid").val());
+        addField("AWS_SECRET_ACCESS_KEY", $("#cs-s3-secret").val());
+        addField("AWS_BUCKET", $("#cs-s3-bucket").val());
+        addField("AWS_REGION", $("#cs-s3-region").val());
+        addField("AWS_ENDPOINT_URL", $("#cs-s3-endpoint").val());
+        addField("AZURE_STORAGE_ACCOUNT", $("#cs-az-account").val());
+        addField("AZURE_STORAGE_ACCOUNT_KEY", $("#cs-az-key").val());
+        addField("AZURE_CONTAINER", $("#cs-az-container").val());
+        addField("AZURE_ENDPOINT_SUFFIX", $("#cs-az-suffix").val());
+        return payload;
+    }
+
+    function doSave() {
+        const payload = collectPayload();
+        return $.ajax({
+            url: "/api/cloud-sync/config",
+            method: "POST",
+            contentType: "application/json",
+            data: JSON.stringify(payload),
+        });
+    }
+
+    function renderStatus(data) {
+        const c = data.plan_counts || {};
+        const html = ["upload", "download", "skip", "conflict"].map(function (k) {
+            return `<div class="card">
+                <div class="label">${k}</div>
+                <div class="value">${c[k] || 0}</div>
+            </div>`;
+        }).join("") + `
+            <div class="card">
+                <div class="label">local</div>
+                <div class="value">${data.local_count ?? 0}</div>
+            </div>
+            <div class="card">
+                <div class="label">remote</div>
+                <div class="value">${data.remote_count ?? 0}</div>
+            </div>`;
+        $("#cs-status-cards").html(html);
+    }
+
+    function refreshStatus() {
+        const params = {};
+        if ($("#cs-include-local-yml").is(":checked")) {
+            params["include_project_local_yml"] = "1";
+        }
+        return $.get("/api/cloud-sync/status", params).done(renderStatus);
+    }
+
+    function doRun(mode, dryRun) {
+        const body = {
+            dry_run: !!dryRun,
+            byte_compare: $("#cs-byte-compare").is(":checked"),
+            include_project_local_yml: $("#cs-include-local-yml").is(":checked"),
+        };
+        $("#cs-plan-output").text(`Running ${mode}${dryRun ? " (dry-run)" : ""}...`);
+        return $.ajax({
+            url: "/api/cloud-sync/" + mode,
+            method: "POST",
+            contentType: "application/json",
+            data: JSON.stringify(body),
+        }).done(function (d) {
+            $("#cs-plan-output").text(JSON.stringify(d, null, 2));
+            refreshStatus();
+        }).fail(function (xhr) {
+            $("#cs-plan-output").text("ERROR " + xhr.status + "\n" + (xhr.responseText || ""));
+        });
+    }
+
+    $(function () {
+        $("#cs-provider").on("change", function () {
+            showProvider($(this).val());
+        });
+
+        $("#cs-save").on("click", function () {
+            doSave().done(function () {
+                $("#cs-plan-output").text("Saved. Reloading config...");
+                loadConfig();
+            }).fail(function (xhr) {
+                $("#cs-plan-output").text("Save failed: " + xhr.status + " " + xhr.responseText);
+            });
+        });
+
+        $("#cs-test").on("click", function () {
+            $("#cs-plan-output").text("Testing connection...");
+            $.post("/api/cloud-sync/test").done(function (d) {
+                $("#cs-plan-output").text("Test " + (d.ok ? "OK" : "FAILED") + "\n" + JSON.stringify(d, null, 2));
+            }).fail(function (xhr) {
+                $("#cs-plan-output").text("Test error: " + xhr.status + "\n" + xhr.responseText);
+            });
+        });
+
+        $("#cs-plan-push").on("click", function () { doRun("push", true); });
+        $("#cs-plan-pull").on("click", function () { doRun("pull", true); });
+        $("#cs-push").on("click", function () {
+            if (confirm("Push now? Divergent remote files are preserved (never overwritten).")) doRun("push", false);
+        });
+        $("#cs-pull").on("click", function () {
+            if (confirm("Pull now? Divergent local files are preserved as .cloud-<ts> siblings.")) doRun("pull", false);
+        });
+        $("#cs-include-local-yml").on("change", refreshStatus);
+
+        fetchToken().always(function () {
+            loadConfig().always(refreshStatus);
+        });
+    });
+})();

--- a/test/cloud_sync/fakes.py
+++ b/test/cloud_sync/fakes.py
@@ -1,0 +1,108 @@
+"""In-memory CloudStorageProvider used for every unit test in this package."""
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+from typing import Iterator
+
+from serena.cloud_sync.exceptions import ProviderConflictError
+from serena.cloud_sync.provider import META_SHA256, META_SIZE, CloudStorageProvider, RemoteObjectMeta
+
+
+class FakeCloudProvider(CloudStorageProvider):
+    """Thread-safe in-memory store that mimics S3-ish semantics."""
+
+    supports_multipart = False
+    supports_conditional_put = True
+    supports_object_metadata = True
+    supports_server_side_copy = False
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._store: dict[str, tuple[bytes, dict[str, str], datetime]] = {}
+        self.last_content_type: dict[str, str] = {}
+
+    # ---- primitives -------------------------------------------------------
+
+    def list_objects(self, prefix: str) -> Iterator[RemoteObjectMeta]:
+        with self._lock:
+            items = [(k, v) for k, v in self._store.items() if k.startswith(prefix)]
+        for k, (body, meta, ts) in items:
+            sha = meta.get(META_SHA256)
+            yield RemoteObjectMeta(
+                key=k,
+                size=len(body),
+                sha256=sha,
+                etag=f"\"{sha[:16]}\"" if sha else None,
+                last_modified=ts,
+                metadata_present=sha is not None,
+                raw_metadata=dict(meta),
+            )
+
+    def head_object(self, key: str) -> RemoteObjectMeta | None:
+        with self._lock:
+            entry = self._store.get(key)
+        if entry is None:
+            return None
+        body, meta, ts = entry
+        sha = meta.get(META_SHA256)
+        return RemoteObjectMeta(
+            key=key,
+            size=len(body),
+            sha256=sha,
+            etag=f"\"{sha[:16]}\"" if sha else None,
+            last_modified=ts,
+            metadata_present=sha is not None,
+            raw_metadata=dict(meta),
+        )
+
+    def get_object(self, key: str) -> bytes:
+        with self._lock:
+            entry = self._store.get(key)
+        if entry is None:
+            raise KeyError(key)
+        return entry[0]
+
+    def iter_object(self, key: str, chunk_size: int = 1024 * 1024):
+        body = self.get_object(key)
+        for i in range(0, len(body), chunk_size):
+            yield body[i: i + chunk_size]
+
+    def put_object(self, key: str, data: bytes, sha256_hex: str,
+                   content_type: str = "application/octet-stream") -> None:
+        with self._lock:
+            self._store[key] = (bytes(data), {META_SHA256: sha256_hex, META_SIZE: str(len(data))},
+                                datetime.now(timezone.utc))
+            self.last_content_type[key] = content_type
+
+    def put_object_if_absent(self, key: str, data: bytes, sha256_hex: str,
+                             content_type: str = "application/octet-stream") -> bool:
+        with self._lock:
+            if key in self._store:
+                existing = self._store[key][1].get(META_SHA256)
+                if existing == sha256_hex:
+                    return False
+                raise ProviderConflictError(f"{key} already exists with different content",
+                                            provider_code="412")
+            self._store[key] = (bytes(data), {META_SHA256: sha256_hex, META_SIZE: str(len(data))},
+                                datetime.now(timezone.utc))
+            self.last_content_type[key] = content_type
+        return True
+
+    def delete_object(self, key: str) -> None:
+        with self._lock:
+            self._store.pop(key, None)
+
+    # ---- test-only helpers ------------------------------------------------
+
+    def seed(self, key: str, body: bytes, sha: str | None = None) -> None:
+        if sha is None:
+            import hashlib
+            sha = hashlib.sha256(body).hexdigest()
+        self.put_object(key, body, sha)
+
+    def raw(self, key: str) -> bytes:
+        return self._store[key][0]
+
+    def keys(self) -> list[str]:
+        return sorted(self._store.keys())

--- a/test/cloud_sync/integration/test_azure_provider.py
+++ b/test/cloud_sync/integration/test_azure_provider.py
@@ -1,0 +1,65 @@
+"""Azurite-backed round-trip for the Azure provider.
+
+Skipped unless ``AZURITE_CONNECTION_STRING`` is set. The default Azurite
+development connection string is:
+    DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=...
+but this test only consumes account/key/endpoint-suffix separately.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from serena.cloud_sync.exceptions import ProviderConflictError
+from serena.cloud_sync.settings import AzureSettings
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("AZURITE_ACCOUNT"),
+    reason="set AZURITE_ACCOUNT/AZURITE_KEY/AZURITE_ENDPOINT_SUFFIX to run",
+)
+
+
+@pytest.fixture
+def azure_provider():
+    try:
+        from serena.cloud_sync.providers.azure import AzureBlobProvider
+    except ImportError:  # pragma: no cover
+        pytest.skip("azure-storage-blob not installed")
+    settings = AzureSettings(
+        account_name=os.environ["AZURITE_ACCOUNT"],
+        account_key=os.environ["AZURITE_KEY"],
+        container=os.environ.get("AZURITE_CONTAINER", "serena-sync-test"),
+        endpoint_suffix=os.environ.get("AZURITE_ENDPOINT_SUFFIX", "core.windows.net"),
+    )
+    provider = AzureBlobProvider(settings)
+    # Ensure container exists
+    try:
+        provider._service.create_container(settings.container)
+    except Exception:
+        pass
+    yield provider
+    provider.close()
+
+
+def test_roundtrip(azure_provider) -> None:
+    key = "serena-test/azure-rt.md"
+    body = b"hello azure" * 10
+    import hashlib
+    sha = hashlib.sha256(body).hexdigest()
+    assert azure_provider.put_object_if_absent(key, body, sha) is True
+    assert azure_provider.put_object_if_absent(key, body, sha) is False
+    assert azure_provider.get_object(key) == body
+    meta = azure_provider.head_object(key)
+    assert meta is not None
+    assert meta.sha256 == sha
+    azure_provider.delete_object(key)
+
+
+def test_conflict(azure_provider) -> None:
+    key = "serena-test/azure-conflict.md"
+    import hashlib
+    azure_provider.put_object_if_absent(key, b"A", hashlib.sha256(b"A").hexdigest())
+    with pytest.raises(ProviderConflictError):
+        azure_provider.put_object_if_absent(key, b"B", hashlib.sha256(b"B").hexdigest())
+    azure_provider.delete_object(key)

--- a/test/cloud_sync/integration/test_s3_provider.py
+++ b/test/cloud_sync/integration/test_s3_provider.py
@@ -1,0 +1,65 @@
+"""LocalStack-backed round-trip for the S3 / R2 providers.
+
+Skipped unless ``LOCALSTACK_ENDPOINT`` is set in the environment. Works against
+any S3-compatible backend exposed at that endpoint (tested with LocalStack and
+MinIO).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from serena.cloud_sync.exceptions import ProviderConflictError
+from serena.cloud_sync.settings import S3Settings
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("LOCALSTACK_ENDPOINT"),
+    reason="set LOCALSTACK_ENDPOINT=http://localhost:4566 (or your MinIO URL) to run",
+)
+
+
+@pytest.fixture
+def s3_provider():
+    from serena.cloud_sync.providers.s3 import S3Provider
+    settings = S3Settings(
+        access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "test"),
+        secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "test"),
+        bucket=os.environ.get("S3_BUCKET", "serena-cloud-sync-test"),
+        region=os.environ.get("AWS_REGION", "us-east-1"),
+        endpoint_url=os.environ["LOCALSTACK_ENDPOINT"],
+    )
+    provider = S3Provider(settings)
+    # Ensure bucket exists (LocalStack allows creation without auth fanfare)
+    try:
+        provider._client.create_bucket(Bucket=settings.bucket)
+    except Exception:
+        pass
+    yield provider
+    provider.close()
+
+
+def test_roundtrip(s3_provider) -> None:
+    key = "serena-test/roundtrip.md"
+    body = b"hello serena" * 10
+    import hashlib
+    sha = hashlib.sha256(body).hexdigest()
+
+    assert s3_provider.put_object_if_absent(key, body, sha) is True
+    # Idempotent: same content returns False
+    assert s3_provider.put_object_if_absent(key, body, sha) is False
+    assert s3_provider.get_object(key) == body
+    meta = s3_provider.head_object(key)
+    assert meta is not None
+    assert meta.sha256 == sha
+    s3_provider.delete_object(key)
+    assert s3_provider.head_object(key) is None
+
+
+def test_conflict(s3_provider) -> None:
+    key = "serena-test/conflict.md"
+    import hashlib
+    s3_provider.put_object_if_absent(key, b"A", hashlib.sha256(b"A").hexdigest())
+    with pytest.raises(ProviderConflictError):
+        s3_provider.put_object_if_absent(key, b"B", hashlib.sha256(b"B").hexdigest())
+    s3_provider.delete_object(key)

--- a/test/cloud_sync/test_credentials.py
+++ b/test/cloud_sync/test_credentials.py
@@ -1,0 +1,71 @@
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from serena.cloud_sync import credentials as creds
+from serena.cloud_sync.exceptions import CredentialError
+
+
+@pytest.fixture
+def tmp_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the module-level env_path to a tmp location."""
+    env_path = tmp_path / "cloud-sync.env"
+    monkeypatch.setattr(creds, "ENV_PATH", env_path)
+    monkeypatch.setattr(creds, "ENV_BACKUP_PATH", env_path.parent / (env_path.name + ".bak"))
+    monkeypatch.setattr(creds, "SERENA_HOME", tmp_path)
+    return env_path
+
+
+def test_save_and_reload_r2(tmp_env: Path) -> None:
+    creds.save_env({
+        creds.K_PROVIDER: "r2",
+        creds.K_R2_ACCOUNT_ID: "abc123",
+        creds.K_R2_ACCESS_KEY_ID: "AKID",
+        creds.K_R2_SECRET_ACCESS_KEY: "s3cr3t",
+        creds.K_R2_BUCKET: "my-bucket",
+    }, path=tmp_env)
+    s = creds.load_settings(path=tmp_env)
+    assert s.provider.value == "r2"
+    assert s.r2 is not None
+    assert s.r2.secret_access_key == "s3cr3t"
+    # File must be 0600 on POSIX
+    if os.name == "posix":
+        mode = stat.S_IMODE(tmp_env.stat().st_mode)
+        assert mode == 0o600
+
+
+def test_perms_warning_raises(tmp_env: Path) -> None:
+    creds.save_env({
+        creds.K_PROVIDER: "r2",
+        creds.K_R2_ACCOUNT_ID: "x", creds.K_R2_ACCESS_KEY_ID: "x",
+        creds.K_R2_SECRET_ACCESS_KEY: "x", creds.K_R2_BUCKET: "x",
+    }, path=tmp_env)
+    if os.name == "posix":
+        os.chmod(tmp_env, 0o644)
+        with pytest.raises(CredentialError):
+            creds.check_perms(tmp_env)
+
+
+def test_mask_sentinel_preserves_existing_secret(tmp_env: Path) -> None:
+    creds.save_env({
+        creds.K_PROVIDER: "r2",
+        creds.K_R2_ACCOUNT_ID: "x", creds.K_R2_ACCESS_KEY_ID: "AKID",
+        creds.K_R2_SECRET_ACCESS_KEY: "REAL-SECRET",
+        creds.K_R2_BUCKET: "x",
+    }, path=tmp_env)
+    # Second save: secret passed as '****' must not overwrite
+    creds.save_env({
+        creds.K_R2_SECRET_ACCESS_KEY: "****",
+        creds.K_R2_BUCKET: "new-bucket",
+    }, path=tmp_env)
+    s = creds.load_settings(path=tmp_env)
+    assert s.r2 is not None
+    assert s.r2.secret_access_key == "REAL-SECRET"
+    assert s.r2.bucket == "new-bucket"
+
+
+def test_missing_file_raises(tmp_env: Path) -> None:
+    with pytest.raises(CredentialError):
+        creds.load_settings(path=tmp_env)

--- a/test/cloud_sync/test_diff.py
+++ b/test/cloud_sync/test_diff.py
@@ -1,0 +1,66 @@
+import hashlib
+from pathlib import Path
+
+from serena.cloud_sync.diff import SyncAction, classify
+from serena.cloud_sync.inventory import LocalInventory, LocalObjectMeta, RemoteInventory
+from serena.cloud_sync.provider import RemoteObjectMeta
+
+
+def _sha(body: bytes) -> str:
+    return hashlib.sha256(body).hexdigest()
+
+
+def _local(key: str, path: Path, body: bytes) -> LocalObjectMeta:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(body)
+    return LocalObjectMeta(
+        remote_key=key, abs_path=path, size=len(body), sha256=_sha(body), scope_origin="global",
+    )
+
+
+def _remote(key: str, body: bytes) -> RemoteObjectMeta:
+    sha = _sha(body)
+    return RemoteObjectMeta(key=key, size=len(body), sha256=sha, metadata_present=True)
+
+
+def test_upload_download_skip(tmp_path: Path) -> None:
+    local = LocalInventory()
+    remote = RemoteInventory()
+
+    local.entries["a"] = _local("a", tmp_path / "a", b"only-local")
+    remote.entries["b"] = _remote("b", b"only-remote")
+    local.entries["c"] = _local("c", tmp_path / "c", b"same")
+    remote.entries["c"] = _remote("c", b"same")
+
+    plan = classify(local, remote)
+    actions = {e.key: e.action for e in plan.entries}
+    assert actions["a"] is SyncAction.UPLOAD
+    assert actions["b"] is SyncAction.DOWNLOAD
+    assert actions["c"] is SyncAction.SKIP
+    assert plan.counts()["upload"] == 1
+    assert plan.counts()["download"] == 1
+    assert plan.counts()["skip"] == 1
+
+
+def test_conflict(tmp_path: Path) -> None:
+    local = LocalInventory()
+    remote = RemoteInventory()
+    local.entries["k"] = _local("k", tmp_path / "k", b"LOCAL")
+    remote.entries["k"] = _remote("k", b"REMOTE-DIFFERENT")
+
+    plan = classify(local, remote)
+    e = plan.entries[0]
+    assert e.action is SyncAction.CONFLICT
+    assert "sha256 mismatch" in e.reason
+
+
+def test_remote_without_metadata_is_conflict(tmp_path: Path) -> None:
+    """Defensive: if an older / alien object lacks our sha256 metadata and the
+    hash_fallback pass didn't run, classify must not silently choose a side."""
+    local = LocalInventory()
+    remote = RemoteInventory()
+    local.entries["k"] = _local("k", tmp_path / "k", b"LOCAL")
+    remote.entries["k"] = RemoteObjectMeta(key="k", size=5, sha256=None, metadata_present=False)
+    plan = classify(local, remote)
+    assert plan.entries[0].action is SyncAction.CONFLICT
+    assert "missing sha256" in plan.entries[0].reason

--- a/test/cloud_sync/test_hash_util.py
+++ b/test/cloud_sync/test_hash_util.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from serena.cloud_sync.hash_util import (
+    byte_compare_file_to_stream,
+    sha256_bytes,
+    sha256_file,
+    sha256_stream,
+)
+
+
+def test_sha256_bytes_matches_file(tmp_path: Path) -> None:
+    p = tmp_path / "x.txt"
+    body = b"hello serena " * 1024
+    p.write_bytes(body)
+    assert sha256_bytes(body) == sha256_file(p) == sha256_stream([body])
+
+
+def test_byte_compare_identical(tmp_path: Path) -> None:
+    p = tmp_path / "x.bin"
+    body = b"a" * (1024 * 1024 + 7)
+    p.write_bytes(body)
+    # one-chunk stream
+    assert byte_compare_file_to_stream(p, [body])
+    # multi-chunk stream
+    mid = len(body) // 2
+    assert byte_compare_file_to_stream(p, [body[:mid], body[mid:]])
+
+
+def test_byte_compare_divergent(tmp_path: Path) -> None:
+    p = tmp_path / "x.bin"
+    p.write_bytes(b"abcdef")
+    assert not byte_compare_file_to_stream(p, [b"abcdff"])
+    assert not byte_compare_file_to_stream(p, [b"abc"])
+    assert not byte_compare_file_to_stream(p, [b"abcdefg"])

--- a/test/cloud_sync/test_provider_contract.py
+++ b/test/cloud_sync/test_provider_contract.py
@@ -1,0 +1,51 @@
+"""Provider-contract assertions that don't require a real backend.
+
+Guards two lazy-loading / structural invariants:
+ 1. Importing ``serena.cloud_sync`` does NOT import boto3 or azure SDKs.
+ 2. Azure provider module uploads with ContentSettings inline on the upload
+    call (not via a follow-up ``set_http_headers``), matching the plan.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_importing_cloud_sync_does_not_load_sdks() -> None:
+    # Fresh import
+    for m in list(sys.modules):
+        if m.startswith(("boto3", "botocore", "azure")):
+            sys.modules.pop(m, None)
+    for m in list(sys.modules):
+        if m.startswith("serena.cloud_sync"):
+            sys.modules.pop(m, None)
+    importlib.import_module("serena.cloud_sync")
+    # boto3 + azure are NOT in sys.modules until a provider is built
+    # boto3 may be pulled by factory.build_provider, but plain import should not.
+    loaded = [m for m in sys.modules if m.startswith(("boto3", "botocore", "azure"))]
+    assert not loaded, f"cloud_sync import eagerly loaded SDKs: {loaded}"
+
+
+def test_azure_provider_uses_content_settings_inline() -> None:
+    """Lexical check: Azure provider calls upload_blob with content_settings=
+    in the same call (not a follow-up set_http_headers). This keeps metadata
+    and body atomic from the backend's perspective."""
+    from pathlib import Path
+    src = Path(__file__).resolve().parents[2] / "src/serena/cloud_sync/providers/azure.py"
+    body = src.read_text()
+    assert "upload_blob" in body
+    assert "content_settings=ContentSettings" in body
+    assert "set_http_headers" not in body, (
+        "Azure adapter should set content-type in upload_blob(content_settings=...) "
+        "not via a follow-up set_http_headers call"
+    )
+
+
+def test_content_type_propagates_to_provider() -> None:
+    """Ensure CloudStorageProvider's content_type param is forwarded by put_object."""
+    from .fakes import FakeCloudProvider
+    p = FakeCloudProvider()
+    p.put_object("k", b"data", "sha", content_type="text/markdown")
+    assert p.last_content_type["k"] == "text/markdown"
+    p.put_object_if_absent("k2", b"data2", "sha2", content_type="application/yaml")
+    assert p.last_content_type["k2"] == "application/yaml"

--- a/test/cloud_sync/test_scope.py
+++ b/test/cloud_sync/test_scope.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from serena.cloud_sync.scope import (
+    DEFAULT_GLOBAL_INCLUDES,
+    DEFAULT_PROJECT_INCLUDES,
+    ScopeFilter,
+    ScopeRoot,
+)
+
+
+def _make_scope(opt_in_local_yml: bool = False) -> ScopeFilter:
+    return ScopeFilter(
+        include_patterns=tuple(list(DEFAULT_GLOBAL_INCLUDES) + list(DEFAULT_PROJECT_INCLUDES)),
+        opt_in_project_local_yml=opt_in_local_yml,
+    )
+
+
+def test_hard_excludes_are_not_overridable(tmp_path: Path) -> None:
+    s = _make_scope()
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / "serena.log").write_text("x")
+    (tmp_path / "config.env").write_text("SECRET=1")
+    (tmp_path / "id_rsa").write_text("-----BEGIN RSA-----")
+    (tmp_path / "memories").mkdir()
+    (tmp_path / "memories" / "ok.md").write_text("m")
+    (tmp_path / "serena_config.yml").write_text("x")
+
+    root = ScopeRoot(local_root=tmp_path, remote_subprefix="global")
+    collected = [rel for _, _, rel in s.iter_files([root])]
+    assert "memories/ok.md" in collected
+    assert "serena_config.yml" in collected
+    assert not any("logs/" in p for p in collected)
+    assert "config.env" not in collected
+    assert "id_rsa" not in collected
+
+
+def test_project_local_yml_opt_in(tmp_path: Path) -> None:
+    (tmp_path / "project.yml").write_text("y")
+    (tmp_path / "project.local.yml").write_text("y")
+    root = ScopeRoot(local_root=tmp_path, remote_subprefix="projects/x")
+
+    s_off = _make_scope(opt_in_local_yml=False)
+    collected = {rel for _, _, rel in s_off.iter_files([root])}
+    assert "project.yml" in collected
+    assert "project.local.yml" not in collected
+
+    s_on = _make_scope(opt_in_local_yml=True)
+    collected = {rel for _, _, rel in s_on.iter_files([root])}
+    assert "project.local.yml" in collected
+
+
+def test_size_cap(tmp_path: Path) -> None:
+    s = _make_scope()
+    root = ScopeRoot(local_root=tmp_path, remote_subprefix="global")
+    (tmp_path / "memories").mkdir()
+    # Under cap
+    (tmp_path / "memories" / "small.md").write_bytes(b"a" * 100)
+    # Over cap (6 MiB)
+    big = tmp_path / "memories" / "big.md"
+    big.write_bytes(b"b" * (6 * 1024 * 1024))
+    collected = {rel for _, _, rel in s.iter_files([root])}
+    assert "memories/small.md" in collected
+    assert "memories/big.md" not in collected

--- a/test/cloud_sync/test_sync.py
+++ b/test/cloud_sync/test_sync.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+
+import pytest
+
+from serena.cloud_sync.diff import SyncAction
+from serena.cloud_sync.scope import ScopeFilter, ScopeRoot
+from serena.cloud_sync.sync import CloudSyncService
+
+from .fakes import FakeCloudProvider
+
+
+ROOT_PREFIX = "serena-sync/"
+
+
+def _make_service(tmp_path: Path, provider: FakeCloudProvider,
+                  opt_in_local_yml: bool = False) -> tuple[CloudSyncService, ScopeRoot]:
+    root = ScopeRoot(local_root=tmp_path, remote_subprefix="global")
+    scope = ScopeFilter(
+        include_patterns=("memories/**/*.md", "serena_config.yml"),
+        opt_in_project_local_yml=opt_in_local_yml,
+    )
+    return CloudSyncService(
+        provider=provider,
+        scope=scope,
+        roots=[root],
+        root_prefix=ROOT_PREFIX,
+    ), root
+
+
+def _write(path: Path, body: str = "hi") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def test_push_uploads_local_only(tmp_path: Path) -> None:
+    provider = FakeCloudProvider()
+    _write(tmp_path / "serena_config.yml", "a: 1")
+    _write(tmp_path / "memories" / "one.md", "m1")
+    _write(tmp_path / "memories" / "two.md", "m2")
+
+    service, _ = _make_service(tmp_path, provider)
+    report = service.push(dry_run=False)
+    assert sorted(report.uploaded) == [
+        "serena-sync/global/memories/one.md",
+        "serena-sync/global/memories/two.md",
+        "serena-sync/global/serena_config.yml",
+    ]
+    assert not report.conflicts
+    assert not report.failed
+
+
+def test_pull_downloads_remote_only(tmp_path: Path) -> None:
+    provider = FakeCloudProvider()
+    provider.seed("serena-sync/global/memories/x.md", b"remote body")
+
+    service, _ = _make_service(tmp_path, provider)
+    report = service.pull(dry_run=False)
+    assert "serena-sync/global/memories/x.md" in report.downloaded
+    assert (tmp_path / "memories" / "x.md").read_bytes() == b"remote body"
+
+
+def test_conflict_push_preserves_remote(tmp_path: Path) -> None:
+    provider = FakeCloudProvider()
+    key = "serena-sync/global/memories/x.md"
+    provider.seed(key, b"REMOTE")
+    _write(tmp_path / "memories" / "x.md", "LOCAL")
+
+    service, _ = _make_service(tmp_path, provider)
+    report = service.push(dry_run=False)
+    # remote unchanged
+    assert provider.raw(key) == b"REMOTE"
+    assert len(report.conflicts) == 1
+    assert report.conflicts[0]["resolution"] == "kept-remote"
+
+
+def test_conflict_pull_saves_sibling(tmp_path: Path) -> None:
+    provider = FakeCloudProvider()
+    key = "serena-sync/global/memories/x.md"
+    provider.seed(key, b"REMOTE")
+    target = tmp_path / "memories" / "x.md"
+    _write(target, "LOCAL")
+
+    service, _ = _make_service(tmp_path, provider)
+    report = service.pull(dry_run=False)
+    # local untouched
+    assert target.read_text() == "LOCAL"
+    # sibling created with .cloud-<ts> suffix containing remote body
+    siblings = list((tmp_path / "memories").glob("x.md.cloud-*"))
+    assert len(siblings) == 1
+    assert siblings[0].read_bytes() == b"REMOTE"
+    assert report.conflicts[0]["resolution"].startswith("remote-saved-as:")
+
+
+def test_force_push_overwrites_conflict(tmp_path: Path) -> None:
+    provider = FakeCloudProvider()
+    key = "serena-sync/global/memories/x.md"
+    provider.seed(key, b"REMOTE")
+    _write(tmp_path / "memories" / "x.md", "LOCAL-NEW")
+
+    service, _ = _make_service(tmp_path, provider)
+    report = service.push(dry_run=False, force=True)
+    assert provider.raw(key) == b"LOCAL-NEW"
+    assert key in report.uploaded
+
+
+def test_dry_run_no_mutation(tmp_path: Path) -> None:
+    provider = FakeCloudProvider()
+    _write(tmp_path / "memories" / "x.md", "LOCAL")
+    service, _ = _make_service(tmp_path, provider)
+    report = service.push(dry_run=True)
+    assert report.dry_run
+    assert report.plan is not None
+    assert not report.uploaded
+    assert not provider.keys()  # remote still empty
+
+
+def test_idempotent_push(tmp_path: Path) -> None:
+    provider = FakeCloudProvider()
+    _write(tmp_path / "memories" / "x.md", "HELLO")
+    service, _ = _make_service(tmp_path, provider)
+    r1 = service.push(dry_run=False)
+    r2 = service.push(dry_run=False)
+    assert len(r1.uploaded) == 1
+    assert len(r2.uploaded) == 0
+    assert len(r2.skipped) == 1
+
+
+def test_no_boto3_in_business_logic() -> None:
+    """Guard: business logic modules must not import boto3 / azure SDKs."""
+    import importlib
+    mods = [
+        "serena.cloud_sync.sync",
+        "serena.cloud_sync.diff",
+        "serena.cloud_sync.inventory",
+        "serena.cloud_sync.scope",
+        "serena.cloud_sync.hash_util",
+        "serena.cloud_sync.credentials",
+        "serena.cloud_sync.provider",
+    ]
+    for name in mods:
+        m = importlib.import_module(name)
+        src = getattr(m, "__dict__")
+        banned = {"boto3", "botocore", "azure"}
+        for k in banned:
+            assert k not in src, f"{name} must not import {k}"

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,34 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/83/bbde3faa84ddcb8eb0eca4b3ffb3221252281db4ce351300fe248c5c70b1/azure_core-1.39.0.tar.gz", hash = "sha256:8a90a562998dd44ce84597590fff6249701b98c0e8797c95fcdd695b54c35d74", size = 367531, upload-time = "2026-03-19T01:31:29.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d6/8ebcd05b01a580f086ac9a97fb9fac65c09a4b012161cc97c21a336e880b/azure_core-1.39.0-py3-none-any.whl", hash = "sha256:4ac7b70fab5438c3f68770649a78daf97833caa83827f91df9c14e0e0ea7d34f", size = 218318, upload-time = "2026-03-19T01:31:31.25Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/95/3e3414491ce45025a1cde107b6ae72bf72049e6021597c201cd6a3029b9a/azure_storage_blob-12.26.0.tar.gz", hash = "sha256:5dd7d7824224f7de00bfeb032753601c982655173061e242f13be6e26d78d71f", size = 583332, upload-time = "2025-07-16T21:34:07.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/64/63dbfdd83b31200ac58820a7951ddfdeed1fbee9285b0f3eae12d1357155/azure_storage_blob-12.26.0-py3-none-any.whl", hash = "sha256:8c5631b8b22b4f53ec5fff2f3bededf34cfef111e2af613ad42c9e6de00a77fe", size = 412907, upload-time = "2025-07-16T21:34:09.367Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -214,6 +242,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.40.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/89/36c09108d8d35e6f722cdc9ff169f003c7458657ecf04c3a375dca973ccb/boto3-1.40.54.tar.gz", hash = "sha256:5f7dbf8539d26e0ee973baea49d0db8c1ee57707a785c5a23307241fdba04327", size = 111594, upload-time = "2025-10-16T19:26:43.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ac/41be779a035210b9223560316e1e5bd994f786424acc96383d0ba5fb8613/boto3-1.40.54-py3-none-any.whl", hash = "sha256:81d32d4f09ecddc2c48aa3d0acfd5dbd2d2e3e2718c353a56cb3af59b2e22148", size = 139321, upload-time = "2025-10-16T19:26:41.495Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.40.76"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/eb/50e2d280589a3c20c3b649bb66262d2b53a25c03262e4cc492048ac7540a/botocore-1.40.76.tar.gz", hash = "sha256:2b16024d68b29b973005adfb5039adfe9099ebe772d40a90ca89f2e165c495dc", size = 14494001, upload-time = "2025-11-18T20:22:59.131Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/6c/522e05388aa6fc66cf8ea46c6b29809a1a6f527ea864998b01ffb368ca36/botocore-1.40.76-py3-none-any.whl", hash = "sha256:fe425d386e48ac64c81cbb4a7181688d813df2e2b4c78b95ebe833c9e868c6f4", size = 14161738, upload-time = "2025-11-18T20:22:55.332Z" },
 ]
 
 [[package]]
@@ -775,6 +831,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -783,6 +840,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -791,6 +849,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -799,6 +858,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -807,6 +867,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -1035,6 +1096,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1150,6 +1220,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2938,6 +3017,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+]
+
+[[package]]
 name = "sensai-utils"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2955,7 +3046,9 @@ version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "azure-storage-blob" },
     { name = "beautifulsoup4" },
+    { name = "boto3" },
     { name = "cryptography" },
     { name = "docstring-parser" },
     { name = "dotenv" },
@@ -3028,7 +3121,9 @@ google = [
 requires-dist = [
     { name = "agno", marker = "extra == 'agno'", specifier = "==2.5.10" },
     { name = "anthropic", specifier = "==0.59.0" },
+    { name = "azure-storage-blob", specifier = "==12.26.0" },
     { name = "beautifulsoup4", specifier = "==4.14.2" },
+    { name = "boto3", specifier = "==1.40.54" },
     { name = "cryptography", specifier = "==46.0.7" },
     { name = "docstring-parser", specifier = "==0.17.0" },
     { name = "dotenv", specifier = "==0.9.9" },


### PR DESCRIPTION
Refs #1328. Supersedes #1329 (closed — same branch renamed).

Adds an **experimental, opt-in** `cloud-sync` feature so Serena's memories and configuration can be mirrored to a user-provided cloud bucket across machines. Additive union — no silent overwrites.

## What it does
- CLI group `serena cloud-sync {configure, test, status, push, pull, fix-perms}`.
- Dashboard panel at `/dashboard/cloud-sync.html` with credential form, dry-run plan preview, and push/pull actions.
- Providers: **Cloudflare R2** and **Amazon S3** via `boto3` (the `endpoint_url` override also enables MinIO / Ceph RGW / SeaweedFS), and **Azure Blob** via `azure-storage-blob` (lazy-imported so R2/S3 users never load it).

## How it's shaped
- `CloudStorageProvider` ABC is the only seam; `CloudSyncService` receives the provider via constructor. A guard test (`test_no_boto3_in_business_logic`) fails if any SDK leaks into `sync`/`diff`/`inventory`/`scope`/`hash_util`/`credentials`/`provider`.
- Conflict preservation by default: sha256 compare; mismatches leave both sides intact. On pull the remote is saved as `<path>.cloud-<ts>`; on push the remote is kept. `--force-push` / `--force-pull` are opt-in.
- Credentials live only in `~/.serena/cloud-sync.env` (chmod 0600, atomic write; a `****` sentinel on re-save preserves existing secrets). Dashboard routes require a per-process local token and reject non-localhost callers.
- Dry-run-first on both CLI and dashboard — destructive actions only run after the user sees the classified plan.

## Scope (explicit MVP non-goals)
- No delete propagation, no rename detection, no background scheduler.
- 5 MiB per-object cap.
- Hard-excludes credentials, logs, caches, symlinks, `project.local.yml` (opt-in only).

## Tests
- 24 unit tests via an in-memory `FakeCloudProvider`.
- LocalStack and Azurite integration skeletons — auto-skip unless `LOCALSTACK_ENDPOINT` / `AZURITE_ACCOUNT` env is set.

## Docs
Design rationale, data model, failure/idempotency contract, and acceptance criteria in `docs/cloud-sync-feature-plan.md`.