### PR TITLE
Add selected C# workspace support

### DIFF
--- a/docs/02-usage/040_workflow.md
+++ b/docs/02-usage/040_workflow.md
@@ -65,6 +65,33 @@ You can specify local overrides for the settings in a `project.local.yml` file i
 (which, by default, is ignored by git). 
 Any keys defined therein will override the respective key in `project.yml`.
 
+### Selecting a C# Workspace in Large Repositories
+
+For large C# repositories that contain multiple `.sln`, `.slnx`, or standalone `.csproj` files,
+you can select the workspace Serena should target by setting `active_workspace` in `project.local.yml`.
+The path must be relative to the project root.
+
+```yaml
+active_workspace: "Hyland.Applications.Server.sln"
+```
+
+This setting is especially useful for monorepos where loading every solution is either too expensive
+or not representative of the task at hand. When `active_workspace` is set for a C# project, Serena
+passes the selected solution or project to the language server and narrows initialization and open-file
+behavior to that workspace.
+
+You can also manage the selection dynamically while Serena is running:
+
+* `list_workspace_entries` lists the available `.sln`, `.slnx`, and `.csproj` candidates in the project.
+* `set_active_workspace` switches the selected workspace and can persist the change to `project.local.yml`
+  or keep it only for the current session.
+* `get_current_config` shows the active project configuration, including the currently selected workspace.
+
+If no `active_workspace` is configured, Serena falls back to its default breadth-first workspace discovery.
+This workflow is intentionally scoped to one selected C# workspace at a time. If you need to work across
+multiple independent solutions simultaneously, use separate Serena projects or combine this with the
+`query_project` workflow described later in this guide.
+
 (indexing)=
 ### Indexing
 

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -1187,6 +1187,8 @@ class SerenaAgent:
         result_str += f"Loglevel: {self.serena_config.log_level}, trace_lsp_communication={self.serena_config.trace_lsp_communication}\n"
         if self._active_project is not None:
             result_str += f"Active project: {self._active_project.project_name}\n"
+            active_workspace = self._active_project.project_config.active_workspace or "<none>"
+            result_str += f"Active workspace: {active_workspace}\n"
         else:
             result_str += "No active project\n"
         result_str += f"Language backend: {self._language_backend.value}"

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -275,6 +275,7 @@ class ProjectConfig(SharedConfig, ModeSelectionDefinitionWithAddedModes):
     ignore_all_files_in_gitignore: bool = True
     initial_prompt: str = ""
     encoding: str = DEFAULT_SOURCE_FILE_ENCODING
+    active_workspace: str | None = None
 
     # internal fields which are not mapped to/from the configuration file (must start with "_")
     _local_override_keys: list[str] = field(default_factory=list)
@@ -499,6 +500,7 @@ class ProjectConfig(SharedConfig, ModeSelectionDefinitionWithAddedModes):
             ignore_all_files_in_gitignore=data["ignore_all_files_in_gitignore"],
             initial_prompt=data["initial_prompt"],
             encoding=data["encoding"],
+            active_workspace=data.get("active_workspace"),
             line_ending=line_ending,
             language_backend=language_backend,
             added_modes=data["added_modes"],

--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -628,6 +628,25 @@ class Project(ToStringMixin):
             source_file_path=relative_file_path,
         )
 
+    def _get_ls_specific_settings(self) -> dict:
+        """
+        Build the merged language server specific settings for the project.
+        """
+        ls_specific_settings = {**self.serena_config.ls_specific_settings, **self.project_config.ls_specific_settings}
+
+        active_workspace = self.project_config.active_workspace
+        if active_workspace is None:
+            return ls_specific_settings
+
+        for language in (Language.CSHARP, Language.CSHARP_OMNISHARP):
+            if language not in self.project_config.languages:
+                continue
+            language_settings = dict(ls_specific_settings.get(language, {}))
+            language_settings["active_workspace"] = active_workspace
+            ls_specific_settings[language] = language_settings
+
+        return ls_specific_settings
+
     def create_language_server_manager(self) -> LanguageServerManager:
         """
         Creates the language server manager for the project, starting one language server per configured programming language.
@@ -652,7 +671,7 @@ class Project(ToStringMixin):
 
             log.info(f"Creating language server manager for {self.project_root}")
             self._language_server_manager_init_error = None
-            ls_specific_settings = {**self.serena_config.ls_specific_settings, **self.project_config.ls_specific_settings}
+            ls_specific_settings = self._get_ls_specific_settings()
             factory = LanguageServerFactory(
                 project_root=self.project_root,
                 project_data_path=self._serena_data_folder,

--- a/src/serena/resources/project.local.template.yml
+++ b/src/serena/resources/project.local.template.yml
@@ -3,3 +3,6 @@
 # Use the same keys as in project.yml here. Any setting you specify will override the corresponding
 # setting in project.yml, allowing you to customise the configuration for your local development environment
 # without affecting the project configuration in project.yml (which is intended to be versioned).
+#
+# Example user-local workspace selection:
+# active_workspace: "src/Main/Main.sln"

--- a/src/serena/resources/project.template.yml
+++ b/src/serena/resources/project.template.yml
@@ -46,6 +46,11 @@ line_ending:
 # is activated post-init, an error will be returned.
 language_backend:
 
+# relative path from the project root to the currently selected workspace entry.
+# This may point to a .sln, .slnx, or .csproj file.
+# Prefer setting this in project.local.yml when the selection is user-local.
+active_workspace:
+
 # whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 

--- a/src/serena/tools/config_tools.py
+++ b/src/serena/tools/config_tools.py
@@ -1,4 +1,8 @@
 from sensai.util.helper import mark_used
+from pathlib import Path
+
+from solidlsp.language_servers.csharp_language_server import breadth_first_file_scan
+from solidlsp.ls_config import Language
 
 from serena.tools import Tool, ToolMarkerDoesNotRequireActiveProject, ToolMarkerOptional
 
@@ -64,3 +68,114 @@ class GetCurrentConfigTool(Tool):
         Print the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
         """
         return self.agent.get_current_config_overview()
+
+
+
+def _project_supports_csharp_workspace_selection(project) -> bool:
+    return Language.CSHARP in project.project_config.languages or Language.CSHARP_OMNISHARP in project.project_config.languages
+
+
+
+def _iter_csharp_workspace_entries(project_root: str, include_projects: bool) -> list[dict[str, str]]:
+    entries = []
+    root = Path(project_root).resolve()
+    for filename in breadth_first_file_scan(project_root):
+        absolute_path = Path(filename).resolve()
+        suffix = absolute_path.suffix.lower()
+        if suffix in (".sln", ".slnx"):
+            kind = "solution"
+        elif include_projects and suffix == ".csproj":
+            kind = "project"
+        else:
+            continue
+
+        relative_path = absolute_path.relative_to(root).as_posix()
+        entries.append({"path": relative_path, "kind": kind})
+    return entries
+
+
+
+def _resolve_workspace_path(project_root: str, path: str) -> tuple[str, Path]:
+    if not path:
+        raise ValueError("Workspace path must not be empty.")
+
+    root = Path(project_root).resolve()
+    candidate = Path(path)
+    absolute_path = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+
+    try:
+        relative_path = absolute_path.relative_to(root).as_posix()
+    except ValueError as e:
+        raise ValueError(f"Workspace path '{path}' must be inside the active project root {project_root}.") from e
+
+    if not absolute_path.is_file():
+        raise ValueError(f"Workspace path '{path}' does not resolve to a file.")
+
+    if absolute_path.suffix.lower() not in (".sln", ".slnx", ".csproj"):
+        raise ValueError("Workspace path must point to a .sln, .slnx, or .csproj file.")
+
+    return relative_path, absolute_path
+
+
+class ListWorkspaceEntriesTool(Tool):
+    """
+    Lists candidate C# workspace entries under the active project root.
+    """
+
+    def apply(self, kind: str = "csharp", include_projects: bool = True) -> str:
+        """
+        Lists candidate workspace entries for the active project.
+
+        :param kind: workspace kind to list. Currently only 'csharp' is supported.
+        :param include_projects: whether to include .csproj files in addition to solutions
+        """
+        if kind != "csharp":
+            raise ValueError("Only kind='csharp' is currently supported.")
+
+        project = self.project
+        if not _project_supports_csharp_workspace_selection(project):
+            raise ValueError("Workspace selection is currently only supported for C# projects.")
+
+        selected_path = Path(project.project_config.active_workspace).as_posix() if project.project_config.active_workspace else None
+        entries = _iter_csharp_workspace_entries(project.project_root, include_projects)
+        for entry in entries:
+            entry["selected"] = entry["path"] == selected_path  # type: ignore[index]
+        return self._to_json(entries)
+
+
+class SetActiveWorkspaceTool(Tool):
+    """
+    Sets the active workspace entry for the active project.
+    """
+
+    def apply(self, path: str, persist_mode: str = "project_local", restart: bool = True) -> str:
+        """
+        Sets the active workspace entry for the active project.
+
+        :param path: relative or absolute path to the selected workspace entry
+        :param persist_mode: whether to persist to project.local.yml or only change the current session
+        :param restart: whether to restart the language server manager after changing the active workspace
+        """
+        if persist_mode not in ("project_local", "session"):
+            raise ValueError("persist_mode must be either 'project_local' or 'session'.")
+
+        project = self.project
+        if not _project_supports_csharp_workspace_selection(project):
+            raise ValueError("Workspace selection is currently only supported for C# projects.")
+
+        relative_path, absolute_path = _resolve_workspace_path(project.project_root, path)
+        project.project_config.active_workspace = relative_path
+
+        if persist_mode == "project_local":
+            if "active_workspace" not in project.project_config._local_override_keys:
+                project.project_config._local_override_keys.append("active_workspace")
+            project.save_config()
+
+        if restart:
+            self.agent.reset_language_server_manager()
+
+        suffix = absolute_path.suffix.lower()
+        return (
+            f"Active workspace set to '{relative_path}' ({suffix}) "
+            f"with persist_mode='{persist_mode}' and restart={str(restart).lower()}."
+        )

--- a/src/solidlsp/language_servers/csharp_language_server.py
+++ b/src/solidlsp/language_servers/csharp_language_server.py
@@ -8,7 +8,7 @@ import platform
 import shutil
 import threading
 from collections.abc import Hashable, Iterable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -179,6 +179,54 @@ def find_solution_or_project_file(root_dir: str) -> str | None:
     return csproj_file
 
 
+@dataclass(frozen=True)
+class SelectedWorkspaceEntry:
+    path: str
+    workspace_root: str
+    kind: str
+
+
+def resolve_selected_workspace_entry(repository_root_path: str, active_workspace: str | None) -> SelectedWorkspaceEntry | None:
+    """
+    Resolve the configured workspace entry against the repository root.
+    """
+    if not isinstance(active_workspace, str) or not active_workspace:
+        return None
+
+    repository_root = Path(repository_root_path).resolve()
+    selected_path = (repository_root / active_workspace).resolve()
+
+    try:
+        selected_path.relative_to(repository_root)
+    except ValueError:
+        log.warning(
+            "Ignoring active_workspace '%s' because it is outside the repository root %s",
+            active_workspace,
+            repository_root_path,
+        )
+        return None
+
+    if not selected_path.is_file():
+        log.warning(
+            "Ignoring active_workspace '%s' because it does not resolve to a file under %s",
+            active_workspace,
+            repository_root_path,
+        )
+        return None
+
+    suffix = selected_path.suffix.lower()
+    if suffix in (".sln", ".slnx"):
+        return SelectedWorkspaceEntry(path=str(selected_path), workspace_root=str(selected_path.parent), kind="solution")
+    if suffix == ".csproj":
+        return SelectedWorkspaceEntry(path=str(selected_path), workspace_root=str(selected_path.parent), kind="project")
+
+    log.warning(
+        "Ignoring active_workspace '%s' because only .sln, .slnx, and .csproj entries are supported",
+        active_workspace,
+    )
+    return None
+
+
 class CSharpLanguageServer(SolidLanguageServer):
     """
     Provides C# specific instantiation of the LanguageServer class using the official Roslyn-based
@@ -331,8 +379,11 @@ class CSharpLanguageServer(SolidLanguageServer):
             self._dotnet_path, self._language_server_path = self._ensure_server_installed()
 
         def create_launch_command(self) -> list[str]:
-            # Find solution or project file
-            solution_or_project = find_solution_or_project_file(self._repository_root_path)
+            selected_workspace = resolve_selected_workspace_entry(
+                self._repository_root_path,
+                cast(str | None, self._custom_settings.get("active_workspace")),
+            )
+            solution_or_project = selected_workspace.path if selected_workspace is not None else find_solution_or_project_file(self._repository_root_path)
 
             # Create log directory
             log_dir = Path(self._ls_resources_dir) / "logs"
@@ -342,7 +393,9 @@ class CSharpLanguageServer(SolidLanguageServer):
             cmd = [self._dotnet_path, self._language_server_path, "--logLevel=Information", f"--extensionLogDirectory={log_dir}", "--stdio"]
 
             # The language server will discover the solution/project from the workspace root
-            if solution_or_project:
+            if selected_workspace is not None:
+                log.info(f"Using configured workspace entry: {selected_workspace.path}")
+            elif solution_or_project:
                 log.info(f"Found solution/project file: {solution_or_project}")
             else:
                 log.warning("No .sln/.slnx or .csproj file found, language server will attempt auto-discovery")
@@ -480,18 +533,29 @@ class CSharpLanguageServer(SolidLanguageServer):
             except Exception as e:
                 raise SolidLSPException(f"Failed to download package {package_name} version {package_version} from NuGet.org: {e}") from e
 
+    def _get_selected_workspace_entry(self) -> SelectedWorkspaceEntry | None:
+        """
+        Resolve the configured active workspace for the current project.
+        """
+        return resolve_selected_workspace_entry(
+            self.repository_root_path,
+            cast(str | None, self._custom_settings.get("active_workspace")),
+        )
+
     def _get_initialize_params(self) -> InitializeParams:
         """
         Returns the initialize params for the Microsoft.CodeAnalysis.LanguageServer.
         """
-        root_uri = PathUtils.path_to_uri(self.repository_root_path)
-        root_name = os.path.basename(self.repository_root_path)
+        selected_workspace = self._get_selected_workspace_entry()
+        workspace_root = selected_workspace.workspace_root if selected_workspace is not None else self.repository_root_path
+        root_uri = PathUtils.path_to_uri(workspace_root)
+        root_name = os.path.basename(workspace_root)
         return cast(
             InitializeParams,
             {
                 "workspaceFolders": [{"uri": root_uri, "name": root_name}],
                 "processId": os.getpid(),
-                "rootPath": self.repository_root_path,
+                "rootPath": workspace_root,
                 "rootUri": root_uri,
                 "capabilities": {
                     "window": {
@@ -733,6 +797,18 @@ class CSharpLanguageServer(SolidLanguageServer):
         """
         Open solution and project files using notifications.
         """
+        selected_workspace = self._get_selected_workspace_entry()
+        if selected_workspace is not None:
+            selected_uri = PathUtils.path_to_uri(selected_workspace.path)
+            if selected_workspace.kind == "solution":
+                self.server.notify.send_notification("solution/open", {"solution": selected_uri})
+                log.debug(f"Opened configured solution file: {selected_workspace.path}")
+                return
+
+            self.server.notify.send_notification("project/open", {"projects": [selected_uri]})
+            log.debug(f"Opened configured project file: {selected_workspace.path}")
+            return
+
         # Find solution file (.sln or .slnx)
         solution_file = None
         for filename in breadth_first_file_scan(self.repository_root_path):

--- a/test/serena/config/test_serena_config.py
+++ b/test/serena/config/test_serena_config.py
@@ -201,6 +201,146 @@ class TestProjectConfigLanguageBackend:
         assert config.language_backend is None
 
 
+class TestProjectConfigActiveWorkspace:
+    """Tests for the per-project active_workspace field."""
+
+    def setup_method(self):
+        """Set up test environment before each test method."""
+        self.test_dir = tempfile.mkdtemp()
+        self.serena_config = create_default_serena_config()
+        self.project_path = Path(self.test_dir)
+
+    def teardown_method(self):
+        """Clean up test environment after each test method."""
+        shutil.rmtree(self.test_dir)
+
+    def test_active_workspace_defaults_to_none(self):
+        config = ProjectConfig(
+            project_name="test",
+            languages=[Language.PYTHON],
+        )
+        assert config.active_workspace is None
+
+    def test_active_workspace_roundtrips_through_yaml(self):
+        config = ProjectConfig(
+            project_name="test",
+            languages=[Language.PYTHON],
+            active_workspace="src/Main/Main.sln",
+        )
+        d = config._to_yaml_dict()
+        assert d["active_workspace"] == "src/Main/Main.sln"
+
+    def test_active_workspace_parsed_from_dict(self):
+        """Test that _from_dict parses active_workspace correctly."""
+        data, _ = ProjectConfig._load_yaml_dict(PROJECT_TEMPLATE_FILE)
+        data["project_name"] = "test"
+        data["languages"] = ["python"]
+        data["active_workspace"] = "src/Main/Main.sln"
+        config = ProjectConfig._from_dict(data, local_override_keys=[])
+        assert config.active_workspace == "src/Main/Main.sln"
+
+    def test_active_workspace_none_when_missing_from_dict(self):
+        """Test that _from_dict handles missing active_workspace gracefully."""
+        data, _ = ProjectConfig._load_yaml_dict(PROJECT_TEMPLATE_FILE)
+        data["project_name"] = "test"
+        data["languages"] = ["python"]
+        data.pop("active_workspace", None)
+        config = ProjectConfig._from_dict(data, local_override_keys=[])
+        assert config.active_workspace is None
+
+    def test_active_workspace_persists_to_project_local_yml(self):
+        ProjectConfig.autogenerate(
+            self.project_path,
+            self.serena_config,
+            languages=[Language.PYTHON],
+            save_to_disk=True,
+        )
+        project_yml_path = self.serena_config.get_project_yml_location(self.project_path)
+        config = ProjectConfig.load(self.project_path, self.serena_config)
+        config.active_workspace = "src/Main/Main.sln"
+        config._local_override_keys = ["active_workspace"]
+
+        config.save(project_yml_path)
+
+        project_yml_data, _ = ProjectConfig._load_yaml_dict(project_yml_path)
+        project_local_yml_path = ProjectConfig._project_local_yml_path(project_yml_path)
+        project_local_yml_data, _ = ProjectConfig._load_yaml_dict(project_local_yml_path, apply_defaults=False)
+        reloaded_config = ProjectConfig.load(self.project_path, self.serena_config)
+
+        assert project_yml_data["active_workspace"] is None
+        assert project_local_yml_data["active_workspace"] == "src/Main/Main.sln"
+        assert reloaded_config.active_workspace == "src/Main/Main.sln"
+        assert "active_workspace" in reloaded_config._local_override_keys
+
+
+class TestProjectLanguageServerSettings:
+    """Tests for Project language server settings propagation."""
+
+    def test_active_workspace_is_injected_into_csharp_settings(self, monkeypatch, tmp_path):
+        serena_config = create_default_serena_config()
+        project = Project(
+            project_root=str(tmp_path),
+            project_config=ProjectConfig(
+                project_name="test",
+                languages=[Language.CSHARP],
+                active_workspace="src/Main/Main.sln",
+                ls_specific_settings={Language.CSHARP: {"existing_setting": "value"}},
+            ),
+            serena_config=serena_config,
+        )
+        captured: dict[str, object] = {}
+
+        class DummyManager:
+            def stop_all(self) -> None:
+                return None
+
+        def fake_from_languages(languages, factory):
+            captured["languages"] = languages
+            captured["ls_specific_settings"] = factory.ls_specific_settings
+            return DummyManager()
+
+        monkeypatch.setattr("serena.project.LanguageServerManager.from_languages", fake_from_languages)
+
+        manager = project.create_language_server_manager()
+
+        assert manager is project.language_server_manager
+        assert captured["languages"] == [Language.CSHARP]
+        csharp_settings = captured["ls_specific_settings"][Language.CSHARP]
+        assert csharp_settings["existing_setting"] == "value"
+        assert csharp_settings["active_workspace"] == "src/Main/Main.sln"
+
+    def test_active_workspace_is_not_injected_when_unset(self, monkeypatch, tmp_path):
+        serena_config = create_default_serena_config()
+        project = Project(
+            project_root=str(tmp_path),
+            project_config=ProjectConfig(
+                project_name="test",
+                languages=[Language.CSHARP],
+                ls_specific_settings={Language.CSHARP: {"existing_setting": "value"}},
+            ),
+            serena_config=serena_config,
+        )
+        captured: dict[str, object] = {}
+
+        class DummyManager:
+            def stop_all(self) -> None:
+                return None
+
+        def fake_from_languages(languages, factory):
+            captured["languages"] = languages
+            captured["ls_specific_settings"] = factory.ls_specific_settings
+            return DummyManager()
+
+        monkeypatch.setattr("serena.project.LanguageServerManager.from_languages", fake_from_languages)
+
+        project.create_language_server_manager()
+
+        assert captured["languages"] == [Language.CSHARP]
+        csharp_settings = captured["ls_specific_settings"][Language.CSHARP]
+        assert csharp_settings["existing_setting"] == "value"
+        assert "active_workspace" not in csharp_settings
+
+
 def _make_config_with_project(
     project_name: str,
     language_backend: LanguageBackend | None = None,

--- a/test/serena/test_config_tools.py
+++ b/test/serena/test_config_tools.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from serena.config.serena_config import ProjectConfig
+from serena.project import Project
+from serena.tools.config_tools import ListWorkspaceEntriesTool, SetActiveWorkspaceTool
+from solidlsp.ls_config import Language
+from test.conftest import create_default_serena_config
+
+
+class StubAgent:
+    def __init__(self, project: Project):
+        self._project = project
+        self.reset_calls = 0
+
+    def get_active_project_or_raise(self) -> Project:
+        return self._project
+
+    def reset_language_server_manager(self) -> None:
+        self.reset_calls += 1
+
+
+
+def _create_csharp_project(tmp_path: Path) -> Project:
+    main_dir = tmp_path / "src" / "Main"
+    main_dir.mkdir(parents=True)
+    (main_dir / "Main.sln").touch()
+    (main_dir / "Main.csproj").touch()
+
+    other_dir = tmp_path / "src" / "Other"
+    other_dir.mkdir(parents=True)
+    (other_dir / "Other.sln").touch()
+
+    serena_config = create_default_serena_config()
+    ProjectConfig.autogenerate(tmp_path, serena_config, languages=[Language.CSHARP], save_to_disk=True)
+    return Project.load(tmp_path, serena_config)
+
+
+class TestWorkspaceConfigTools:
+    def test_list_workspace_entries_marks_selected_entry(self, tmp_path: Path) -> None:
+        project = _create_csharp_project(tmp_path)
+        project.project_config.active_workspace = "src/Main/Main.sln"
+
+        entries = json.loads(ListWorkspaceEntriesTool(StubAgent(project)).apply())
+
+        assert {"path": "src/Main/Main.sln", "kind": "solution", "selected": True} in entries
+        assert {"path": "src/Main/Main.csproj", "kind": "project", "selected": False} in entries
+        assert {"path": "src/Other/Other.sln", "kind": "solution", "selected": False} in entries
+
+    def test_set_active_workspace_persists_to_project_local_and_restarts(self, tmp_path: Path) -> None:
+        project = _create_csharp_project(tmp_path)
+        agent = StubAgent(project)
+        result = SetActiveWorkspaceTool(agent).apply("src/Main/Main.sln")
+        reloaded = Project.load(tmp_path, project.serena_config)
+
+        assert project.project_config.active_workspace == "src/Main/Main.sln"
+        assert "active_workspace" in project.project_config._local_override_keys
+        assert reloaded.project_config.active_workspace == "src/Main/Main.sln"
+        assert "active_workspace" in reloaded.project_config._local_override_keys
+        assert agent.reset_calls == 1
+        assert "src/Main/Main.sln" in result
+
+    def test_set_active_workspace_session_mode_does_not_write_to_disk(self, tmp_path: Path) -> None:
+        project = _create_csharp_project(tmp_path)
+        agent = StubAgent(project)
+        SetActiveWorkspaceTool(agent).apply("src/Main/Main.sln", persist_mode="session", restart=False)
+        reloaded = Project.load(tmp_path, project.serena_config)
+
+        assert project.project_config.active_workspace == "src/Main/Main.sln"
+        assert reloaded.project_config.active_workspace is None
+        assert agent.reset_calls == 0
+
+    def test_set_active_workspace_rejects_path_outside_project_root(self, tmp_path: Path) -> None:
+        project = _create_csharp_project(tmp_path)
+        outside_dir = tmp_path.parent / f"{tmp_path.name}_outside"
+        outside_dir.mkdir()
+        outside_file = outside_dir / "Outside.sln"
+        outside_file.touch()
+
+        with pytest.raises(ValueError, match="inside the active project root"):
+            SetActiveWorkspaceTool(StubAgent(project)).apply(str(outside_file))

--- a/test/serena/test_serena_agent.py
+++ b/test/serena/test_serena_agent.py
@@ -870,6 +870,15 @@ class TestSerenaAgent:
         serena_config = SerenaConfig(gui_log_window=False, web_dashboard=False)
         SerenaAgent(project=project, serena_config=serena_config)
 
+
+    @pytest.mark.parametrize("serena_agent", [Language.PYTHON], indirect=True)
+    def test_current_config_overview_includes_active_workspace(self, serena_agent: SerenaAgent) -> None:
+        serena_agent.get_active_project_or_raise().project_config.active_workspace = "demo/Main.sln"
+
+        result = serena_agent.get_current_config_overview()
+
+        assert "Active workspace: demo/Main.sln" in result
+
     def _symbol_matches_expected_name(self, symbol: dict, expected_name: str) -> bool:
         return (
             symbol.get("name") == expected_name

--- a/test/solidlsp/csharp/test_csharp_basic.py
+++ b/test/solidlsp/csharp/test_csharp_basic.py
@@ -13,6 +13,7 @@ from solidlsp.language_servers.csharp_language_server import (
     CSharpLanguageServer,
     breadth_first_file_scan,
     find_solution_or_project_file,
+    resolve_selected_workspace_entry,
 )
 from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_types import SymbolKind
@@ -20,6 +21,19 @@ from solidlsp.ls_utils import SymbolUtils
 from solidlsp.settings import SolidLSPSettings
 from test.conftest import find_identifier_position, get_repo_path, language_has_verified_implementation_support
 from test.solidlsp.conftest import format_symbol_for_assert, has_malformed_name, request_all_symbols
+
+
+def _make_csharp_language_server_stub(repository_root: Path, active_workspace: str | None = None) -> CSharpLanguageServer:
+    server = object.__new__(CSharpLanguageServer)
+    server.repository_root_path = str(repository_root)
+    settings = {}
+    if active_workspace is not None:
+        settings["active_workspace"] = active_workspace
+    server._custom_settings = SolidLSPSettings.CustomLSSettings(settings)
+    server.server = Mock()
+    server.server.notify = Mock()
+    server.server.notify.send_notification = Mock()
+    return server
 
 
 @pytest.mark.csharp
@@ -313,6 +327,76 @@ class TestCSharpSolutionProjectOpening:
 
             # Should still prefer .sln file even though it's deeper
             assert result == str(solution_file)
+
+
+    def test_resolve_selected_workspace_entry_returns_solution_details(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            solution_dir = temp_path / "src" / "Main"
+            solution_dir.mkdir(parents=True)
+            solution_file = solution_dir / "Main.sln"
+            solution_file.touch()
+
+            workspace_entry = resolve_selected_workspace_entry(str(temp_path), "src/Main/Main.sln")
+
+            assert workspace_entry is not None
+            assert workspace_entry.kind == "solution"
+            assert workspace_entry.path == str(solution_file)
+            assert workspace_entry.workspace_root == str(solution_dir)
+
+    def test_get_initialize_params_uses_selected_workspace_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            solution_dir = temp_path / "src" / "Main"
+            solution_dir.mkdir(parents=True)
+            solution_file = solution_dir / "Main.sln"
+            solution_file.touch()
+            language_server = _make_csharp_language_server_stub(temp_path, "src/Main/Main.sln")
+
+            initialize_params = language_server._get_initialize_params()
+
+            expected_root = str(solution_dir)
+            expected_uri = Path(expected_root).as_uri()
+            assert initialize_params["rootPath"] == expected_root
+            assert initialize_params["rootUri"] == expected_uri
+            assert initialize_params["workspaceFolders"] == [{"uri": expected_uri, "name": "Main"}]
+
+    def test_open_solution_and_projects_uses_selected_solution_only(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            solution_dir = temp_path / "src" / "Main"
+            solution_dir.mkdir(parents=True)
+            solution_file = solution_dir / "Main.sln"
+            solution_file.touch()
+            stray_project_dir = temp_path / "src" / "Other"
+            stray_project_dir.mkdir(parents=True)
+            (stray_project_dir / "Other.csproj").touch()
+            language_server = _make_csharp_language_server_stub(temp_path, "src/Main/Main.sln")
+
+            language_server._open_solution_and_projects()
+
+            language_server.server.notify.send_notification.assert_called_once_with(
+                "solution/open",
+                {"solution": solution_file.as_uri()},
+            )
+
+    def test_open_solution_and_projects_uses_selected_project_only(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            project_dir = temp_path / "src" / "Main"
+            project_dir.mkdir(parents=True)
+            project_file = project_dir / "Main.csproj"
+            project_file.touch()
+            stray_solution = temp_path / "Main.sln"
+            stray_solution.touch()
+            language_server = _make_csharp_language_server_stub(temp_path, "src/Main/Main.csproj")
+
+            language_server._open_solution_and_projects()
+
+            language_server.server.notify.send_notification.assert_called_once_with(
+                "project/open",
+                {"projects": [project_file.as_uri()]},
+            )
 
     @patch("solidlsp.language_servers.csharp_language_server.CSharpLanguageServer.DependencyProvider._ensure_server_installed")
     @patch("solidlsp.language_servers.csharp_language_server.CSharpLanguageServer._start_server")

--- a/test/solidlsp/csharp/test_csharp_workspace_selection.py
+++ b/test/solidlsp/csharp/test_csharp_workspace_selection.py
@@ -1,0 +1,173 @@
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import Mock, call
+
+import pytest
+
+from solidlsp.language_servers.csharp_language_server import CSharpLanguageServer, resolve_selected_workspace_entry
+from solidlsp.settings import SolidLSPSettings
+
+
+@dataclass
+class CSharpWorkspaceFixture:
+    repository_root: Path
+    main_solution: Path
+    secondary_solutionx: Path
+    standalone_project: Path
+    stray_project: Path
+
+    def relative_path(self, path: Path) -> str:
+        return path.relative_to(self.repository_root).as_posix()
+
+
+@dataclass
+class CSharpFallbackFixture:
+    repository_root: Path
+    fallback_solution: Path
+    stray_project: Path
+
+
+def _make_csharp_language_server_stub(repository_root: Path, active_workspace: str | None = None) -> CSharpLanguageServer:
+    server = object.__new__(CSharpLanguageServer)
+    server.repository_root_path = str(repository_root)
+    settings = {}
+    if active_workspace is not None:
+        settings["active_workspace"] = active_workspace
+    server._custom_settings = SolidLSPSettings.CustomLSSettings(settings)
+    server.server = Mock()
+    server.server.notify = Mock()
+    server.server.notify.send_notification = Mock()
+    return server
+
+
+def _create_workspace_fixture(tmp_path: Path) -> CSharpWorkspaceFixture:
+    repository_root = tmp_path / "repo"
+    repository_root.mkdir()
+
+    main_solution = repository_root / "workspaces" / "Main" / "Main.sln"
+    main_solution.parent.mkdir(parents=True)
+    main_solution.touch()
+
+    secondary_solutionx = repository_root / "workspaces" / "Secondary" / "Secondary.slnx"
+    secondary_solutionx.parent.mkdir(parents=True)
+    secondary_solutionx.touch()
+
+    standalone_project = repository_root / "apps" / "Standalone" / "Standalone.csproj"
+    standalone_project.parent.mkdir(parents=True)
+    standalone_project.touch()
+
+    stray_project = repository_root / "StrayRoot.csproj"
+    stray_project.touch()
+
+    return CSharpWorkspaceFixture(
+        repository_root=repository_root,
+        main_solution=main_solution,
+        secondary_solutionx=secondary_solutionx,
+        standalone_project=standalone_project,
+        stray_project=stray_project,
+    )
+
+
+def _create_fallback_fixture(tmp_path: Path) -> CSharpFallbackFixture:
+    repository_root = tmp_path / "repo"
+    repository_root.mkdir()
+
+    fallback_solution = repository_root / "workspace" / "Fallback" / "Fallback.sln"
+    fallback_solution.parent.mkdir(parents=True)
+    fallback_solution.touch()
+
+    stray_project = repository_root / "StrayRoot.csproj"
+    stray_project.touch()
+
+    return CSharpFallbackFixture(
+        repository_root=repository_root,
+        fallback_solution=fallback_solution,
+        stray_project=stray_project,
+    )
+
+
+@pytest.mark.csharp
+class TestCSharpWorkspaceSelection:
+    def test_resolve_selected_workspace_entry_supports_slnx(self, tmp_path: Path) -> None:
+        fixture = _create_workspace_fixture(tmp_path)
+
+        workspace_entry = resolve_selected_workspace_entry(
+            str(fixture.repository_root),
+            fixture.relative_path(fixture.secondary_solutionx),
+        )
+
+        assert workspace_entry is not None
+        assert workspace_entry.kind == "solution"
+        assert workspace_entry.path == str(fixture.secondary_solutionx)
+        assert workspace_entry.workspace_root == str(fixture.secondary_solutionx.parent)
+
+    def test_get_initialize_params_uses_selected_project_root(self, tmp_path: Path) -> None:
+        fixture = _create_workspace_fixture(tmp_path)
+        language_server = _make_csharp_language_server_stub(
+            fixture.repository_root,
+            fixture.relative_path(fixture.standalone_project),
+        )
+
+        initialize_params = language_server._get_initialize_params()
+
+        expected_root = str(fixture.standalone_project.parent)
+        expected_uri = fixture.standalone_project.parent.as_uri()
+        assert initialize_params["rootPath"] == expected_root
+        assert initialize_params["rootUri"] == expected_uri
+        assert initialize_params["workspaceFolders"] == [{"uri": expected_uri, "name": "Standalone"}]
+
+    def test_open_solution_and_projects_uses_selected_solution_only(self, tmp_path: Path) -> None:
+        fixture = _create_workspace_fixture(tmp_path)
+        language_server = _make_csharp_language_server_stub(
+            fixture.repository_root,
+            fixture.relative_path(fixture.main_solution),
+        )
+
+        language_server._open_solution_and_projects()
+
+        language_server.server.notify.send_notification.assert_called_once_with(
+            "solution/open",
+            {"solution": fixture.main_solution.as_uri()},
+        )
+
+    def test_open_solution_and_projects_uses_selected_solutionx_only(self, tmp_path: Path) -> None:
+        fixture = _create_workspace_fixture(tmp_path)
+        language_server = _make_csharp_language_server_stub(
+            fixture.repository_root,
+            fixture.relative_path(fixture.secondary_solutionx),
+        )
+
+        language_server._open_solution_and_projects()
+
+        language_server.server.notify.send_notification.assert_called_once_with(
+            "solution/open",
+            {"solution": fixture.secondary_solutionx.as_uri()},
+        )
+
+    def test_open_solution_and_projects_uses_selected_project_only(self, tmp_path: Path) -> None:
+        fixture = _create_workspace_fixture(tmp_path)
+        language_server = _make_csharp_language_server_stub(
+            fixture.repository_root,
+            fixture.relative_path(fixture.standalone_project),
+        )
+
+        language_server._open_solution_and_projects()
+
+        language_server.server.notify.send_notification.assert_called_once_with(
+            "project/open",
+            {"projects": [fixture.standalone_project.as_uri()]},
+        )
+
+    def test_open_solution_and_projects_falls_back_when_selected_workspace_is_stale(self, tmp_path: Path) -> None:
+        fixture = _create_fallback_fixture(tmp_path)
+        language_server = _make_csharp_language_server_stub(
+            fixture.repository_root,
+            "workspace/Missing/Missing.sln",
+        )
+
+        language_server._open_solution_and_projects()
+
+        assert language_server.server.notify.send_notification.mock_calls == [
+            call("solution/open", {"solution": fixture.fallback_solution.as_uri()}),
+            call("project/open", {"projects": [fixture.stray_project.as_uri()]}),
+        ]


### PR DESCRIPTION
## Summary
- add `active_workspace` persistence and template support for C# `.sln`, `.slnx`, and `.csproj` selection
- pass the selected workspace through existing LS settings, narrow C# initialize/open behavior to the selected workspace, and add runtime tools to list/switch workspace entries
- surface the active workspace in `get_current_config` and document the large-repository workflow
- add focused config, tool, agent, and C# workspace-selection tests

## Validation
- `uv run python -m pytest test/serena/test_serena_agent.py -k active_workspace test/serena/config/test_serena_config.py test/serena/test_config_tools.py test/solidlsp/csharp/test_csharp_basic.py -q`
- `uv run python -m pytest test/solidlsp/csharp/test_csharp_basic.py test/solidlsp/csharp/test_csharp_workspace_selection.py test/serena/config/test_serena_config.py test/serena/test_config_tools.py test/serena/test_serena_agent.py -k "active_workspace or csharp_workspace_selection or csharp or workspace" -q`

## Dogfooding
- exercised the flow against `C:\OnBase.NET` using `serena-dev`
- verified workspace switching and semantic queries under multiple solutions, including `OnBase.NET.Master.sln`, `Hyland.Applications.Server.sln`, and `Hyland.Applications.Web.Client.sln`
