### PR TITLE
Optimize glob_match, search_text, scan_directory

### DIFF
--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -427,14 +427,23 @@ class Project(ToStringMixin):
             )
         return self.__ignored_patterns
 
-    def _is_ignored_relative_path(self, relative_path: str | Path, ignore_non_source_files: bool = True) -> bool:
+    def _is_ignored_relative_path(
+        self,
+        relative_path: str | Path,
+        ignore_non_source_files: bool = True,
+        is_dir: bool | None = None,
+    ) -> bool:
         """
         Determine whether an existing path should be ignored based on file type and ignore patterns.
-        Raises `FileNotFoundError` if the path does not exist.
+        Raises `FileNotFoundError` if the path does not exist *and* ``is_dir`` was not supplied.
 
         :param relative_path: Relative path to check
         :param ignore_non_source_files: whether files that are not source files (according to the file masks
             determined by the project's programming language) shall be ignored
+        :param is_dir: whether ``relative_path`` refers to a directory; if the caller already knows
+            (typically from ``os.scandir(...).is_dir()``), passing it here avoids ``os.path.exists``
+            and ``os.path.isfile`` syscalls per call. ``None`` falls back to the syscall path
+            (and to the existing FileNotFoundError contract).
 
         :return: whether the path should be ignored
         """
@@ -445,11 +454,16 @@ class Project(ToStringMixin):
             return False
 
         abs_path = os.path.join(self.project_root, relative_path)
-        if not os.path.exists(abs_path):
-            raise FileNotFoundError(f"File {abs_path} not found, the ignore check cannot be performed")
+
+        # determine kind: prefer the caller's hint, fall back to syscalls
+        if is_dir is None:
+            if not os.path.exists(abs_path):
+                raise FileNotFoundError(f"File {abs_path} not found, the ignore check cannot be performed")
+            is_file = os.path.isfile(abs_path)
+        else:
+            is_file = not is_dir
 
         # Check file extension if it's a file
-        is_file = os.path.isfile(abs_path)
         if is_file and ignore_non_source_files:
             is_file_in_supported_language = False
             for language in self.project_config.languages:
@@ -467,15 +481,25 @@ class Project(ToStringMixin):
         if len(rel_path.parts) > 0 and ".git" in rel_path.parts:
             return True
 
-        return match_path(str(relative_path), self._ignore_spec, root_path=self.project_root)
+        # forward the kind to match_path so it skips its own os.path.isdir syscall
+        return match_path(str(relative_path), self._ignore_spec, root_path=self.project_root, is_dir=not is_file)
 
-    def is_ignored_path(self, path: str | Path, ignore_non_source_files: bool = False) -> bool:
+    def is_ignored_path(
+        self,
+        path: str | Path,
+        ignore_non_source_files: bool = False,
+        is_dir: bool | None = None,
+    ) -> bool:
         """
         Checks whether the given path is ignored
 
         :param path: the path to check, can be absolute or relative
         :param ignore_non_source_files: whether to ignore files that are not source files
             (according to the file masks determined by the project's programming language)
+        :param is_dir: whether ``path`` refers to a directory; forwarded to the underlying
+            check to skip per-call ``os.path.exists`` / ``os.path.isfile`` syscalls when known.
+            Particularly worth threading through from ``scan_directory``, which has the kind
+            from ``os.scandir(...).is_dir()`` already.
         """
         path = Path(path)
         if path.is_absolute():
@@ -489,7 +513,7 @@ class Project(ToStringMixin):
         else:
             relative_path = path
 
-        return self._is_ignored_relative_path(str(relative_path), ignore_non_source_files=ignore_non_source_files)
+        return self._is_ignored_relative_path(str(relative_path), ignore_non_source_files=ignore_non_source_files, is_dir=is_dir)
 
     def is_path_in_project(self, path: str | Path) -> bool:
         """

--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -112,12 +112,22 @@ class ListDirTool(Tool):
 
         self.project.validate_relative_path(relative_path, require_not_ignored=skip_ignored_files)
 
+        # scan_directory already knows the entry kind from os.scandir, so we wrap is_ignored_path
+        # to thread is_dir through and skip its os.path.exists / os.path.isfile syscalls.
+        if skip_ignored_files:
+            project = self.project
+            is_ignored_dir = lambda p: project.is_ignored_path(p, is_dir=True)
+            is_ignored_file = lambda p: project.is_ignored_path(p, is_dir=False)
+        else:
+            is_ignored_dir = None
+            is_ignored_file = None
+
         dirs, files = scan_directory(
             os.path.join(self.get_project_root(), relative_path),
             relative_to=self.get_project_root(),
             recursive=recursive,
-            is_ignored_dir=self.project.is_ignored_path if skip_ignored_files else None,
-            is_ignored_file=self.project.is_ignored_path if skip_ignored_files else None,
+            is_ignored_dir=is_ignored_dir,
+            is_ignored_file=is_ignored_file,
         )
 
         result = self._to_json({"dirs": dirs, "files": files})
@@ -141,9 +151,12 @@ class FindFileTool(Tool):
 
         dir_to_scan = os.path.join(self.get_project_root(), relative_path)
 
-        # find the files by ignoring everything that doesn't match
+        # scan_directory tells us the entry kind (file vs dir) implicitly by which callback it
+        # picks; thread that through so is_ignored_path can skip its own stat syscalls.
+        project = self.project
+
         def is_ignored_file(abs_path: str) -> bool:
-            if self.project.is_ignored_path(abs_path):
+            if project.is_ignored_path(abs_path, is_dir=False):
                 return True
             filename = os.path.basename(abs_path)
             return not fnmatch(filename, file_mask)
@@ -151,7 +164,7 @@ class FindFileTool(Tool):
         _dirs, files = scan_directory(
             path=dir_to_scan,
             recursive=True,
-            is_ignored_dir=self.project.is_ignored_path,
+            is_ignored_dir=lambda p: project.is_ignored_path(p, is_dir=True),
             is_ignored_file=is_ignored_file,
             relative_to=self.get_project_root(),
         )
@@ -408,11 +421,13 @@ class SearchForPatternTool(Tool):
             if os.path.isfile(abs_path):
                 rel_paths_to_search = [relative_path]
             else:
+                # thread is_dir through to skip per-call stat syscalls in is_ignored_path
+                project = self.project
                 _dirs, rel_paths_to_search = scan_directory(
                     path=abs_path,
                     recursive=True,
-                    is_ignored_dir=self.project.is_ignored_path,
-                    is_ignored_file=self.project.is_ignored_path,
+                    is_ignored_dir=lambda p: project.is_ignored_path(p, is_dir=True),
+                    is_ignored_file=lambda p: project.is_ignored_path(p, is_dir=False),
                     relative_to=self.get_project_root(),
                 )
             # TODO (maybe): not super efficient to walk through the files again and filter if glob patterns are provided

--- a/src/serena/util/file_system.py
+++ b/src/serena/util/file_system.py
@@ -96,8 +96,14 @@ def find_all_non_ignored_files(repo_root: str) -> list[str]:
     :return: A list of all non-ignored files in the repository
     """
     gitignore_parser = GitignoreParser(repo_root)
+    # scan_directory already knows whether each entry is a file or directory (from os.scandir).
+    # We thread that knowledge through into the ignore check via separate callbacks so
+    # GitignoreParser.should_ignore can skip its own os.path.isdir/os.path.exists syscalls.
     _, files = scan_directory(
-        repo_root, recursive=True, is_ignored_dir=gitignore_parser.should_ignore, is_ignored_file=gitignore_parser.should_ignore
+        repo_root,
+        recursive=True,
+        is_ignored_dir=lambda p: gitignore_parser.should_ignore(p, is_dir=True),
+        is_ignored_file=lambda p: gitignore_parser.should_ignore(p, is_dir=False),
     )
     return files
 
@@ -117,14 +123,16 @@ class GitignoreSpec:
         """Initialize the PathSpec from patterns."""
         self.pathspec = PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, self.patterns)
 
-    def matches(self, relative_path: str) -> bool:
+    def matches(self, relative_path: str, is_dir: bool | None = None) -> bool:
         """
         Check if the given path matches any pattern in this gitignore spec.
 
         :param relative_path: Path to check (should be relative to repo root)
+        :param is_dir: whether the path is a directory; forwarded to ``match_path`` to avoid
+            a per-call ``os.path.isdir`` syscall when the caller already knows
         :return: True if path matches any pattern
         """
-        return match_path(relative_path, self.pathspec, root_path=os.path.dirname(self.file_path))
+        return match_path(relative_path, self.pathspec, root_path=os.path.dirname(self.file_path), is_dir=is_dir)
 
 
 class GitignoreParser:
@@ -185,7 +193,8 @@ class GitignoreParser:
                 except ValueError:
                     # If the path is on a different drive (Windows) or cannot be made relative for another reason, we ignore it
                     continue
-                if self.should_ignore(rel_path):
+                # everything in the queue is a directory (only is_dir entries are appended)
+                if self.should_ignore(rel_path, is_dir=True):
                     continue
             yield from scan(next_abs_path)
 
@@ -285,11 +294,16 @@ class GitignoreParser:
 
         return patterns
 
-    def should_ignore(self, path: str) -> bool:
+    def should_ignore(self, path: str, is_dir: bool | None = None) -> bool:
         """
         Check if a path should be ignored based on the gitignore rules.
 
         :param path: Path to check (absolute or relative to repo_root)
+        :param is_dir: whether ``path`` is a directory; if the caller already knows (e.g. from
+            ``os.scandir(...).is_dir()``), passing it skips an ``os.path.exists`` /
+            ``os.path.isdir`` syscall pair per call. The syscalls are particularly expensive
+            on Windows where each one is a separate ``GetFileAttributes`` round-trip.
+            ``None`` falls back to the syscall path (backwards compatible).
         :return: True if the path should be ignored, False otherwise
         """
         # Convert to relative path from repo root
@@ -309,17 +323,19 @@ class GitignoreParser:
         if rel_path_first_path == ".git":
             return True
 
-        abs_path = os.path.join(self.repo_root, rel_path)
-
         # Normalize path separators
         rel_path = rel_path.replace(os.sep, "/")
 
-        if os.path.exists(abs_path) and os.path.isdir(abs_path) and not rel_path.endswith("/"):
+        # determine kind: prefer the caller's hint, fall back to syscalls
+        if is_dir is None:
+            abs_path = os.path.join(self.repo_root, rel_path)
+            is_dir = os.path.exists(abs_path) and os.path.isdir(abs_path)
+        if is_dir and not rel_path.endswith("/"):
             rel_path = rel_path + "/"
 
-        # Check against each ignore spec
+        # Check against each ignore spec — pass the kind through so each spec.matches() doesn't re-stat
         for spec in self.ignore_specs:
-            if spec.matches(rel_path):
+            if spec.matches(rel_path, is_dir=is_dir):
                 return True
 
         return False
@@ -338,7 +354,7 @@ class GitignoreParser:
         self._load_gitignore_files()
 
 
-def match_path(relative_path: str, path_spec: PathSpec, root_path: str = "") -> bool:
+def match_path(relative_path: str, path_spec: PathSpec, root_path: str = "", is_dir: bool | None = None) -> bool:
     """
     Match a relative path against a given pathspec. Just pathspec.match_file() is not enough,
     we need to do some massaging to fix issues with pathspec matching.
@@ -346,6 +362,10 @@ def match_path(relative_path: str, path_spec: PathSpec, root_path: str = "") -> 
     :param relative_path: relative path to match against the pathspec
     :param path_spec: the pathspec to match against
     :param root_path: the root path from which the relative path is derived
+    :param is_dir: whether ``relative_path`` refers to a directory; if known by the caller
+        (typically from ``os.scandir(...).is_dir()``), passing it here avoids a per-call
+        ``os.path.isdir`` syscall — the dominant tottime contributor on large trees,
+        especially on Windows. ``None`` falls back to the syscall (backwards compatible).
     :return:
     """
     if str(relative_path) in {"", "."}:
@@ -363,7 +383,9 @@ def match_path(relative_path: str, path_spec: PathSpec, root_path: str = "") -> 
 
     # pathspec can't handle the matching of directories if they don't end with a slash!
     # see https://github.com/cpburnz/python-pathspec/issues/89
-    abs_path = os.path.abspath(os.path.join(root_path, relative_path))
-    if os.path.isdir(abs_path) and not normalized_path.endswith("/"):
+    if is_dir is None:
+        abs_path = os.path.abspath(os.path.join(root_path, relative_path))
+        is_dir = os.path.isdir(abs_path)
+    if is_dir and not normalized_path.endswith("/"):
         normalized_path = normalized_path + "/"
     return path_spec.match_file(normalized_path)

--- a/src/serena/util/text_utils.py
+++ b/src/serena/util/text_utils.py
@@ -182,14 +182,25 @@ def search_text(
     if allow_multiline_match:
         # For multiline matches, we need to use the DOTALL flag to make '.' match newlines
         compiled_pattern = re.compile(pattern, re.DOTALL)
+        # The previous implementation computed start_line_num via content[:start_pos].count("\n")
+        # for every match — O(n) per match, so O(n*m) total. Since finditer yields matches in
+        # increasing start-position order, we can instead count newlines incrementally over the
+        # *new* region only. Each str.count call is C-level and total C work is O(n); Python-level
+        # iteration is O(m). No upfront index build, no bisect.
+        cursor = 0  # content position up to which we've already counted newlines
+        cursor_line = 0  # line number at `cursor`
+
         # Search across the entire content as a single string
         for match in compiled_pattern.finditer(content):
             start_pos = match.start()
             end_pos = match.end()
 
-            # Find the line numbers for the start and end positions
-            start_line_num = content[:start_pos].count("\n")
-            end_line_num = content[:end_pos].count("\n")
+            # advance cursor → match start, accumulating any newlines crossed
+            start_line_num = cursor_line + content.count("\n", cursor, start_pos)
+            # then advance through the match itself for the end line
+            end_line_num = start_line_num + content.count("\n", start_pos, end_pos)
+            cursor = end_pos
+            cursor_line = end_line_num
 
             # Calculate the range of lines to include in the context
             context_start = max(0, start_line_num - context_lines_before)
@@ -265,6 +276,27 @@ def expand_braces(pattern: str) -> list[str]:
     return patterns
 
 
+# cache of compiled glob regexes, keyed by the normalised (forward-slash) pattern.
+# fnmatch.translate + re.compile is the dominant cost when glob_match is invoked in a
+# tight loop over many files; caching turns a per-call regex compile into a single dict
+# lookup. The cache is unbounded in principle but capped in practice by the small set
+# of glob patterns any given workload uses (typically O(10)).
+_GLOB_CACHE: dict[str, list[re.Pattern[str]]] = {}
+
+
+def _compile_glob_pattern(normalised_pattern: str) -> list[re.Pattern[str]]:
+    """Compile a normalised glob pattern into the 1-3 regexes ``glob_match`` needs for ``**`` semantics."""
+    regexes = [re.compile(fnmatch.translate(normalised_pattern))]
+    if "**" in normalised_pattern:
+        # zero-directory case: "src/**/test.py" should also match "src/test.py"
+        if "/**/" in normalised_pattern:
+            regexes.append(re.compile(fnmatch.translate(normalised_pattern.replace("/**/", "/"))))
+        # leading ** zero-directory case: "**/test.py" should also match "test.py"
+        if normalised_pattern.startswith("**/"):
+            regexes.append(re.compile(fnmatch.translate(normalised_pattern[3:])))
+    return regexes
+
+
 def glob_match(pattern: str, path: str) -> bool:
     """
     Match a file path against a glob pattern.
@@ -286,36 +318,19 @@ def glob_match(pattern: str, path: str) -> bool:
     :param path: File path to match against
     :return: True if path matches pattern
     """
-    pattern = pattern.replace("\\", "/")  # Normalize backslashes to forward slashes
-    path = path.replace("\\", "/")  # Normalize path backslashes to forward slashes
+    # normalise backslashes (Windows) to forward slashes before matching
+    pattern = pattern.replace("\\", "/")
+    path = path.replace("\\", "/")
 
-    # Handle ** patterns that should match zero or more directories
-    if "**" in pattern:
-        # Method 1: Standard fnmatch (matches one or more directories)
-        regex1 = fnmatch.translate(pattern)
-        if re.match(regex1, path):
+    regexes = _GLOB_CACHE.get(pattern)
+    if regexes is None:
+        regexes = _compile_glob_pattern(pattern)
+        _GLOB_CACHE[pattern] = regexes
+
+    for rx in regexes:
+        if rx.match(path):
             return True
-
-        # Method 2: Handle zero-directory case by removing /** entirely
-        # Convert "src/**/test.py" to "src/test.py"
-        if "/**/" in pattern:
-            zero_dir_pattern = pattern.replace("/**/", "/")
-            regex2 = fnmatch.translate(zero_dir_pattern)
-            if re.match(regex2, path):
-                return True
-
-        # Method 3: Handle leading ** case by removing **/
-        # Convert "**/test.py" to "test.py"
-        if pattern.startswith("**/"):
-            zero_dir_pattern = pattern[3:]  # Remove "**/"
-            regex3 = fnmatch.translate(zero_dir_pattern)
-            if re.match(regex3, path):
-                return True
-
-        return False
-    else:
-        # Simple pattern without **, use fnmatch directly
-        return fnmatch.fnmatch(path, pattern)
+    return False
 
 
 def search_files(

--- a/test/serena/config/test_global_ignored_paths.py
+++ b/test/serena/config/test_global_ignored_paths.py
@@ -244,3 +244,51 @@ class TestSerenaConfigIgnoredPaths:
             ignored_paths=["node_modules", "*.log", "build"],
         )
         assert config.ignored_paths == ["node_modules", "*.log", "build"]
+
+
+class TestIsIgnoredPathIsDirHint:
+    """The is_dir hint on Project.is_ignored_path must produce the same result as the syscall
+    fallback and must not require the path to exist on disk.
+    """
+
+    def setup_method(self) -> None:
+        self.test_dir = tempfile.mkdtemp()
+        self.project_path = Path(self.test_dir)
+        (self.project_path / "main.py").write_text("print('hi')")
+        os.makedirs(self.project_path / "node_modules", exist_ok=True)
+        (self.project_path / "node_modules" / "pkg.js").write_text("x")
+
+    def teardown_method(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_hint_matches_syscall_path_for_existing_file(self) -> None:
+        project = _create_test_project(self.project_path, global_ignored_paths=["node_modules"])
+        abs_file = str(self.project_path / "node_modules" / "pkg.js")
+
+        # syscall path (no hint): ignored
+        assert project.is_ignored_path(abs_file) is True
+        # hint path: same result
+        assert project.is_ignored_path(abs_file, is_dir=False) is True
+
+    def test_hint_matches_syscall_path_for_directory(self) -> None:
+        project = _create_test_project(self.project_path, global_ignored_paths=["node_modules"])
+        abs_dir = str(self.project_path / "node_modules")
+
+        assert project.is_ignored_path(abs_dir) is True
+        assert project.is_ignored_path(abs_dir, is_dir=True) is True
+
+    def test_hint_does_not_require_path_to_exist(self) -> None:
+        """Without the hint, _is_ignored_relative_path raises FileNotFoundError on missing paths.
+        With the hint we trust the caller and just match against the ignore spec.
+        """
+        project = _create_test_project(self.project_path, global_ignored_paths=["node_modules"])
+        abs_missing = str(self.project_path / "node_modules" / "deep" / "does_not_exist.js")
+
+        # hint path: returns True without stat-ing
+        assert project.is_ignored_path(abs_missing, is_dir=False) is True
+
+        # syscall path: still raises FileNotFoundError, contract preserved
+        import pytest
+
+        with pytest.raises(FileNotFoundError):
+            project.is_ignored_path(abs_missing)

--- a/test/serena/test_text_utils.py
+++ b/test/serena/test_text_utils.py
@@ -214,6 +214,33 @@ class TestSearchText:
 
         assert len(matches) == 0
 
+    def test_search_text_multiline_many_matches_line_numbers(self):
+        """Many-match regression: incremental newline counting must produce the same line numbers
+        as the previous prefix-counting implementation, including the very first match on line 0
+        and matches separated by varying line counts.
+        """
+        content = "\n".join(f"alpha_{i:04d} = compute({i})" for i in range(200))
+        matches = search_text(r"alpha_\d+", content=content, allow_multiline_match=True)
+
+        assert len(matches) == 200
+        for i, m in enumerate(matches):
+            assert m.start_line == i, f"match {i} reported line {m.start_line}, expected {i}"
+            assert m.matched_lines[0].line_content == f"alpha_{i:04d} = compute({i})"
+
+    def test_search_text_multiline_match_spanning_multiple_lines(self):
+        """A match that spans several lines must report start/end line correctly under the
+        new incremental cursor logic.
+        """
+        content = "header\nline1\nline2\nMARK\nline3\nMARK\nfooter\n"
+        # match from first MARK through the second MARK on a later line
+        matches = search_text(r"MARK.*MARK", content=content, allow_multiline_match=True)
+
+        assert len(matches) == 1
+        m = matches[0]
+        # MARK starts on line 3 (0-indexed), second MARK ends on line 5
+        assert m.matched_lines[0].line_number == 3
+        assert m.matched_lines[-1].line_number == 5
+
 
 # Mock file reader that always returns matching content
 def mock_reader_always_match(file_path: str) -> str:
@@ -575,3 +602,37 @@ class TestExpandBraces:
         from serena.util.text_utils import expand_braces
 
         assert sorted(expand_braces(pattern)) == sorted(expected)
+
+
+class TestGlobMatchCache:
+    """The compile cache must be transparent (correctness unchanged) and actually populate."""
+
+    def test_repeated_calls_consistent(self):
+        """Calling glob_match many times must keep returning the same result for the same input."""
+        from serena.util.text_utils import glob_match
+
+        for _ in range(50):
+            assert glob_match("**/*.py", "src/serena/agent.py") is True
+            assert glob_match("**/*.py", "src/serena/agent.txt") is False
+            assert glob_match("src/**/test_*.py", "src/a/b/test_foo.py") is True
+            assert glob_match("src/**/test_*.py", "other/test_foo.py") is False
+
+    def test_cache_populates_after_first_call(self):
+        """After a call, the (normalised) pattern must be in the cache as a list of compiled regexes."""
+        import re
+
+        from serena.util.text_utils import _GLOB_CACHE, glob_match
+
+        _GLOB_CACHE.pop("**/*.unique-ext", None)
+        glob_match("**/*.unique-ext", "foo.unique-ext")
+        cached = _GLOB_CACHE.get("**/*.unique-ext")
+        assert cached is not None
+        assert all(isinstance(rx, re.Pattern) for rx in cached)
+
+    def test_backslash_pattern_normalised_in_cache_key(self):
+        """Windows-style patterns must reach the cache under the same key as forward-slash ones."""
+        from serena.util.text_utils import _GLOB_CACHE, glob_match
+
+        _GLOB_CACHE.pop("src/foo/*.py", None)
+        glob_match("src\\foo\\*.py", "src/foo/bar.py")
+        assert "src/foo/*.py" in _GLOB_CACHE

--- a/test/serena/util/test_file_system.py
+++ b/test/serena/util/test_file_system.py
@@ -684,6 +684,39 @@ src/*.o
         # foo.txt in other/ should NOT be ignored (outside foo/ subtree)
         assert not parser.should_ignore("other/foo.txt"), "other/foo.txt should NOT be ignored by foo/.gitignore"
 
+    def test_should_ignore_with_is_dir_hint(self):
+        """``is_dir`` hint must produce the same result as the syscall fallback, for both files and directories."""
+        parser = GitignoreParser(str(self.repo_path))
+
+        # existing file (test.log matches `*.log`) - syscall path and hint path should agree
+        assert parser.should_ignore("test.log") is True
+        assert parser.should_ignore("test.log", is_dir=False) is True
+
+        # existing directory (src/build matches `/build/` from src/.gitignore)
+        assert parser.should_ignore("src/build") is True
+        assert parser.should_ignore("src/build", is_dir=True) is True
+
+        # non-ignored file - both paths agree
+        assert parser.should_ignore("file1.txt", is_dir=False) is False
+
+    def test_should_ignore_hint_skips_syscalls_for_nonexistent_path(self):
+        """Hint path must not depend on the file actually existing on disk."""
+        parser = GitignoreParser(str(self.repo_path))
+
+        # `*.log` from root .gitignore — path doesn't exist but hint says it's a file → ignored
+        assert parser.should_ignore("does/not/exist/test.log", is_dir=False) is True
+        # path that doesn't match any pattern is not ignored, with or without hint
+        assert parser.should_ignore("nope/file1.txt", is_dir=False) is False
+
+    def test_match_path_with_is_dir_hint(self):
+        """``match_path`` must respect the explicit hint instead of stat-ing the path."""
+        spec = PathSpec.from_lines("gitwildmatch", ["build/"])
+
+        # is_dir=True → trailing slash appended, directory-only pattern matches
+        assert match_path("nonexistent/build", spec, root_path=str(self.repo_path), is_dir=True) is True
+        # is_dir=False → no trailing slash, directory-only pattern does NOT match
+        assert match_path("nonexistent/build", spec, root_path=str(self.repo_path), is_dir=False) is False
+
     def test_anchored_double_star_pattern(self):
         """Test that /**/pattern in subdirectory works correctly."""
         test_dir = self.repo_path / "test_anchored_doublestar"


### PR DESCRIPTION
  Main changes:
  - Cache compiled glob regexes used by `glob_match`.
  - Thread optional `is_dir` hints through ignore/path matching to avoid redundant filesystem checks.
  - Make multiline `search_text` line-number calculation incremental instead of repeatedly recounting newlines.
  - Add regression tests for ignore matching, glob-cache behavior, and multiline search line numbers.

  Main benchmark results on the Serena repo corpus:
  - `glob_match`: 31.3 ms -> 3.2 ms, about 9.7x faster.
  - `scan_directory + GitignoreParser`: 771 ms -> 230 ms, about 3.4x faster.
