### PR TITLE
Fix TIKTOKEN_GPT4 typo in config template (enum is GPT4O)

### DIFF
--- a/src/serena/resources/serena_config.template.yml
+++ b/src/serena/resources/serena_config.template.yml
@@ -141,7 +141,7 @@ default_max_tool_answer_chars: 150000
 # See the `RegisteredTokenCountEstimator` enum for available options.
 #
 # By default, a very naive character count estimator is used, which simply counts the number of characters.
-# You can configure this to TIKTOKEN_GPT4 to use a local tiktoken-based estimator for GPT-4 (will download tiktoken
+# You can configure this to TIKTOKEN_GPT4O to use a local tiktoken-based estimator for GPT-4o (will download tiktoken
 # data files on first run), or ANTHROPIC_CLAUDE_SONNET_4 which will use the (free of cost) Anthropic API to
 # estimate the token count using the Claude Sonnet 4 tokenizer.
 token_count_estimator: CHAR_COUNT


### PR DESCRIPTION
## Summary

The default config template references `TIKTOKEN_GPT4` and `GPT-4`, but the
actual enum member in `src/serena/analytics.py:88-91` is `TIKTOKEN_GPT4O`,
which uses OpenAI's `o200k_base` tokenizer (GPT-4o et seq).

## Bug

Setting `token_count_estimator: TIKTOKEN_GPT4` per the example comment raises:

```
KeyError: 'TIKTOKEN_GPT4'
  File ".../serena/agent.py:588", in __init__
    token_count_estimator = RegisteredTokenCountEstimator[self.serena_config.token_count_estimator]
```

This is fatal at `SerenaAgent.__init__`. MCP clients (tested Claude.app /
Cowork Desktop) mark the MCP server fatal and stop retrying after 3
attempts, requiring a manual app restart to recover.

## Fix

One-line comment update so the example matches the enum.

## Test plan

- [x] Diff confirmed against `RegisteredTokenCountEstimator` members in `src/serena/analytics.py`
- [x] Reproduced the original `KeyError` locally on v1.2.0
- [x] After fix, `serena context list` loads cleanly with the corrected value