### PR TITLE
Fix/mobile responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Dashboard:
   - Add configurable dashboard interface mode (new global configuration setting `web_dashboard_interface`):
     Three modes (browser, native app with tray, tray manager for aggregating multiple instances) are supported, depending on the OS
   - Fix: Memory leaks in frontend when using Chromium-based browsers/Windows webview #1389
+  - Fix: Dashboard UI now renders correctly on tablet and mobile viewports — removed `min-width: 1280px` constraint that forced horizontal scrolling and disabled all responsive breakpoints; header collapses to a compact layout at ≤768px; new 480px breakpoint added for small phones
 
 # v1.1.2 (2026-04-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Dashboard:
   - Add configurable dashboard interface mode (new global configuration setting `web_dashboard_interface`):
     Three modes (browser, native app with tray, tray manager for aggregating multiple instances) are supported, depending on the OS
   - Fix: Memory leaks in frontend when using Chromium-based browsers/Windows webview #1389
-  - Fix: Dashboard UI now renders correctly on tablet and mobile viewports — removed `min-width: 1280px` constraint that forced horizontal scrolling and disabled all responsive breakpoints; header collapses to a compact layout at ≤768px; new 480px breakpoint added for small phones
+  - Fix: Dashboard UI now renders correctly on tablet and mobile viewports — removed `min-width: 1280px` constraint that forced horizontal scrolling and disabled all responsive breakpoints; header collapses to a compact column layout at ≤768px with a properly scaled logo; platinum banner moved out of the header into its own full-width strip below it; new 480px breakpoint added for small phones
 
 # v1.1.2 (2026-04-14)
 

--- a/src/serena/resources/dashboard/dashboard.css
+++ b/src/serena/resources/dashboard/dashboard.css
@@ -1019,27 +1019,40 @@ body {
 }
 
 @media (max-width: 768px) {
-    body {
-        padding-top: 140px;
-    }
-
     .header {
         flex-direction: column;
+        height: auto;
         gap: 10px;
         padding: 10px 15px;
     }
 
-    .logo-container {
+    .header-left {
         width: 100%;
+        justify-content: center;
+        gap: 15px;
+    }
+
+    .logo-container {
+        width: auto;
+        height: auto;
         text-align: center;
+        flex-shrink: 1;
     }
 
     .logo-container img {
+        height: 55px;
         max-width: 200px;
+        margin-top: 0;
+    }
+
+    .header-banner {
+        height: auto;
+        max-height: 55px;
     }
 
     .header-nav {
         width: 100%;
+        height: auto;
         align-items: center;
     }
 

--- a/src/serena/resources/dashboard/dashboard.css
+++ b/src/serena/resources/dashboard/dashboard.css
@@ -156,7 +156,6 @@ body {
     margin: 0 auto;
     padding: var(--frame-padding);
     padding-top: 0;
-    min-width: 1280px;
 }
 
 .main {
@@ -1008,6 +1007,15 @@ body {
     .overview-right {
         order: -1;
     }
+
+    .stat-tool-name {
+        min-width: 140px;
+        max-width: 140px;
+    }
+
+    .config-grid {
+        grid-template-columns: 140px 1fr;
+    }
 }
 
 @media (max-width: 768px) {
@@ -1072,6 +1080,29 @@ body {
 
     .stat-tool-name {
         min-width: 100%;
+    }
+
+    .log-container {
+        height: calc(100vh - 200px);
+    }
+}
+
+@media (max-width: 480px) {
+    #frame {
+        padding: 8px;
+    }
+
+    .header {
+        padding: 8px;
+    }
+
+    .menu-dropdown {
+        min-width: 160px;
+    }
+
+    .stat-tool-name {
+        min-width: 100%;
+        max-width: 100%;
     }
 }
 

--- a/src/serena/resources/dashboard/dashboard.css
+++ b/src/serena/resources/dashboard/dashboard.css
@@ -197,17 +197,17 @@ body {
 
 .logo-container img {
     height: calc(var(--header-height) - 20px);
+    max-width: 100%;
     margin-top: 10px;
     display: block;
 }
 
-.header-banner {
+.platinum-banners-row {
     position: relative;
-    top: 0;
-    left: 0;
-    order: 2;
-    height: var(--header-height);
-    max-height: var(--header-height);
+    margin-top: var(--header-gap-main);
+    max-height: 150px;
+    overflow: hidden;
+    border-radius: var(--border-radius);
 }
 
 .header-nav {
@@ -314,6 +314,7 @@ body {
     display: none;
     pointer-events: none;
     height: 100%;
+    width: 100%;
 }
 
 .platinum-banner-slide.active {
@@ -332,6 +333,7 @@ body {
 
 .platinum-banner-slide .banner-image {
     max-height: 100%;
+    max-width: 100%;
     object-fit: contain;
 }
 
@@ -1022,6 +1024,7 @@ body {
     .header {
         flex-direction: column;
         height: auto;
+        align-items: stretch;
         gap: 10px;
         padding: 10px 15px;
     }
@@ -1029,25 +1032,19 @@ body {
     .header-left {
         width: 100%;
         justify-content: center;
-        gap: 15px;
     }
 
     .logo-container {
         width: auto;
         height: auto;
         text-align: center;
-        flex-shrink: 1;
+        flex-shrink: 0;
     }
 
     .logo-container img {
-        height: 55px;
-        max-width: 200px;
+        height: 100px;
+        max-width: 300px;
         margin-top: 0;
-    }
-
-    .header-banner {
-        height: auto;
-        max-height: 55px;
     }
 
     .header-nav {

--- a/src/serena/resources/dashboard/dashboard.css
+++ b/src/serena/resources/dashboard/dashboard.css
@@ -205,7 +205,7 @@ body {
 .platinum-banners-row {
     position: relative;
     margin-top: var(--header-gap-main);
-    max-height: 150px;
+    max-height: 156px;
     overflow: hidden;
     border-radius: var(--border-radius);
 }

--- a/src/serena/resources/dashboard/index.html
+++ b/src/serena/resources/dashboard/index.html
@@ -24,11 +24,6 @@
             <img id="serena-logo" class="theme-aware-img" src="serena-logo.svg" data-src-light="serena-logo.svg" data-src-dark="serena-logo-dark-mode.svg" alt="Serena">
         </div>
 
-        <!-- Platinum Banners in Header -->
-        <div id="platinum-banners" class="header-banner">
-            <button class="banner-arrow banner-arrow-left" data-target="platinum" aria-label="Previous banner">&#8249;</button>
-            <button class="banner-arrow banner-arrow-right" data-target="platinum" aria-label="Next banner">&#8250;</button>
-        </div>
     </div>
 
     <nav class="header-nav">
@@ -54,6 +49,10 @@
     </nav>
 </header>
 
+<div id="platinum-banners" class="platinum-banners-row">
+    <button class="banner-arrow banner-arrow-left" data-target="platinum" aria-label="Previous banner">&#8249;</button>
+    <button class="banner-arrow banner-arrow-right" data-target="platinum" aria-label="Next banner">&#8250;</button>
+</div>
 
 <div class="main">
     <!-- Overview Page (Landing) -->


### PR DESCRIPTION
  Fix: Dashboard Mobile & Tablet Responsiveness                                                                                  
                                                                                                                                 
  Problem
                                                                                                                                 
  The Serena dashboard was completely broken on any screen narrower than 1280px. A single CSS rule — min-width: 1280px on the    
  #frame container — forced horizontal scrolling at all smaller widths and silently disabled every responsive media query in the
  stylesheet. Additionally, the platinum banner was embedded inside the header's flex layout, causing cascading sizing and       
  overlap issues at mid-range viewports.                          

  Changes

  Root cause fix                                                                                                                 
  - Removed min-width: 1280px from #frame, enabling all responsive breakpoints to actually fire
                                                                                                                                 
  Header layout                                                   
  - Header collapses to a compact column layout at ≤768px with height: auto so it sizes naturally                                
  - Logo scales down to 100px tall on mobile (was inheriting the full 150px desktop value)                                       
  - Removed a pre-existing body { padding-top: 140px } that assumed a fixed/sticky header (the header is neither — it was        
  creating a large blank space at the top of the page on mobile)                                                                 
  - header-nav and header-left set to height: auto at mobile so they don't try to fill the desktop height                        
                                                                                                                                 
  Breakpoints                                                                                                                    
  - 1024px: overview grid collapses to single column; stat tool name and config grid label column widths reduced for tablet
  - 768px: full mobile column layout, compact logo, log container height recalculated                                            
  - 480px (new): tighter padding for small phones                                    
                                                                                                                                 
  Platinum banner                                                                                                                
  - Moved out of the header entirely into its own .platinum-banners-row div between the header and main content                  
  - Capped at max-height: 156px with overflow: hidden so it can't blow out on large screens                                      
  - Images get max-width: 100% to prevent async-loaded content from overflowing the container
                                                                                                                                 
  Gold banners ("Support Serena")                                                                                                
  - Restored to original location in overview-right — no functional changes                                                      
                                                                                                                                 
  Testing                                                         
                                                                                                                                 
  Open the dashboard and use browser DevTools responsive mode at:                                                                
  - 1024px — overview collapses to single column, no horizontal scroll
  - 768px — header stacks vertically, compact logo, banner below header                                                          
  - 480px — padding tightens, no overflow                              
  - 375px — no horizontal scrollbar at any point    


BEFORE:
<img width="880" height="1063" alt="Screenshot 2026-04-24 at 1 11 18 PM" src="https://github.com/user-attachments/assets/875adc9a-d723-4ffc-9a57-0fa82c552a84" />

AFTER:
<img width="866" height="1062" alt="Screenshot 2026-04-24 at 1 11 27 PM" src="https://github.com/user-attachments/assets/103f59b6-72b2-4384-815a-023a252e7614" />

For context, I have no interest in spending more time redesigning the UX, I would recommend considering a redesign of the CTA for support and making a carousel or two column layout underneath the navbar for your announcements/notifications/banners. Right now it feels awkward on desktop but I don't have have more time to spend.