### PR TITLE
fix(agent): swallow OSError in _open_dashboard_in_browser (#1363)

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -629,14 +629,24 @@ class SerenaAgent:
 
     @staticmethod
     def _open_dashboard_in_browser(url: str) -> None:
-        # Use a subprocess to avoid any output from webbrowser.open being written to stdout
-        subprocess.Popen(
-            [sys.executable, "-c", f"import webbrowser; webbrowser.open({url!r})"],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=False,
-        )
+        # Use a subprocess to avoid any output from webbrowser.open being written to stdout.
+        # Auto-opening the browser is best-effort: any failure here must be non-fatal, since
+        # this runs inside SerenaAgent.__init__ and a propagating OSError would abort agent
+        # construction and break the MCP handshake (see oraios/serena#1363).
+        try:
+            subprocess.Popen(
+                [sys.executable, "-c", f"import webbrowser; webbrowser.open({url!r})"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=False,
+            )
+        except OSError as e:
+            log.warning(
+                "Failed to auto-open dashboard in browser (%s); dashboard remains accessible at %s",
+                e,
+                url,
+            )
 
     def get_exposed_tool_instances(self) -> list["Tool"]:
         """

--- a/test/serena/test_dashboard.py
+++ b/test/serena/test_dashboard.py
@@ -1,5 +1,9 @@
+import logging
 from types import SimpleNamespace
 
+import pytest
+
+from serena.agent import SerenaAgent
 from serena.dashboard import SerenaDashboardAPI
 from solidlsp.ls_config import Language
 
@@ -47,3 +51,19 @@ def test_available_languages_exclude_project_languages():
     assert Language.MARKDOWN.value not in available
     # ensure experimental languages remain available for selection
     assert Language.ANSIBLE.value in available
+
+
+def test_open_dashboard_in_browser_swallows_os_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """`_open_dashboard_in_browser` must never propagate OSError: it runs inside
+    SerenaAgent.__init__ and a fatal here breaks the MCP handshake (see #1363).
+    """
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise OSError(14, "Bad address")
+
+    monkeypatch.setattr("serena.agent.subprocess.Popen", _raise)
+
+    with caplog.at_level(logging.WARNING, logger="serena.agent"):
+        SerenaAgent._open_dashboard_in_browser("http://localhost:24282/dashboard/")
+
+    assert any("Failed to auto-open dashboard" in record.message and record.levelno == logging.WARNING for record in caplog.records)


### PR DESCRIPTION
## Summary

Fixes #1363.

`SerenaAgent._open_dashboard_in_browser` currently calls `subprocess.Popen` with no error handling. Because it runs inside `SerenaAgent.__init__` (via `_start_dashboard_viewer` on Linux systems without a usable tray), any `OSError` from `Popen` aborts agent construction. When that happens under Claude Code's stdio MCP transport, `create_mcp_server` never returns and the client times out after 30s with `MCP server "serena" connection timed out after 30000ms`.

Observed failure on Linux 6.17 / Python 3.13 / serena 1.1.2:

```
OSError: [Errno 14] Bad address: '/…/serena-agent/bin/python'
```

(full traceback in #1363 — `execve` EFAULT inside the stdio-hosted agent, while the same binary runs fine outside that context).

Opening a browser is best-effort and must never be fatal. This PR wraps the `Popen` in `try/except OSError` and logs a warning; the dashboard itself remains reachable at its URL.

## Changes

- `src/serena/agent.py`: catch `OSError` in `_open_dashboard_in_browser`, log a warning pointing at the dashboard URL instead of propagating.
- `test/serena/test_dashboard.py`: regression test — monkeypatches `subprocess.Popen` to raise `OSError(14, "Bad address")` and asserts the call returns normally with a `WARNING` on the `serena.agent` logger.

## Test plan

- [x] `poe format` — clean
- [x] `poe type-check` — `Success: no issues found in 124 source files` (both src and test passes)
- [x] `pytest test/serena/test_dashboard.py -v` — 3 passed (2 pre-existing + new regression test)

## Notes

- Scope intentionally minimal: only the `Popen` call in `_open_dashboard_in_browser` is touched. The same method is also called from the user-triggered `open_dashboard()` tool path (agent.py:627), which benefits from the same protection.
- Existing `test_serena_agent.py` fixtures already set `web_dashboard=False`, so the buggy path had no CI coverage. This PR adds targeted coverage.
- Related but not a duplicate: #898 (macOS, same class — dashboard side-effect breaking MCP handshake), #1147 (Codex on Linux — different branch, handled via `system_has_usable_display` early-return), #1266 (open PR that refactors `_start_dashboard_viewer` but keeps `_open_dashboard_in_browser` unchanged).

cc @opcode81