### PR TITLE
Rewrite Dockerfile into multi-stage build, minor updates to support that change

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,10 @@
 {
   "name": "serena Project",
   "dockerFile": "../Dockerfile",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "target": "dev"
+  },
   "workspaceFolder": "/workspaces/serena",
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash",

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
+        target: prod
         platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -16,12 +16,12 @@ Docker support allows you to run Serena in an isolated container environment, wh
 
 ### Configuration
 
-Serena's configuration and log files are stored in the container in `/workspaces/serena/config/`.
+Serena's configuration and log files are stored in the container in `/home/serena/.serena`.
 Any local configuration you may have for Serena will not apply; the container uses its own separate configuration.
 
 You can mount a local configuration/data directory to persist settings across container restarts
 (which will also contain session log files).
-Simply mount your local directory to `/workspaces/serena/config` in the container.
+Simply mount your local directory to `/home/serena/.serena` in the container.
 Initially, be sure to add a `serena_config.yml` file to the mounted directory which applies the following
 special settings for Docker usage:
 ```
@@ -45,7 +45,10 @@ Set other configuration options as needed.
 
 The default Docker image does not include dependencies for languages that
 require explicit system-level installations.
+
 Only languages that install their requirements on the fly will work out of the box.
+
+A basic example of using Serena for your own toolchain can be seen in `examples/docker/
 
 ### Dashboard Port Configuration
 
@@ -73,17 +76,29 @@ SERENA_DASHBOARD_PORT=8080 docker-compose up serena
 
 ### Using Docker Compose (Recommended)
 
-1. **Production mode** (for using Serena as MCP server):
+#### Using Serena with other projects
+
+For developing your own project with Serena you may use the following command. 
+
+By default this will mount the local directory that the compose file is started in.
+
    ```bash
    docker-compose up serena
    ```
 
-2. **Development mode** (with source code mounted):
+To override this behavior pass in the `PROJECT_DIR` environment variable at the CLI or by modifying the compose file. 
+
    ```bash
-   docker-compose up serena-dev
+   PROJECT_DIR="../reponame" docker-compose up serena
    ```
 
-Note: Edit the `compose.yaml` file to customize volume mounts for your projects.
+#### For Serena Development
+
+To develop the Serena codebase you can run the following command
+
+   ```bash
+   docker-compose -f compose-dev.yaml up
+   ```
 
 ### Building the Docker Image Manually
 
@@ -99,45 +114,32 @@ docker run -it --rm \
   serena
 ```
 
-### Using Docker Compose with Merge Compose files
-
-To use Docker Compose with merge files, you can create a `compose.override.yml` file to customize the configuration:
-
-```yaml
-services:
-  serena:
-    # To work with projects, you must mount them as volumes:
-    volumes:
-      - ./my-project:/workspace/my-project
-      - /path/to/another/project:/workspace/another-project
-    # Add the context for the IDE assistant option:
-    command:
-      - "uv run --directory . serena-mcp-server --transport sse --port 9121 --host 0.0.0.0 --context claude-code"
-```
-
-See the [Docker Merge Compose files documentation](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/) for more details on using merge files.
-
 ## Accessing the Dashboard
 
 Once running, access the web dashboard at:
-- Default: http://localhost:24282/dashboard
-- Custom port: http://localhost:${SERENA_DASHBOARD_PORT}/dashboard
+
+http://localhost:24282/dashboard
 
 ## Volume Mounting
 
 To work with projects, you must mount them as volumes:
 
-```yaml
-# In compose.yaml
-volumes:
-  - ./my-project:/workspace/my-project
-  - /path/to/another/project:/workspace/another-project
-```
+  ```yaml
+  # In compose.yaml
+  volumes:
+    - ./my-project:/workspace/
+  ```
+
+   ```bash
+   # Using the environment variable
+   PROJECT_DIR="../reponame" docker-compose up serena
+   ```
 
 ## Environment Variables
 
-- `SERENA_PORT`: MCP server port (default: 9121)
-- `SERENA_DASHBOARD_PORT`: Web dashboard port (default: 24282)
+- `SERENA_PORT`: MCP server port (default: `9121`)
+- `SERENA_DASHBOARD_PORT`: Web dashboard port (default: `24282`)
+- `PROJECT_DIR`: The local project directory to mount into the container (default: `./`)
 - `INTELEPHENSE_LICENSE_KEY`: License key for Intelephense PHP LSP premium features (optional)
 
 ## Troubleshooting
@@ -154,19 +156,9 @@ netstat -ano | findstr :24282  # Windows
 SERENA_DASHBOARD_PORT=8080 docker-compose up serena
 ```
 
-### Configuration Issues
-
-If you need to reset Docker configuration:
-```bash
-# Remove Docker-specific config
-rm serena_config.docker.yml
-
-# Serena will auto-generate a new one on next run
-```
-
 ### Project Access Issues
 
 Ensure projects are properly mounted:
-- Check volume mounts in `docker-compose.yaml`
+- Check volume mounts in `compose.yaml`
 - Use absolute paths for external projects
 - Verify permissions on mounted directories

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -96,7 +96,6 @@ docker run -it --rm \
   -v "$(pwd)":/workspace \
   -p 9121:9121 \
   -p 24282:24282 \
-  -e SERENA_DOCKER=1 \
   serena
 ```
 
@@ -137,7 +136,6 @@ volumes:
 
 ## Environment Variables
 
-- `SERENA_DOCKER=1`: Set automatically to indicate Docker environment
 - `SERENA_PORT`: MCP server port (default: 9121)
 - `SERENA_DASHBOARD_PORT`: Web dashboard port (default: 24282)
 - `INTELEPHENSE_LICENSE_KEY`: License key for Intelephense PHP LSP premium features (optional)

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ USER serena
 EXPOSE 9121 24282
 
 ENTRYPOINT ["serena"]
-CMD ["start-mcp-server", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9121", "--project", "./"]
+CMD ["start-mcp-server", "--transport", "stdio", "--project", "./"]
 
 FROM base AS dev
 SHELL ["/bin/bash", "-c"]
@@ -78,4 +78,4 @@ RUN uv sync
 ENV PATH="/workspaces/serena/.venv/bin:${PATH}"
 
 ENTRYPOINT ["serena"]
-CMD ["start-mcp-server", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9121", "--project", "./"]
+CMD ["start-mcp-server", "--transport", "stdio", "--project", "./"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,77 +1,79 @@
-# Base stage with common dependencies
+FROM node:22.22-slim AS node
+FROM rust:1.94-slim AS rust
+FROM ghcr.io/astral-sh/uv:0.11.7 AS uv
+
 FROM python:3.11-slim AS base
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+FROM base AS builder
+
+WORKDIR /build
+
+COPY --from=uv /uv /uvx /bin/
+
+COPY pyproject.toml README.md uv.lock ./
+COPY src ./src
+
+RUN uv build
+
+FROM base AS prod
+
+WORKDIR /workspace
+
+RUN useradd --create-home --shell /usr/sbin/nologin serena \
+    && mkdir -p "/workspace" \
+    && chown -R serena:serena "/workspace"
+
+COPY --from=builder /build/dist/*.whl /tmp/
+
+RUN pip install --no-cache-dir /tmp/*.whl \
+    && rm -f /tmp/*.whl
+
+USER serena
+
+EXPOSE 9121 24282
+
+ENTRYPOINT ["serena"]
+CMD ["start-mcp-server", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9121"]
+
+FROM base AS dev
 SHELL ["/bin/bash", "-c"]
 
-# Set environment variables to make Python print directly to the terminal and avoid .pyc files.
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
-
-# Install system dependencies required for package manager and build tools.
-# sudo, wget, zip needed for some assistants, like junie
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     build-essential \
     git \
     ssh \
-    sudo \
     wget \
     zip \
     unzip \
-    git \
+    sed \
     && rm -rf /var/lib/apt/lists/*
 
-# Install pipx.
-RUN python3 -m pip install --no-cache-dir pipx \
-    && pipx ensurepath
+# NVM can be readded if switching node version is common while testing/developing serena
+COPY --from=node /usr/local /usr/local
+COPY --from=uv /uv /uvx /bin/
+COPY --from=rust /usr/local/cargo /usr/local/cargo
+COPY --from=rust /usr/local/rustup /usr/local/rustup
 
-# Install nodejs
-ENV NVM_VERSION=0.40.3
-ENV NODE_VERSION=22.18.0
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash
-# standard location
-ENV NVM_DIR=/root/.nvm
-RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
-ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH="/usr/local/cargo/bin:${PATH}"
 
-# Add local bin to the path
-ENV PATH="${PATH}:/root/.local/bin"
-
-# Install the latest version of uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Install Rust and rustup for rust-analyzer support (minimal profile)
-ENV RUSTUP_HOME=/usr/local/rustup
-ENV CARGO_HOME=/usr/local/cargo
-ENV PATH="${CARGO_HOME}/bin:${PATH}"
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    --default-toolchain stable \
-    --profile minimal \
-    && rustup component add rust-analyzer
-
-# Set the working directory
 WORKDIR /workspaces/serena
 
-# Copy all files for development
 COPY . /workspaces/serena/
 
-# Install sed
-RUN apt-get update && apt-get install -y sed
-
-# Create Serena configuration
 ENV SERENA_HOME=/workspaces/serena/config
-RUN mkdir -p $SERENA_HOME
-RUN cp src/serena/resources/serena_config.template.yml $SERENA_HOME/serena_config.yml
-RUN sed -i 's/^gui_log_window: .*/gui_log_window: False/' $SERENA_HOME/serena_config.yml
-RUN sed -i 's/^web_dashboard_listen_address: .*/web_dashboard_listen_address: 0.0.0.0/' $SERENA_HOME/serena_config.yml
-RUN sed -i 's/^web_dashboard_open_on_launch: .*/web_dashboard_open_on_launch: False/' $SERENA_HOME/serena_config.yml
+RUN mkdir -p "$SERENA_HOME" && \
+    cp src/serena/resources/serena_config.template.yml "$SERENA_HOME/serena_config.yml" && \
+    sed -i 's/^gui_log_window: .*/gui_log_window: False/' "$SERENA_HOME/serena_config.yml" && \
+    sed -i 's/^web_dashboard_listen_address: .*/web_dashboard_listen_address: 0.0.0.0/' "$SERENA_HOME/serena_config.yml" && \
+    sed -i 's/^web_dashboard_open_on_launch: .*/web_dashboard_open_on_launch: False/' "$SERENA_HOME/serena_config.yml" && \
+    uv sync
 
-# Create virtual environment and install dependencies
-RUN uv venv
-RUN . .venv/bin/activate
-RUN uv pip install -r pyproject.toml -e .
 ENV PATH="/workspaces/serena/.venv/bin:${PATH}"
 
-# Entrypoint to ensure environment is activated
-ENTRYPOINT ["/bin/bash", "-c", "source .venv/bin/activate && $0 $@"]
+ENTRYPOINT ["serena"]
+CMD ["start-mcp-server", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9121"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ USER serena
 EXPOSE 9121 24282
 
 ENTRYPOINT ["serena"]
-CMD ["start-mcp-server", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9121"]
+CMD ["start-mcp-server", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9121", "--project", "./"]
 
 FROM base AS dev
 SHELL ["/bin/bash", "-c"]
@@ -78,4 +78,4 @@ RUN uv sync
 ENV PATH="/workspaces/serena/.venv/bin:${PATH}"
 
 ENTRYPOINT ["serena"]
-CMD ["start-mcp-server", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9121"]
+CMD ["start-mcp-server", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9121", "--project", "./"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sed \
     && rm -rf /var/lib/apt/lists/*
 
-# NVM can be readded if switching node version is common while testing/developing serena
+# NVM can be re-added if switching node version is common while testing/developing serena
 COPY --from=node /usr/local /usr/local
 COPY --from=uv /uv /uvx /bin/
 COPY --from=rust /usr/local/cargo /usr/local/cargo

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,19 @@ FROM ghcr.io/astral-sh/uv:0.11.7 AS uv
 
 FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1
+    PYTHONDONTWRITEBYTECODE=1 \
+    SERENA_HOME=/home/serena/.serena
+
+COPY ./src/serena/resources/serena_config.template.yml /home/serena/.serena/serena_config.yml
+
+RUN sed -i 's/^gui_log_window: .*/gui_log_window: False/' "$SERENA_HOME/serena_config.yml" && \
+    sed -i 's/^web_dashboard_listen_address: .*/web_dashboard_listen_address: 0.0.0.0/' "$SERENA_HOME/serena_config.yml" && \
+    sed -i 's/^web_dashboard_open_on_launch: .*/web_dashboard_open_on_launch: False/' "$SERENA_HOME/serena_config.yml"
+
+RUN useradd --create-home --shell /usr/sbin/nologin serena \
+    && mkdir -p "/workspace" \
+    && chown -R serena:serena "/workspace" \
+    && chown -R serena:serena /home/serena
 
 FROM base AS builder
 
@@ -20,10 +32,6 @@ RUN uv build
 FROM base AS prod
 
 WORKDIR /workspace
-
-RUN useradd --create-home --shell /usr/sbin/nologin serena \
-    && mkdir -p "/workspace" \
-    && chown -R serena:serena "/workspace"
 
 COPY --from=builder /build/dist/*.whl /tmp/
 
@@ -65,13 +73,7 @@ WORKDIR /workspaces/serena
 
 COPY . /workspaces/serena/
 
-ENV SERENA_HOME=/workspaces/serena/config
-RUN mkdir -p "$SERENA_HOME" && \
-    cp src/serena/resources/serena_config.template.yml "$SERENA_HOME/serena_config.yml" && \
-    sed -i 's/^gui_log_window: .*/gui_log_window: False/' "$SERENA_HOME/serena_config.yml" && \
-    sed -i 's/^web_dashboard_listen_address: .*/web_dashboard_listen_address: 0.0.0.0/' "$SERENA_HOME/serena_config.yml" && \
-    sed -i 's/^web_dashboard_open_on_launch: .*/web_dashboard_open_on_launch: False/' "$SERENA_HOME/serena_config.yml" && \
-    uv sync
+RUN uv sync
 
 ENV PATH="/workspaces/serena/.venv/bin:${PATH}"
 

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -1,0 +1,9 @@
+include:
+  - compose.yaml
+
+services:
+  serena:
+    pull_policy: build
+    build:
+      context: .
+      target: dev

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
       - "${SERENA_DASHBOARD_PORT:-24282}:24282"  # Dashboard port (default 0x5EDA = 24282)
     volumes:
       - ${PROJECT_DIR:-.}:/workspace/
-    # Default command can be overidden below
+    # Default command can be overridden below
     # command:
     #   - start-mcp-server
     #   - --transport

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,14 +1,23 @@
 services:
   serena:
     image: serena:latest
+    pull_policy: always
+    build:
+      context: .
+      target: prod
     ports:
       - "${SERENA_PORT:-9121}:9121"  # MCP server port
       - "${SERENA_DASHBOARD_PORT:-24282}:24282"  # Dashboard port (default 0x5EDA = 24282)
-    # To work with projects, you must mount them into /workspace/ in the container:
-    # volumes:
-      # - ./my-project:/workspace/my-project
-      # - /path/to/another/project:/workspace/another-project
+    volumes:
+      - ${PROJECT_DIR:-.}:/workspace/
     # Default command can be overidden below
     # command:
-    #   - "start-mcp-server --transport streamable-http --host 0.0.0.0 --port 9121 --project ./ --context=vscode"
-
+    #   - start-mcp-server
+    #   - --transport
+    #   - streamable-http
+    #   - --host
+    #   - 0.0.0.0
+    #   - --port
+    #   - "9121"
+    #   - --context
+    #   - vscode

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,15 +1,13 @@
 services:
   serena:
     image: serena:latest
+    ports:
+      - "${SERENA_PORT:-9121}:9121"  # MCP server port
+      - "${SERENA_DASHBOARD_PORT:-24282}:24282"  # Dashboard port (default 0x5EDA = 24282)
     # To work with projects, you must mount them into /workspace/ in the container:
     # volumes:
       # - ./my-project:/workspace/my-project
       # - /path/to/another/project:/workspace/another-project
-    ports:
-      - "${SERENA_PORT:-9121}:9121"  # MCP server port
-      - "${SERENA_DASHBOARD_PORT:-24282}:24282"  # Dashboard port (default 0x5EDA = 24282)
-    environment:
-      - SERENA_DOCKER=1
     # Default command can be overidden below
     # command:
     #   - "serena-mcp-server --transport streamable-http --port 9121 --host 0.0.0.0 --context ide"

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,17 +5,12 @@ services:
     # volumes:
       # - ./my-project:/workspace/my-project
       # - /path/to/another/project:/workspace/another-project
-    build:
-      context: ./
-      dockerfile: Dockerfile
-      target: production
     ports:
       - "${SERENA_PORT:-9121}:9121"  # MCP server port
       - "${SERENA_DASHBOARD_PORT:-24282}:24282"  # Dashboard port (default 0x5EDA = 24282)
     environment:
       - SERENA_DOCKER=1
-    command:
-      - "uv run --directory . serena-mcp-server --transport sse --port 9121 --host 0.0.0.0"
-      # Alternatively add further arguments, e.g. a context
-      # - "uv run --directory . serena-mcp-server --transport sse --port 9121 --host 0.0.0.0 --context ide"
+    # Default command can be overidden below
+    # command:
+    #   - "serena-mcp-server --transport streamable-http --port 9121 --host 0.0.0.0 --context ide"
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,5 +10,5 @@ services:
       # - /path/to/another/project:/workspace/another-project
     # Default command can be overidden below
     # command:
-    #   - "serena-mcp-server --transport streamable-http --port 9121 --host 0.0.0.0 --context ide"
+    #   - "start-mcp-server --transport streamable-http --host 0.0.0.0 --port 9121 --project ./ --context=vscode"
 

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM ghcr.io/opentofu/opentofu:minimal AS tofu
+
+FROM node:22.22-slim AS node
+
+FROM serena:latest
+
+USER root
+
+COPY --from=node /usr/local /usr/local
+COPY --from=tofu /usr/local/bin/tofu /usr/local/bin/tofu
+
+RUN ln -s /usr/local/bin/tofu /usr/local/bin/terraform
+
+USER serena

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -2,6 +2,6 @@
 
 This directory demonstrates building a Serena images with the necessary dependencies for Terraform/OpenTofu and Ansible. 
 
-The `Dockerfile` bases itself on the latest serena image, then layers the necessary dependecies on the top. 
+The `Dockerfile` bases itself on the latest serena image, then layers the necessary dependencies on the top. 
 
 The `compose.yaml` then builds the image and mounts the local directory as a project.

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,7 @@
+# Example: Build a Serena image for Terraform/OpenTofu & Ansible 
+
+This directory demonstrates building a Serena images with the necessary dependecies for Terraform/OpenTofu and Ansible. 
+
+The `Dockerfile` bases itself on the latest serena image, then layers the necessary dependecies on the top. 
+
+The `compose.yaml` then builds the image and mounts the local directory as a project.

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,6 +1,6 @@
 # Example: Build a Serena image for Terraform/OpenTofu & Ansible 
 
-This directory demonstrates building a Serena images with the necessary dependecies for Terraform/OpenTofu and Ansible. 
+This directory demonstrates building a Serena images with the necessary dependencies for Terraform/OpenTofu and Ansible. 
 
 The `Dockerfile` bases itself on the latest serena image, then layers the necessary dependecies on the top. 
 

--- a/examples/docker/compose.yaml
+++ b/examples/docker/compose.yaml
@@ -10,3 +10,14 @@ services:
     ports:
       - "${SERENA_PORT:-9121}:9121"  # MCP server port
       - "${SERENA_DASHBOARD_PORT:-24282}:24282"  # Dashboard port (default 0x5EDA = 24282)
+    # HTTP Server setup
+    command:
+      - start-mcp-server
+      - --transport
+      - streamable-http
+      - --host
+      - 0.0.0.0
+      - --port
+      - "9121"
+      - --context
+      - vscode

--- a/examples/docker/compose.yaml
+++ b/examples/docker/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  serena:
+    image: serena-infra:latest
+    volumes:
+      - ${PROJECT_DIR:-.}:/workspace/
+    pull_policy: build
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    ports:
+      - "${SERENA_PORT:-9121}:9121"  # MCP server port
+      - "${SERENA_DASHBOARD_PORT:-24282}:24282"  # Dashboard port (default 0x5EDA = 24282)


### PR DESCRIPTION
The previous Docker setup is a bit confusing but I tried to infer what was intended.

# Changes:

1. Ensures a proper `ENTRYPOINT` and `CMD` are so the MCP server starts successfully
2. Utilizes a multi-stage build so the version pushed to the registry is a slim image (~275 MB) that can have various LSPs and tooling layered on top as needed. 
3. Includes minor updates to docs and ensures the push workflow leverages the proper target (prod)

The idea here is that someone who wishes to run this MCP inside of Docker can base off the pushed serena image and layer on their necessary dependencies. 

Still a bit more work to do here and I'm currently experimenting a bit locally.