### PR TITLE
Send languageId 'typescriptreact' / 'javascriptreact' for .tsx / .jsx files

### DIFF
--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -217,6 +217,15 @@ class TypeScriptLanguageServer(SolidLanguageServer):
         def _create_launch_command(self, core_path: str) -> list[str]:
             return [core_path, "--stdio"]
 
+    def _get_language_id_for_file(self, relative_file_path: str) -> str:
+        # JSX is parsed as TS without this, which silently truncates symbol
+        # ranges at the first multi-line JSX expression.
+        if relative_file_path.endswith(".tsx"):
+            return "typescriptreact"
+        if relative_file_path.endswith(".jsx"):
+            return "javascriptreact"
+        return self.language_id
+
     def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
         """
         Returns the initialize params for the TypeScript Language Server.

--- a/test/resources/repos/typescript/test_repo/jsx_component.tsx
+++ b/test/resources/repos/typescript/test_repo/jsx_component.tsx
@@ -1,0 +1,44 @@
+// Regression fixture: mirrors the real-world pattern that caused
+// languageId=typescript (instead of typescriptreact) to truncate symbol
+// ranges at the first multi-line JSX expression.
+
+import * as React from "react"
+
+type SectionProps = { title: string; emphasised?: boolean }
+
+function Section({ title, emphasised }: SectionProps) {
+  return emphasised ? (
+    <h1 style={{ color: "red" }}>{title}</h1>
+  ) : (
+    <h2 style={{ color: "gray" }}>{title}</h2>
+  )
+}
+
+export function JsxComponent({ heading, items }: { heading: string; items: string[] }) {
+  const renderHeader = (title: string) =>
+    title.length > 10 ? (
+      <Section title={title} emphasised />
+    ) : (
+      <Section title={title} />
+    )
+
+  // The truncation bug used to cut JsxComponent's range right around here,
+  // hiding everything below from find_symbol. Keep this comment so the
+  // regression test can assert the function body extends past it.
+  const renderItem = (item: string, idx: number) => (
+    <li key={idx} style={{ marginBottom: 4 }}>
+      {item}
+    </li>
+  )
+
+  return (
+    <div>
+      {renderHeader(heading)}
+      <ul>{items.map(renderItem)}</ul>
+    </div>
+  )
+}
+
+export function trailingHelper(): string {
+  return "this symbol is invisible to find_symbol when JsxComponent's range is truncated"
+}

--- a/test/resources/repos/typescript/test_repo/tsconfig.json
+++ b/test/resources/repos/typescript/test_repo/tsconfig.json
@@ -5,8 +5,7 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "jsx": "react"
+    "skipLibCheck": true
   },
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.ts"]
 }

--- a/test/resources/repos/typescript/test_repo/tsconfig.json
+++ b/test/resources/repos/typescript/test_repo/tsconfig.json
@@ -5,7 +5,8 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "jsx": "react"
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/test/solidlsp/typescript/test_typescript_basic.py
+++ b/test/solidlsp/typescript/test_typescript_basic.py
@@ -34,6 +34,37 @@ class TestTypescriptLanguageServer:
         )
 
     @pytest.mark.parametrize("language_server", [Language.TYPESCRIPT], indirect=True)
+    def test_tsx_symbol_range_not_truncated_by_jsx(self, language_server: SolidLanguageServer) -> None:
+        # Regression: when the language id is sent as "typescript" instead of
+        # "typescriptreact" for .tsx files, tsserver parses JSX as syntax
+        # errors and recovers by truncating the enclosing symbol's range at
+        # the first multi-line JSX expression. find_symbol then returns a
+        # body that ends mid-component and hides everything below.
+        file_path = "jsx_component.tsx"
+        roots = language_server.request_document_symbols(file_path).root_symbols
+
+        jsx_component = next((s for s in roots if s.get("name") == "JsxComponent"), None)
+        assert jsx_component is not None, "JsxComponent not found at root level of jsx_component.tsx"
+
+        end_line = jsx_component["location"]["range"]["end"]["line"]
+        # JsxComponent's body extends to line 38 (0-based 37) in the fixture;
+        # the truncation bug cut it at the first multi-line JSX (~line 21).
+        # Use a generous lower bound so the test survives small fixture edits
+        # that don't affect the regression behaviour we care about.
+        assert end_line >= 30, (
+            f"JsxComponent symbol range truncated at line {end_line + 1} (1-based); "
+            f"expected end at or past line 31 (1-based). "
+            f"This indicates the .tsx file was opened with the wrong languageId."
+        )
+
+        # The trailing helper must be visible as a top-level symbol — it lives
+        # past the truncation point and disappears entirely when the bug is
+        # active because tsserver stops emitting symbols after the parse error.
+        assert any(s.get("name") == "trailingHelper" for s in roots), (
+            "trailingHelper missing from jsx_component.tsx root symbols; tsserver likely stopped parsing at the first JSX expression."
+        )
+
+    @pytest.mark.parametrize("language_server", [Language.TYPESCRIPT], indirect=True)
     def test_bare_symbol_names(self, language_server) -> None:
         all_symbols = request_all_symbols(language_server)
         malformed_symbols = []


### PR DESCRIPTION
## Problem

`TypeScriptLanguageServer` sends `languageId: \"typescript\"` for **every** file the language server opens, including `.tsx` and `.jsx`. tsserver therefore parses JSX as plain TS, treats `<Tag />` tokens as syntax errors, and recovers by truncating the enclosing symbol's range at the first multi-line JSX expression.

**Symptoms users see:**
- `find_symbol(name, include_body=True)` on a React function component returns a body that ends mid-component — everything below the first JSX disappears.
- The same component name shows up as multiple `Method`-kind symbols (one per call site) plus a separately-tracked `Constant` for the definition. tsserver is misclassifying JSX tag tokens as method references.
- `replace_symbol_body` then operates on the wrong/duplicate symbol and corrupts files. This is the underlying cause of #1029, which was closed without identifying the root cause.

## Reproducer

A real-world TSX file with an arrow-function helper whose body is a multi-line JSX ternary expression:

```
// Before fix (languageId=typescript)
SidebarPDF range = [11:1-25:207]   ← truncated at first JSX
renderSideTitle = [23:9-25:28]     ← also truncated

// After fix (languageId=typescriptreact)
SidebarPDF range = [11:1-281:2]    ← full body
renderSideTitle = [23:9-26:205]    ← full body
```

I confirmed this is exactly tsserver's behaviour by driving `typescript-language-server` directly with `languageId: \"typescript\"` vs `\"typescriptreact\"` and observing the same range divergence. Same binary, same project, only the languageId differs.

## Fix

Override `_get_language_id_for_file` on `TypeScriptLanguageServer` to return `typescriptreact` for `.tsx` and `javascriptreact` for `.jsx`. The base class hook is explicitly designed for this — its docstring says *\"Override in subclasses to return file-specific language IDs.\"*

```python
def _get_language_id_for_file(self, relative_file_path: str) -> str:
    if relative_file_path.endswith(\".tsx\"):
        return \"typescriptreact\"
    if relative_file_path.endswith(\".jsx\"):
        return \"javascriptreact\"
    return self.language_id
```

## Tests

- New fixture `test/resources/repos/typescript/test_repo/jsx_component.tsx` reproduces the failing pattern (arrow-function with multi-line JSX ternary nested inside a parent function) plus a `trailingHelper` symbol that disappears entirely when the bug is active.
- New `test_tsx_symbol_range_not_truncated_by_jsx` asserts the parent function's body covers the whole component (not just the prologue) and that `trailingHelper` appears at the root.
- `tsconfig.json` updated to include `**/*.tsx` and set `\"jsx\": \"react\"`.

I verified the new test fails on `main` (`assert 28 >= 30, JsxComponent symbol range truncated at line 29`) and passes with the fix applied.

## Notes

- Existing caches (`.serena/cache/typescript/*.pkl`) are poisoned with truncated ranges. Users will need to wipe them after upgrading. Happy to add a cache-version bump if you'd prefer.
- The vtsls adapter (`vts_language_server.py`) doesn't override `_get_language_id_for_file` either. I focused on the typescript-language-server adapter for this PR; happy to do vtsls in a follow-up if it has the same issue.

Closes the root cause behind the test cases in #1029.