### PR TITLE
Add more extensions for clangd and ccls

### DIFF
--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -13,13 +13,21 @@ if TYPE_CHECKING:
 
 
 class FilenameMatcher:
-    def __init__(self, *patterns: str) -> None:
+    patterns: list[str]
+
+    def __init__(self, *patterns: str, insensitive: bool = False) -> None:
         """
         :param patterns: fnmatch-compatible patterns
         """
-        self.patterns = patterns
+        self.insensitive = insensitive
+        # Pre-lowercase patterns if we are in insensitive mode
+        if self.insensitive:
+            self.patterns = [p.lower() for p in patterns]
+        else:
+            self.patterns = list[str](patterns)
 
     def is_relevant_filename(self, fn: str) -> bool:
+        fn = fn.lower() if self.insensitive else fn
         for pattern in self.patterns:
             if fnmatch.fnmatch(fn, pattern):
                 return True
@@ -272,6 +280,7 @@ class Language(str, Enum):
                     # OpenCL
                     "*.cl",
                     "*.clcpp",
+                    insensitive=True,
                 )
             case self.CPP_CCLS:
                 # From llvm-project/clang/lib/Driver/Types.cpp types::lookupTypeForExtension:
@@ -296,6 +305,7 @@ class Language(str, Enum):
                     # Objective-C
                     "*.m",
                     "*.mm",
+                    insensitive=True,
                 )
             case self.KOTLIN:
                 return FilenameMatcher("*.kt", "*.kts")
@@ -352,9 +362,7 @@ class Language(str, Enum):
             case self.JULIA:
                 return FilenameMatcher("*.jl")
             case self.FORTRAN:
-                return FilenameMatcher(
-                    "*.f90", "*.F90", "*.f95", "*.F95", "*.f03", "*.F03", "*.f08", "*.F08", "*.f", "*.F", "*.for", "*.FOR", "*.fpp", "*.FPP"
-                )
+                return FilenameMatcher("*.f90", "*.f95", "*.f03", "*.f08", "*.f", "*.for", "*.fpp", insensitive=True)
             case self.HASKELL:
                 return FilenameMatcher("*.hs", "*.lhs")
             case self.HAXE:

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -237,8 +237,66 @@ class Language(str, Enum):
                 return FilenameMatcher("*.rb", "*.erb")
             case self.RUBY_SOLARGRAPH:
                 return FilenameMatcher("*.rb")
-            case self.CPP | self.CPP_CCLS:
-                return FilenameMatcher("*.cpp", "*.h", "*.hpp", "*.c", "*.hxx", "*.cc", "*.cxx")
+            case self.CPP:
+                # From llvm-project/clang/lib/Driver/Types.cpp types::lookupTypeForExtension:
+                return FilenameMatcher(
+                    # C
+                    "*.c",
+                    "*.h",
+                    # C++
+                    "*.c++",
+                    "*.cc",
+                    "*.cp",
+                    "*.cpp",
+                    "*.cxx",
+                    "*.hh",
+                    "*.hpp",
+                    "*.hxx",
+                    # C++ include files
+                    "*.inl",
+                    "*.ipp",
+                    "*.tpp",
+                    "*.txx",
+                    # Objective-C
+                    "*.m",
+                    "*.mm",
+                    # C++20 module interface files
+                    "*.c++m",
+                    "*.cppm",
+                    "*.cxxm",
+                    "*.ixx",
+                    # CUDA
+                    "*.cu",
+                    # HIP
+                    "*.hip",
+                    # OpenCL
+                    "*.cl",
+                    "*.clcpp",
+                )
+            case self.CPP_CCLS:
+                # From llvm-project/clang/lib/Driver/Types.cpp types::lookupTypeForExtension:
+                return FilenameMatcher(
+                    # C
+                    "*.c",
+                    "*.h",
+                    # C++
+                    "*.c++",
+                    "*.cc",
+                    "*.cp",
+                    "*.cpp",
+                    "*.cxx",
+                    "*.hh",
+                    "*.hpp",
+                    "*.hxx",
+                    # C++ include files
+                    "*.inl",
+                    "*.ipp",
+                    "*.tpp",
+                    "*.txx",
+                    # Objective-C
+                    "*.m",
+                    "*.mm",
+                )
             case self.KOTLIN:
                 return FilenameMatcher("*.kt", "*.kts")
             case self.DART:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -302,6 +302,9 @@ def _determine_disabled_languages() -> list[Language]:
 
     # Disable CPP_CCLS tests if ccls is not available
     ccls_tests_enabled = _sh.which("ccls") is not None
+    # Skip ccls tests on Windows since no recent binary is available and version
+    # 0.20220729 from chocolatey crashes when parsing the test files.
+    ccls_tests_enabled = ccls_tests_enabled and not is_windows
     if not ccls_tests_enabled:
         result.append(Language.CPP_CCLS)
 

--- a/test/resources/repos/cpp/test_repo/C/a.c
+++ b/test/resources/repos/cpp/test_repo/C/a.c
@@ -1,0 +1,7 @@
+#include "b.h"
+
+int main()
+{
+    int x = add(3, 4);
+    return x;
+}

--- a/test/resources/repos/cpp/test_repo/C/b.h
+++ b/test/resources/repos/cpp/test_repo/C/b.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int add(int a, int b);

--- a/test/resources/repos/cpp/test_repo/CUDA/a.cu
+++ b/test/resources/repos/cpp/test_repo/CUDA/a.cu
@@ -1,0 +1,16 @@
+#include <cstdio>
+#include <cstdlib>
+
+__global__ auto
+cuda_hello() -> void
+{
+    printf("Hello World from GPU!\n");
+}
+
+auto
+main() -> int
+{
+    cuda_hello<<<1, 1>>>();
+    cudaDeviceSynchronize();
+    return EXIT_SUCCESS;
+}

--- a/test/resources/repos/cpp/test_repo/CXX20/a.cpp
+++ b/test/resources/repos/cpp/test_repo/CXX20/a.cpp
@@ -1,0 +1,9 @@
+#include <cstdlib>
+
+import b;
+
+auto
+main() noexcept -> int
+{
+    return EXIT_SUCCESS;
+}

--- a/test/resources/repos/cpp/test_repo/CXX20/b.cpp
+++ b/test/resources/repos/cpp/test_repo/CXX20/b.cpp
@@ -1,0 +1,17 @@
+module;
+
+#include <cstdint>
+
+module b;
+
+auto
+add(auto x, auto y) -> decltype(x + y)
+{
+    return x + y;
+}
+
+auto
+add_f32(float x, float y) -> float
+{
+    return add(x, y);
+}

--- a/test/resources/repos/cpp/test_repo/CXX20/b.cppm
+++ b/test/resources/repos/cpp/test_repo/CXX20/b.cppm
@@ -1,0 +1,16 @@
+module;
+
+#include <cstdint>
+
+export module b;
+
+export auto
+add(auto x, auto y) -> decltype(x + y);
+
+export auto
+add_f32(float x, float y) -> float;
+
+auto
+add_u32(std::int32_t x, std::int32_t y) -> std::int32_t {
+    return x + y;
+}

--- a/test/resources/repos/cpp/test_repo/HIP/a.hip
+++ b/test/resources/repos/cpp/test_repo/HIP/a.hip
@@ -1,0 +1,10 @@
+// -*- mode: C -*-
+
+#include <hip/hip_runtime.h>
+
+__global__
+void add_vectors(const float* A, const float* B, float* C)
+{
+    auto const idx = blockIdx.x * blockDim.x + threadIdx.x;
+    C[idx] = A[idx] + B[idx];
+}

--- a/test/resources/repos/cpp/test_repo/Objective-C/a.m
+++ b/test/resources/repos/cpp/test_repo/Objective-C/a.m
@@ -1,0 +1,7 @@
+@interface Hello
+- (void)hello;
+@end
+
+int main(int argc, const char * argv[]) {
+    return 0;
+}

--- a/test/resources/repos/cpp/test_repo/OpenCL/a.cl
+++ b/test/resources/repos/cpp/test_repo/OpenCL/a.cl
@@ -1,0 +1,8 @@
+// -*- mode: C -*-
+
+__kernel
+void add_vectors(__global const float *A, __global const float *B, __global float *C) 
+{
+    int idx = get_global_id(0);
+    C[idx] = A[idx] + B[idx];
+}

--- a/test/resources/repos/cpp/test_repo/compile_commands.json
+++ b/test/resources/repos/cpp/test_repo/compile_commands.json
@@ -13,5 +13,40 @@
     "directory": ".",
     "command": "g++ -std=c++17 -I . -c diagnostics_sample.cpp",
     "file": "diagnostics_sample.cpp"
+  },
+  {
+    "directory": "C",
+    "command": "clang -std=gnu23 -c a.c",
+    "file": "a.c"
+  },
+  {
+    "directory": "CUDA",
+    "command": "nvcc -std=c++20 -c a.cu",
+    "file": "a.cu"
+  },
+  {
+    "directory": "CXX20",
+    "command": "clang++ -std=gnu++20 -fmodule-file=b=b.pcm -c a.cpp",
+    "file": "a.cpp"
+  },
+  {
+    "directory": "CXX20",
+    "command": "clang++ -std=gnu++20 -fmodule-file=b=b.pcm -c b.cpp",
+    "file": "b.cpp"
+  },
+  {
+    "directory": "CXX20",
+    "command": "clang++ -std=gnu++20 -c b.cppm",
+    "file": "b.cppm"
+  },
+  {
+    "directory": "OpenCL",
+    "command": "clang -std=cl3.0 -c a.cl",
+    "file": "a.cl"
+  },
+    {
+    "directory": "HIP",
+    "command": "hipcc -c a.hip",
+    "file": "a.hip"
   }
 ]

--- a/test/serena/test_serena_agent.py
+++ b/test/serena/test_serena_agent.py
@@ -327,7 +327,7 @@ FIND_DEFINING_SYMBOL_CASES = [
         expected_definition_file="utils.ps1",
     ).to_pytest_param(),
     FindDefiningSymbolCase(
-        language=Language.CPP_CCLS,
+        language=Language.CPP,
         id="cpp_add_in_a",
         relative_path="a.cpp",
         identifier="add",
@@ -502,7 +502,7 @@ FIND_SYMBOL_REFERENCES_CASES = [
         expected_file="main.ps1",
     ).to_pytest_param(),
     FindSymbolCase(
-        language=Language.CPP_CCLS, id="cpp_add_function", symbol_name="add", expected_kind="Function", expected_file="b.cpp"
+        language=Language.CPP, id="cpp_add_function", symbol_name="add", expected_kind="Function", expected_file="b.cpp"
     ).to_pytest_param(),
     FindSymbolCase(
         language=Language.LEAN4, id="lean_add_method", symbol_name="add", expected_kind="Method", expected_file="Helper.lean"
@@ -580,7 +580,7 @@ FIND_REFERENCE_CASES = [
         reference_file="main.ps1",
     ).to_pytest_param(),
     FindReferenceCase(
-        language=Language.CPP_CCLS, id="cpp_add_refs", symbol_name="add", definition_file="b.cpp", reference_file="a.cpp"
+        language=Language.CPP, id="cpp_add_refs", symbol_name="add", definition_file="b.cpp", reference_file="a.cpp"
     ).to_pytest_param(),
     FindReferenceCase(
         language=Language.LEAN4, id="lean_add_refs", symbol_name="add", definition_file="Helper.lean", reference_file="Main.lean"
@@ -775,7 +775,7 @@ def serena_config():
         Language.CLOJURE,
         Language.FSHARP,
         Language.POWERSHELL,
-        Language.CPP_CCLS,
+        Language.CPP,
         Language.HAXE,
         Language.LEAN4,
         Language.MSL,

--- a/test/solidlsp/cpp/test_ccls_languages.py
+++ b/test/solidlsp/cpp/test_ccls_languages.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+
+from solidlsp.ls_config import Language
+from test.conftest import start_ls_context
+
+
+@pytest.mark.cpp
+class TestCCLSLanguages:
+    @pytest.mark.parametrize(
+        "lang, unit, names",
+        [
+            ("C", "a.c", {"main"}),
+            ("Objective-C", "a.m", {"main", "Hello", "-hello"}),
+        ],
+    )
+    def test_get_document_symbols(self, lang: str, unit: str, names: set[str]) -> None:
+        with start_ls_context(Language.CPP) as ccls:
+            path = os.path.join(lang, unit)
+            symbols = ccls.request_document_symbols(path).get_all_symbols_and_roots()
+            symbols = symbols[0] if symbols and isinstance(symbols[0], list) else symbols
+            symbols = {s.get("name") for s in symbols}
+            assert names == symbols, f"Expected '{names}' in document symbols, got: {symbols}"

--- a/test/solidlsp/cpp/test_clangd_languages.py
+++ b/test/solidlsp/cpp/test_clangd_languages.py
@@ -1,0 +1,30 @@
+import os
+
+import pytest
+
+from solidlsp.ls_config import Language
+from test.conftest import start_ls_context
+
+
+@pytest.mark.cpp
+class TestClangdLanguages:
+    @pytest.mark.parametrize(
+        "lang, unit, names",
+        [
+            ("C", "a.c", {"main"}),
+            ("CUDA", "a.cu", {"main", "cuda_hello"}),
+            ("CXX20", "a.cpp", {"main"}),
+            ("CXX20", "b.cpp", {"add", "add_f32"}),
+            ("CXX20", "b.cppm", {"add", "add_f32", "add_u32"}),
+            ("HIP", "a.hip", {"add_vectors"}),
+            ("OpenCL", "a.cl", {"add_vectors"}),
+            ("Objective-C", "a.m", {"main", "Hello", "-hello"}),
+        ],
+    )
+    def test_get_document_symbols(self, lang: str, unit: str, names: set[str]) -> None:
+        with start_ls_context(Language.CPP) as clangd:
+            path = os.path.join(lang, unit)
+            symbols = clangd.request_document_symbols(path).get_all_symbols_and_roots()
+            symbols = symbols[0] if symbols and isinstance(symbols[0], list) else symbols
+            symbols = {s.get("name") for s in symbols}
+            assert names == symbols, f"Expected '{names}' in document symbols, got: {symbols}"

--- a/test/solidlsp/cpp/test_cpp_basic.py
+++ b/test/solidlsp/cpp/test_cpp_basic.py
@@ -16,16 +16,11 @@ import pytest
 from solidlsp import SolidLanguageServer
 from solidlsp.ls_config import Language
 from solidlsp.ls_utils import SymbolUtils
-from test.conftest import get_repo_path, start_ls_context
+from test.conftest import get_repo_path, language_tests_enabled, start_ls_context
 from test.solidlsp.conftest import format_symbol_for_assert, has_malformed_name, request_all_symbols
 
-
-def _ccls_available() -> bool:
-    return shutil.which("ccls") is not None
-
-
 _cpp_servers: list[Language] = [Language.CPP]
-if _ccls_available():
+if language_tests_enabled(Language.CPP_CCLS):
     _cpp_servers.append(Language.CPP_CCLS)
 
 


### PR DESCRIPTION
This is a follow up to #1410.

This PR registers several more extensions for `clangd` and `ccls`.

Most of these extensions are taken directly from the `clang` driver frontend source:

https://github.com/llvm/llvm-project/blob/08992737d23113d3b9a78974b87b1ba3e7ecb6cb/clang/lib/Driver/Types.cpp#L309

The one exception is `*.ixx`. This is the default extension Visual Studio uses for C++20 module interface files:

https://learn.microsoft.com/en-us/cpp/cpp/modules-cpp?view=msvc-170#single-partition-modules

The clang source doesn't reference the extension but `clangd` does read the files without issue.

The additional extensions add support for the following:

| language |`clangd` | `ccls` |
|----------|---------|--------|
| Objective-C | :white_check_mark: | :white_check_mark: |
| C++20 module interface files | :white_check_mark: | :x: |
| CUDA | :white_check_mark: | :x: |
| HIP | :white_check_mark: | :x: |
| OpenCL | :white_check_mark: | :x: |

I opted not to associate C++20 module interface files with `ccls` since it sounds like that isn't actually supported: https://github.com/MaskRay/ccls/issues/798 If enabling it in the tests, it does seem to return symbols for the very simple case we have in the test repo though.

Same story for CUDA, HIP, and OpenCL. However, in those cases `ccls` also seems to be returning keywords (e.g, `__global`) as symbols, suggesting it doesn't properly recognize the AST and likely the results would not be reliable.

Related: #1259 