### PR TITLE
Skip and warn on malformed project configs at startup instead of crashing the MCP server

### DIFF
--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -872,7 +872,7 @@ class SerenaConfig(SharedConfig):
             try:
                 project_config = ProjectConfig.load(path, serena_config=instance)  # instance is sufficiently populated
             except Exception as e:
-                log.warning(
+                log.error(
                     "Failed to load project configuration for %s: %s. "
                     "This project will be skipped. Fix or delete its "
                     ".serena/project.yml (or remove it from "

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -869,7 +869,18 @@ class SerenaConfig(SharedConfig):
                 if path is None:
                     continue
                 num_migrations += 1
-            project_config = ProjectConfig.load(path, serena_config=instance)  # instance is sufficiently populated
+            try:
+                project_config = ProjectConfig.load(path, serena_config=instance)  # instance is sufficiently populated
+            except Exception as e:
+                log.warning(
+                    "Failed to load project configuration for %s: %s. "
+                    "This project will be skipped. Fix or delete its "
+                    ".serena/project.yml (or remove it from "
+                    "serena_config.yml) to re-enable it.",
+                    path,
+                    e,
+                )
+                continue
             project = RegisteredProject(
                 project_root=str(path),
                 project_config=project_config,

--- a/test/serena/config/test_serena_config.py
+++ b/test/serena/config/test_serena_config.py
@@ -499,6 +499,62 @@ class TestProjectSerenaDataFolder:
         assert project.path_to_serena_data_folder() == str(custom_serena)
 
 
+class TestSerenaConfigFromConfigFileRobustness:
+    """Tests that ``SerenaConfig.from_config_file`` does not abort the whole
+    loader when a single registered project has a broken ``project.yml``.
+    """
+
+    def setup_method(self):
+        self.test_dir = Path(tempfile.mkdtemp())
+        self.master_config_path = self.test_dir / "serena_config.yml"
+
+    def teardown_method(self):
+        shutil.rmtree(self.test_dir)
+
+    def _make_project_dir(self, name: str, project_yml_body: str) -> Path:
+        project_dir = self.test_dir / name
+        (project_dir / SERENA_MANAGED_DIR_NAME).mkdir(parents=True)
+        (project_dir / SERENA_MANAGED_DIR_NAME / "project.yml").write_text(project_yml_body)
+        return project_dir
+
+    def _write_master_config(self, project_paths: list[Path]) -> None:
+        body_lines = ["projects:"]
+        for p in project_paths:
+            body_lines.append(f"  - {p}")
+        self.master_config_path.write_text("\n".join(body_lines) + "\n")
+
+    def test_malformed_project_is_skipped_with_warning(self, caplog, monkeypatch):
+        """A malformed project.yml must not abort loading of the others."""
+        good_project = self._make_project_dir(
+            "good_project",
+            'project_name: "good_project"\nlanguages: ["python"]\n',
+        )
+        # Invalid YAML: a stray colon at the start of a mapping value.
+        bad_project = self._make_project_dir(
+            "bad_project",
+            ": this is not : valid : yaml :\n",
+        )
+        self._write_master_config([good_project, bad_project])
+
+        # SerenaPaths is a process-wide singleton, so we cannot reliably
+        # redirect it via SERENA_HOME after the fact. Instead, redirect the
+        # config-file-path resolver directly.
+        monkeypatch.setattr(
+            SerenaConfig,
+            "_determine_config_file_path",
+            classmethod(lambda cls: str(self.master_config_path)),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            config = SerenaConfig.from_config_file(generate_if_missing=False)
+
+        registered_roots = {Path(p.project_root).resolve() for p in config.projects}
+        assert registered_roots == {good_project.resolve()}, f"Expected only the good project to be registered, got {registered_roots}"
+        assert any("Failed to load project configuration" in msg and str(bad_project.resolve()) in msg for msg in caplog.messages), (
+            f"Expected a warning naming {bad_project.resolve()}, got: {caplog.messages}"
+        )
+
+
 class TestMemoriesManagerCustomPath:
     """Tests for MemoriesManager with a custom serena data folder."""
 

--- a/test/serena/config/test_serena_config.py
+++ b/test/serena/config/test_serena_config.py
@@ -545,7 +545,7 @@ class TestSerenaConfigFromConfigFileRobustness:
             classmethod(lambda cls: str(self.master_config_path)),
         )
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.ERROR):
             config = SerenaConfig.from_config_file(generate_if_missing=False)
 
         registered_roots = {Path(p.project_root).resolve() for p in config.projects}


### PR DESCRIPTION
## Summary

`SerenaConfig.from_config_file()` iterates the `projects:` list in `serena_config.yml` and calls `ProjectConfig.load(path)` with no exception handling. **A single malformed `.serena/project.yml` (missing required key, bad language string, YAML syntax error, etc.) raises an exception that propagates out of the master loader and aborts MCP server startup before any client handshake or tool registration.**

The blast radius is "everything." Other projects in the list — even ones that would load cleanly in isolation — become unreachable. For users running Serena as an MCP server inside Claude Desktop / Claude Code / IDE integrations, the symptom is "MCP server failed to connect" with no obvious next step until they grep stderr.

This matches the failure mode behind #997. The schema-migration shim added in #704 closed the *cause* (`KeyError: 'language'` from singular→plural drift) but not the *blast radius*. Any future schema change, typo, or filesystem hiccup that raises during `ProjectConfig.load` will still take the whole server down.

## Change

Wrap `ProjectConfig.load(path, serena_config=instance)` (currently bare on line 872 of `src/serena/config/serena_config.py`) in a narrow try/except that logs a warning and continues. This matches the existing skip-with-warning pattern already used a few lines above for inaccessible paths (lines 859-866). One bad project becomes one skipped project, not a server-down event.

```python
try:
    project_config = ProjectConfig.load(path, serena_config=instance)
except Exception as e:
    log.warning(
        "Failed to load project configuration for %s: %s. "
        "This project will be skipped. Fix or delete its "
        ".serena/project.yml (or remove it from "
        "serena_config.yml) to re-enable it.",
        path, e,
    )
    continue
```

Bare `Exception` is intentional — to match #997 in spirit, *any* failure inside `ProjectConfig.load` should be survivable. Happy to narrow to a typed `ProjectConfigError` in a follow-up if preferred.

## Why this is the right shape

1. **Matches existing fault tolerance.** The same loop already uses `try/except + log.warning + continue` for inaccessible project paths (lines 859-863) and missing project.yml files (lines 864-866). This extends that discipline one level deeper to cover *malformed* project.yml.
2. **Non-breaking.** Healthy configs see zero change. A user with one broken project.yml gets a clear warning and a working MCP server with the remaining projects loaded.
3. **Tiny surface area.** ~12 lines, contained in one function, no public API change.
4. **Closes a failure class.** Schema drift is one reason `ProjectConfig.load` can throw; there will be others.

## Test plan

- [x] New unit test: `TestSerenaConfigFromConfigFileRobustness::test_malformed_project_is_skipped_with_warning` registers two projects (one healthy with valid `project.yml`, one with invalid YAML), calls `SerenaConfig.from_config_file()`, asserts that the call returns successfully, that `instance.projects` contains only the healthy project, and that a warning naming the bad path is logged.
- [x] `pytest test/serena/config/` — 52/52 pass (1 new + 51 existing).
- [x] `uv run poe type-check` (mypy) — 0 issues across 126 source + 127 test files.
- [x] `ruff check` and `ruff format --check` — clean.

## Reproducer (current `main`, no patch)

```bash
mkdir -p /tmp/broken/.serena
printf ': not valid : yaml :\n' > /tmp/broken/.serena/project.yml
# add /tmp/broken to projects: in your serena_config.yml
serena start-mcp-server --transport stdio   # crashes before MCP handshake
```

With this patch, the same setup logs:

```
WARNING serena.config.serena_config: Failed to load project configuration for
/tmp/broken: <yaml.parser.ParserError ...>. This project will be skipped.
```

…and the server starts normally with all other projects available.

## Related

- Discovered while diagnosing a Serena 0.1.4 install whose master config registered a `project.yml` scaffolded by a newer Serena CLI (plural `languages:` vs old loader's bare `data["language"]`). After upgrading to 1.1.2, the schema shim handled the case — but the fan-out failure mode would resurface on the next class of project.yml malformation, hence this PR.
- Closes the *failure mode* behind #997.