### PR TITLE
fix(lsp): omit optional Content-Type header from outgoing messages

### DIFF
--- a/src/solidlsp/lsp_protocol_handler/server.py
+++ b/src/solidlsp/lsp_protocol_handler/server.py
@@ -131,11 +131,14 @@ class StopLoopException(Exception):
     pass
 
 
-def create_message(payload: PayloadLike) -> tuple[bytes, bytes, bytes]:
+def create_message(payload: PayloadLike) -> tuple[bytes, bytes]:
     body = json.dumps(payload, check_circular=False, ensure_ascii=False, separators=(",", ":")).encode(ENCODING)
+    # NOTE: only Content-Length is sent. Content-Type is optional per the LSP
+    # spec (default: application/vscode-jsonrpc; charset=utf-8), and Godot's
+    # GDScript LSP parser only handles Content-Length — any additional header
+    # makes it silently drop the message.
     return (
-        f"Content-Length: {len(body)}\r\n".encode(ENCODING),
-        "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n".encode(ENCODING),
+        f"Content-Length: {len(body)}\r\n\r\n".encode(ENCODING),
         body,
     )
 


### PR DESCRIPTION
## Summary

`create_message` currently emits both `Content-Length` and `Content-Type` headers on every outgoing LSP message. Per the LSP spec, `Content-Type` is **optional**, and its default is `application/vscode-jsonrpc; charset=utf-8` — the exact value being sent. Spec-compliant servers behave identically with or without it.

In practice, some servers have stricter parsers and break on extra headers. Concretely, Godot's GDScript LSP (`LSPeer::handle_data` in `modules/gdscript/language_server/gdscript_language_protocol.cpp`) extracts the body length via `header.substr(16).to_int()`, assuming `Content-Length` is the only header. With `Content-Type` present, Godot silently drops the message — no response, no log line, just an LSP-side timeout.

Sending only `Content-Length` is interoperable across the spec-compliant servers Serena talks to today and unblocks the stricter ones.

While here, the type signature of `create_message` is tightened from `tuple[bytes, bytes, bytes]` to `tuple[bytes, bytes]` since there is no longer a `Content-Type` element.

## Verification

Direct probe of Godot's GDScript LSP at `127.0.0.1:6005` with the same JSON body, varying only the headers:

| Frame                                              | Bytes received back |
|----------------------------------------------------|---------------------|
| `Content-Length: N\r\n\r\n<body>`                  | 1126 (full `initialize` capabilities response) |
| `Content-Length: N\r\nContent-Type: ...\r\n\r\n<body>` | 0 (silently dropped) |

After this patch, Serena's symbolic tools (`get_symbols_overview`, `find_symbol`, `find_referencing_symbols`, …) work end-to-end against a Godot 4.7 project with the editor's LSP enabled.

## Test plan

- [x] `create_message` produces a spec-valid frame: `b'Content-Length: N\r\n\r\n<body>'`
- [x] Single call site (`ls_process.py:490 → writelines(msg)`) is unaffected by the tuple-shape change (`writelines` accepts any iterable of bytes).
- [x] Inbound parser (`content_length()`, same module) only acts on `Content-Length:` lines and ignores other headers, so missing/present `Content-Type` on the *server*'s side is not affected.
- [x] No tests reference `create_message` directly (verified via `git grep`).
- [x] Existing CI suite covering Python / TypeScript / Rust / Go / etc. language servers should remain green — those servers all accept bare `Content-Length`.