### PR TITLE
fix: add missing children field to DocumentSymbol TypedDict

### DIFF
--- a/src/solidlsp/lsp_protocol_handler/lsp_types.py
+++ b/src/solidlsp/lsp_protocol_handler/lsp_types.py
@@ -2456,8 +2456,8 @@ class DocumentSymbol(TypedDict):
     selectionRange: "Range"
     """ The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
     Must be contained by the `range`. """
-
-    # TODO: I think this type is missing the 'children' field - DJ
+    children: NotRequired[list["DocumentSymbol"]]
+    """ Children of this symbol, e.g. properties of a class. """
 
 
 class DocumentSymbolRegistrationOptions(TypedDict):


### PR DESCRIPTION
## Summary

The LSP v3.17 specification defines `DocumentSymbol.children` as an optional list of nested `DocumentSymbol` entries (hierarchical symbol support). The field was absent from the `DocumentSymbol` TypedDict in `lsp_types.py`, despite the file being generated from the LSP spec.

A `# TODO` comment at line 2460 explicitly flagged this gap:
```
# TODO: I think this type is missing the 'children' field - DJ
```

## Change

Added the missing field to `DocumentSymbol`:

```python
children: NotRequired[list["DocumentSymbol"]]
""" Children of this symbol, e.g. properties of a class. """
```

This matches the [LSP v3.17 spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol) exactly. The field is `NotRequired` because leaf symbols have no children.

## Impact

- `ls.py` accesses `symbol["children"]` in multiple places and already works correctly at runtime — the missing type just forced `# type: ignore` workarounds and suppressed type-checker errors on those call sites.
- No behaviour change; pure type correctness fix.