### PR TITLE
Fix UNC path parsing and drive letter case sensitivity on Windows

### DIFF
--- a/src/solidlsp/ls_utils.py
+++ b/src/solidlsp/ls_utils.py
@@ -161,7 +161,7 @@ class PathUtils:
             urlparse = urlparse_py2
         parsed = urlparse(uri)
         host = f"{os.path.sep}{os.path.sep}{parsed.netloc}{os.path.sep}"
-        path = os.path.normpath(os.path.join(host, url2pathname(unquote(parsed.path))))
+        path = os.path.abspath(os.path.join(host, url2pathname(unquote(parsed.path))))
         return path
 
     @staticmethod
@@ -182,7 +182,7 @@ class PathUtils:
         Gets relative path if it's possible (paths should be on the same drive),
         returns `None` otherwise.
         """
-        if PurePath(path).drive == PurePath(base_path).drive:
+        if os.path.normcase(PurePath(path).drive) == os.path.normcase(PurePath(base_path).drive):
             rel_path = str(PurePath(os.path.relpath(path, base_path)))
             return rel_path
         return None


### PR DESCRIPTION
### What does this PR do?
Fixes two bugs in path resolution that caused the LSP client to erroneously discard valid responses from Language Servers (e.g., OmniSharp, Roslyn) when the workspace is located on a Windows Network Share (UNC path). 

Because of these bugs, `solidlsp` falsely assumed that perfectly valid referenced files were "outside the repository" and skipped them, returning empty results for tools like `find_referencing_symbols`.

### The Bugs & Causes:
1. **Double slash in UNC paths:** In `PathUtils.uri_to_path`, `os.path.join` was used to concatenate `\\server\` and `\share\path`. On Windows, this results in an invalid UNC path with an extra slash (e.g., `\\legion\\D$`). `os.path.normpath` does not clean this up because it treats the server block as an atomic drive prefix.
2. **Case sensitivity in drive comparison:** In `PathUtils.get_relative_path`, `PurePath.drive` was compared using strict string equality (`==`). Since the LS often returns URIs with lowercase hostnames (e.g., `legion`), and the client/user config might use PascalCase (`Legion`), the comparison failed.

### How it was fixed:
* Used `os.path.abspath` instead of `os.path.normpath` in `uri_to_path`.
* Added `os.path.normcase()` to the drive comparison in `get_relative_path` to ensure platform-appropriate case-insensitive matching on Windows.

### Testing:
Tested locally with OmniSharp and Roslyn backends. The client now correctly maps `file://` URIs from network shares to local workspace paths without dropping them.