### PR TITLE
Add more cpp extensions

### DIFF
--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -232,7 +232,41 @@ class Language(str, Enum):
             case self.RUBY_SOLARGRAPH:
                 return FilenameMatcher("*.rb")
             case self.CPP | self.CPP_CCLS:
-                return FilenameMatcher("*.cpp", "*.h", "*.hpp", "*.c", "*.hxx", "*.cc", "*.cxx")
+                # From llvm-project/clang/lib/Driver/Types.cpp types::lookupTypeForExtension:
+                return FilenameMatcher(
+                    # C
+                    "*.c",
+                    "*.C",
+                    "*.h",
+                    "*.H",
+                    # C++
+                    "*.c++",
+                    "*.C++",
+                    "*.c++m",
+                    "*.cc",
+                    "*.CC",
+                    "*.cp",
+                    "*.cpp",
+                    "*.CPP",
+                    "*.cppm",
+                    "*.cxx",
+                    "*.CXX",
+                    "*.cxxm",
+                    "*.hpp",
+                    "*.hxx",
+                    "*.ixx",
+                    # CUDA
+                    "*.cu",
+                    # HIP
+                    "*.hip",
+                    # Objective-C
+                    "*.m",
+                    "*.M",
+                    "*.mm",
+                    # OpenCL
+                    "*.cl",
+                    "*.clcpp",
+                )
             case self.KOTLIN:
                 return FilenameMatcher("*.kt", "*.kts")
             case self.DART:


### PR DESCRIPTION
This PR adds several missing extensions that `clangd` understands to `cpp`. This enables recognition of C++20 module interface files among other things.

Most of these extensions are taken directly from the `clang` driver frontend:

https://github.com/llvm/llvm-project/blob/08992737d23113d3b9a78974b87b1ba3e7ecb6cb/clang/lib/Driver/Types.cpp#L309

One exception is `*.ixx` which is the default extension Visual Studio uses for C++20 module interface files:

https://learn.microsoft.com/en-us/cpp/cpp/modules-cpp?view=msvc-170#single-partition-modules

Related: #1259 