### PR TITLE
solidlsp: support more C++ file extensions

### DIFF
--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -285,7 +285,7 @@ class Language(str, Enum):
             case self.RUBY_SOLARGRAPH:
                 return FilenameMatcher(".rb")
             case self.CPP | self.CPP_CCLS:
-                return FilenameMatcher(".cpp", ".h", ".hpp", ".c", ".hxx", ".cc", ".cxx")
+                return FilenameMatcher(".C", ".cc", ".cpp", ".cxx", ".c++", ".h", ".H", ".hh", ".hpp", ".hxx", ".h++", ".cppm", ".ixx")
             case self.KOTLIN:
                 return FilenameMatcher(".kt", ".kts")
             case self.DART:


### PR DESCRIPTION
Solidlsp needlessly filters out valid C++ file extensions. As far as I'm aware, there is no official list. Current list (of popular file extensions) was taken from the C++ Wikipedia page.