### PR TITLE
ci: install libuv1-dev to unblock R languageserver build on ubuntu-24.04

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -224,6 +224,10 @@ jobs:
         with:
           r-version: '4.4.2'
           use-public-rspm: true
+      - name: Install R sysdeps (libuv for fs package)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Install R language server
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- Adds a Linux-only `Install R sysdeps` step in `.github/workflows/pytest.yml` that runs `apt-get install -y libuv1-dev` before the existing `Install R language server` step.
- Fixes the Ubuntu pytest job which currently fails on every PR because the R `fs` package can no longer build from source on the latest `ubuntu-24.04` runner image (`libuv1-dev` is not preinstalled and there is no binary build of `fs` for this R/Ubuntu combo).

Refs: #1419

## Why

`pytest.yml` uses `runs-on: ubuntu-latest`, which now resolves to `ubuntu-24.04`. On that image:

```
* installing *source* package ‘fs’ ...
Package libuv was not found in the pkg-config search path.
fatal error: uv.h: No such file or directory
ERROR: configuration failed for package ‘fs’
```

This cascades through `pkgload` → `roxygen2` → `languageserver`, and the 5 R tests in `test/solidlsp/r/test_r_basic.py` fail at setup with `RuntimeError: R languageserver package is not installed`. Full breakdown in #1419.

## Local verification

Reproduced and verified on `docker.io/library/ubuntu:24.04` via podman:

**Before:**
```
$ apt-cache policy libuv1-dev
libuv1-dev:
  Installed: (none)
  Candidate: 1.48.0-1.1build1

$ pkg-config --print-errors libuv
Package libuv was not found in the pkg-config search path.
```
(Identical to the CI failure wording.)

**After `apt-get install -y libuv1-dev`:**
```
$ pkg-config --modversion libuv
1.48.0
```
The `fs` configure check now passes.

## Test plan

- [ ] `Tests on ubuntu-latest` — should now pass (R `fs` builds, `languageserver` installs, `test/solidlsp/r/test_r_basic.py` runs).
- [ ] `Tests on macos-latest` — unaffected (step is gated by `runner.os == 'Linux'`).
- [ ] `Tests on windows-latest` — unaffected (same gate).

## Notes

- Step is intentionally minimal — only `libuv1-dev`, no other sysdeps. If other R packages later need more system libraries, the cleaner long-term fix would be to switch to `r-lib/actions/setup-r-dependencies@v2`, which auto-resolves CRAN sysdeps. Out of scope here.
- `r-lib/actions/setup-r@v2` is showing a Node.js 20 deprecation warning in current runs — not addressed in this PR (worth a follow-up before September 2026).
