### PR TITLE
Fix client hook cleanup event docs

### DIFF
--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -197,7 +197,7 @@ Claude Code settings file (`.claude/settings.json` in your project directory, or
                 ]
             }
         ],
-        "Stop": [
+        "SessionEnd": [
             {
                 "matcher": "",
                 "hooks": [


### PR DESCRIPTION
## Summary
- use `SessionEnd` for the Claude Code cleanup hook example
- keep the fix scoped to the Claude Code issue reported in #1480

## Validation
- `uv run poe doc-build`

Fixes #1480