### PR TITLE
feat(ruby-lsp): allow indexing vendored Rails engines via vendor_include_paths

### DIFF
--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -6,11 +6,8 @@ You can pass the following entries in ``ls_specific_settings["ruby"]``:
     - ruby_lsp_version: Override the pinned ruby-lsp gem version installed by
       Serena when no project-local or global ruby-lsp is already available
       (default: the bundled Serena version).
-    - vendor_include_paths: List of repository-relative paths under ``vendor/``
-      that should remain indexed by ruby-lsp. Example:
-      ``["vendor/engines"]``. When set, Serena replaces the blanket
-      ``**/vendor/**`` exclusion with exclusions for the other top-level
-      ``vendor`` subdirectories it finds in the repository.
+    - vendor_include_paths: List of top-level paths under ``vendor/`` that
+      should remain indexed. Example: ``["vendor/engines"]``.
 """
 
 import json
@@ -77,9 +74,10 @@ class RubyLsp(SolidLanguageServer):
 
     def is_ignored_path(self, relative_path: str, ignore_unsupported_files: bool = True) -> bool:
         """Override to keep only configured vendor subtrees visible to Serena."""
-        normalized_path = pathlib.PurePosixPath(pathlib.Path(relative_path).as_posix())
-        if self._path_contains_vendor_directory(normalized_path):
-            if not self._is_included_vendor_path(normalized_path):
+        parts = pathlib.PurePosixPath(pathlib.Path(relative_path).as_posix()).parts
+        vendor_include_roots = {pathlib.PurePosixPath(path).parts[1] for path in self._custom_settings.get("vendor_include_paths", [])}
+        if "vendor" in parts:
+            if len(parts) < 2 or parts[:1] != ("vendor",) or parts[1] not in vendor_include_roots or "vendor" in parts[2:]:
                 return True
 
         return super().is_ignored_path(relative_path, ignore_unsupported_files)
@@ -311,83 +309,6 @@ class RubyLsp(SolidLanguageServer):
 
         return False
 
-    def _get_vendor_include_roots(self) -> set[str]:
-        """Return top-level vendor directory names that should remain indexed."""
-        vendor_include_paths = self._solidlsp_settings.get_ls_specific_settings(Language.RUBY).get("vendor_include_paths", [])
-        vendor_include_roots: set[str] = set()
-        if isinstance(vendor_include_paths, list):
-            for path in vendor_include_paths:
-                normalized_path = pathlib.PurePosixPath(str(path).strip("/"))
-                if len(normalized_path.parts) >= 2 and normalized_path.parts[0] == "vendor":
-                    vendor_include_roots.add(normalized_path.parts[1])
-                else:
-                    log.warning("Ignoring invalid ruby.vendor_include_paths entry %r; expected a path under vendor/.", path)
-        elif vendor_include_paths:
-            log.warning("Ignoring ruby.vendor_include_paths because it is not a list: %r", vendor_include_paths)
-        return vendor_include_roots
-
-    @staticmethod
-    def _path_contains_vendor_directory(relative_path: pathlib.PurePosixPath) -> bool:
-        """Return whether the path traverses through any vendor directory."""
-        return "vendor" in relative_path.parts
-
-    def _is_included_vendor_path(self, relative_path: pathlib.PurePosixPath) -> bool:
-        """Return whether the path belongs to an allowlisted vendor subtree only."""
-        vendor_include_roots = self._get_vendor_include_roots()
-        if not vendor_include_roots:
-            return False
-
-        found_included_vendor_root = False
-        for index, part in enumerate(relative_path.parts):
-            if part != "vendor":
-                continue
-
-            if index != 0:
-                return False
-
-            if index + 1 >= len(relative_path.parts):
-                return False
-
-            if relative_path.parts[index + 1] not in vendor_include_roots:
-                return False
-
-            found_included_vendor_root = True
-
-        return found_included_vendor_root
-
-    def _get_vendor_exclude_patterns(self, repository_root_path: str) -> list[str]:
-        """Return vendor-specific exclude patterns honoring allowlisted subtrees."""
-        vendor_include_roots = self._get_vendor_include_roots()
-        if not vendor_include_roots:
-            return ["**/vendor/**"]
-
-        vendor_patterns: set[str] = set()
-        repository_root = pathlib.Path(repository_root_path)
-        root_vendor_dir = repository_root / "vendor"
-
-        if root_vendor_dir.is_dir():
-            for child in root_vendor_dir.iterdir():
-                if child.name not in vendor_include_roots:
-                    vendor_patterns.add(f"vendor/{child.name}/**")
-
-        for current_root, dirnames, _filenames in os.walk(repository_root_path):
-            current_root_path = pathlib.Path(current_root)
-            relative_root = current_root_path.relative_to(repository_root).as_posix()
-
-            if relative_root == ".":
-                continue
-
-            if current_root_path.name == "vendor":
-                relative_vendor_path = pathlib.PurePosixPath(relative_root)
-                if relative_vendor_path.parts == ("vendor",):
-                    continue
-
-                if not self._is_included_vendor_path(relative_vendor_path):
-                    vendor_patterns.add(f"{relative_vendor_path.as_posix()}/**")
-                    dirnames[:] = []
-
-        return sorted(vendor_patterns)
-
     def _get_ruby_exclude_patterns(self, repository_root_path: str) -> list[str]:
         """
         Get Ruby and Rails-specific exclude patterns for better performance.
@@ -404,8 +325,14 @@ class RubyLsp(SolidLanguageServer):
             "**/public/assets/**",  # Rails compiled assets
         ]
 
-        # keeping vendor/engines while excluding every other vendored subtree
-        base_patterns.extend(self._get_vendor_exclude_patterns(repository_root_path))
+        vendor_include_roots = {pathlib.PurePosixPath(path).parts[1] for path in self._custom_settings.get("vendor_include_paths", [])}
+        if vendor_include_roots:
+            vendor_dir = pathlib.Path(repository_root_path) / "vendor"
+            if vendor_dir.is_dir():
+                base_patterns.extend(f"vendor/{child.name}/**" for child in vendor_dir.iterdir() if child.name not in vendor_include_roots)
+            base_patterns.extend(f"vendor/{root}/**/vendor/**" for root in vendor_include_roots)
+        else:
+            base_patterns.append("**/vendor/**")
 
         # Add Rails-specific patterns if this is a Rails project
         if RubyLsp._detect_rails_project(repository_root_path):

--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -6,6 +6,11 @@ You can pass the following entries in ``ls_specific_settings["ruby"]``:
     - ruby_lsp_version: Override the pinned ruby-lsp gem version installed by
       Serena when no project-local or global ruby-lsp is already available
       (default: the bundled Serena version).
+    - vendor_include_paths: List of repository-relative paths under ``vendor/``
+      that should remain indexed by ruby-lsp. Example:
+      ``["vendor/engines"]``. When set, Serena replaces the blanket
+      ``**/vendor/**`` exclusion with exclusions for the other top-level
+      ``vendor`` subdirectories it finds in the repository.
 """
 
 import json
@@ -55,7 +60,6 @@ class RubyLsp(SolidLanguageServer):
     def is_ignored_dirname(self, dirname: str) -> bool:
         """Override to ignore Ruby-specific directories that cause performance issues."""
         ruby_ignored_dirs = [
-            "vendor",  # Ruby vendor directory
             ".bundle",  # Bundler cache
             "tmp",  # Temporary files
             "log",  # Log files
@@ -70,6 +74,15 @@ class RubyLsp(SolidLanguageServer):
             ".ruby-lsp",
         ]
         return super().is_ignored_dirname(dirname) or dirname in ruby_ignored_dirs
+
+    def is_ignored_path(self, relative_path: str, ignore_unsupported_files: bool = True) -> bool:
+        """Override to keep only configured vendor subtrees visible to Serena."""
+        normalized_path = pathlib.PurePosixPath(pathlib.Path(relative_path).as_posix())
+        if self._path_contains_vendor_directory(normalized_path):
+            if not self._is_included_vendor_path(normalized_path):
+                return True
+
+        return super().is_ignored_path(relative_path, ignore_unsupported_files)
 
     @override
     def _get_wait_time_for_cross_file_referencing(self) -> float:
@@ -298,13 +311,88 @@ class RubyLsp(SolidLanguageServer):
 
         return False
 
+    def _get_vendor_include_roots(self) -> set[str]:
+        """Return top-level vendor directory names that should remain indexed."""
+        vendor_include_paths = self._solidlsp_settings.get_ls_specific_settings(Language.RUBY).get("vendor_include_paths", [])
+        vendor_include_roots: set[str] = set()
+        if isinstance(vendor_include_paths, list):
+            for path in vendor_include_paths:
+                normalized_path = pathlib.PurePosixPath(str(path).strip("/"))
+                if len(normalized_path.parts) >= 2 and normalized_path.parts[0] == "vendor":
+                    vendor_include_roots.add(normalized_path.parts[1])
+                else:
+                    log.warning("Ignoring invalid ruby.vendor_include_paths entry %r; expected a path under vendor/.", path)
+        elif vendor_include_paths:
+            log.warning("Ignoring ruby.vendor_include_paths because it is not a list: %r", vendor_include_paths)
+        return vendor_include_roots
+
     @staticmethod
-    def _get_ruby_exclude_patterns(repository_root_path: str) -> list[str]:
+    def _path_contains_vendor_directory(relative_path: pathlib.PurePosixPath) -> bool:
+        """Return whether the path traverses through any vendor directory."""
+        return "vendor" in relative_path.parts
+
+    def _is_included_vendor_path(self, relative_path: pathlib.PurePosixPath) -> bool:
+        """Return whether the path belongs to an allowlisted vendor subtree only."""
+        vendor_include_roots = self._get_vendor_include_roots()
+        if not vendor_include_roots:
+            return False
+
+        found_included_vendor_root = False
+        for index, part in enumerate(relative_path.parts):
+            if part != "vendor":
+                continue
+
+            if index != 0:
+                return False
+
+            if index + 1 >= len(relative_path.parts):
+                return False
+
+            if relative_path.parts[index + 1] not in vendor_include_roots:
+                return False
+
+            found_included_vendor_root = True
+
+        return found_included_vendor_root
+
+    def _get_vendor_exclude_patterns(self, repository_root_path: str) -> list[str]:
+        """Return vendor-specific exclude patterns honoring allowlisted subtrees."""
+        vendor_include_roots = self._get_vendor_include_roots()
+        if not vendor_include_roots:
+            return ["**/vendor/**"]
+
+        vendor_patterns: set[str] = set()
+        repository_root = pathlib.Path(repository_root_path)
+        root_vendor_dir = repository_root / "vendor"
+
+        if root_vendor_dir.is_dir():
+            for child in root_vendor_dir.iterdir():
+                if child.name not in vendor_include_roots:
+                    vendor_patterns.add(f"vendor/{child.name}/**")
+
+        for current_root, dirnames, _filenames in os.walk(repository_root_path):
+            current_root_path = pathlib.Path(current_root)
+            relative_root = current_root_path.relative_to(repository_root).as_posix()
+
+            if relative_root == ".":
+                continue
+
+            if current_root_path.name == "vendor":
+                relative_vendor_path = pathlib.PurePosixPath(relative_root)
+                if relative_vendor_path.parts == ("vendor",):
+                    continue
+
+                if not self._is_included_vendor_path(relative_vendor_path):
+                    vendor_patterns.add(f"{relative_vendor_path.as_posix()}/**")
+                    dirnames[:] = []
+
+        return sorted(vendor_patterns)
+
+    def _get_ruby_exclude_patterns(self, repository_root_path: str) -> list[str]:
         """
         Get Ruby and Rails-specific exclude patterns for better performance.
         """
         base_patterns = [
-            "**/vendor/**",  # Ruby vendor directory
             "**/.bundle/**",  # Bundler cache
             "**/tmp/**",  # Temporary files
             "**/log/**",  # Log files
@@ -315,6 +403,9 @@ class RubyLsp(SolidLanguageServer):
             "**/node_modules/**",  # Node modules (for Rails with JS)
             "**/public/assets/**",  # Rails compiled assets
         ]
+
+        # keeping vendor/engines while excluding every other vendored subtree
+        base_patterns.extend(self._get_vendor_exclude_patterns(repository_root_path))
 
         # Add Rails-specific patterns if this is a Rails project
         if RubyLsp._detect_rails_project(repository_root_path):

--- a/test/solidlsp/ruby/test_ruby_lsp_config.py
+++ b/test/solidlsp/ruby/test_ruby_lsp_config.py
@@ -35,7 +35,7 @@ def test_ruby_lsp_can_keep_vendor_engines_indexed(tmp_path: Path) -> None:
     assert "vendor/bundle/**" in patterns
     assert "vendor/cache/**" in patterns
     assert "vendor/engines/**" not in patterns
-    assert "vendor/engines/blog/vendor/**" in patterns
+    assert "vendor/engines/**/vendor/**" in patterns
 
 
 def test_ruby_lsp_ignores_non_allowlisted_vendor_paths(tmp_path: Path) -> None:

--- a/test/solidlsp/ruby/test_ruby_lsp_config.py
+++ b/test/solidlsp/ruby/test_ruby_lsp_config.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from solidlsp.language_servers.ruby_lsp import RubyLsp
+from solidlsp.ls_config import Language
+from solidlsp.settings import SolidLSPSettings
+
+
+def _build_ruby_lsp(settings: SolidLSPSettings) -> RubyLsp:
+    language_server = RubyLsp.__new__(RubyLsp)
+    language_server._solidlsp_settings = settings
+    language_server.repository_root_path = ""
+    return language_server
+
+
+def test_ruby_lsp_excludes_vendor_by_default(tmp_path: Path) -> None:
+    language_server = _build_ruby_lsp(SolidLSPSettings())
+
+    patterns = language_server._get_ruby_exclude_patterns(str(tmp_path))
+
+    assert "**/vendor/**" in patterns
+
+
+def test_ruby_lsp_can_keep_vendor_engines_indexed(tmp_path: Path) -> None:
+    (tmp_path / "vendor" / "engines").mkdir(parents=True)
+    (tmp_path / "vendor" / "bundle").mkdir(parents=True)
+    (tmp_path / "vendor" / "cache").mkdir(parents=True)
+    (tmp_path / "vendor" / "engines" / "blog" / "vendor" / "bundle").mkdir(parents=True)
+
+    settings = SolidLSPSettings(ls_specific_settings={Language.RUBY: {"vendor_include_paths": ["vendor/engines"]}})
+    language_server = _build_ruby_lsp(settings)
+
+    patterns = language_server._get_ruby_exclude_patterns(str(tmp_path))
+
+    assert "**/vendor/**" not in patterns
+    assert "vendor/bundle/**" in patterns
+    assert "vendor/cache/**" in patterns
+    assert "vendor/engines/**" not in patterns
+    assert "vendor/engines/blog/vendor/**" in patterns
+
+
+def test_ruby_lsp_ignores_non_allowlisted_vendor_paths(tmp_path: Path) -> None:
+    bundle_file = tmp_path / "vendor" / "bundle" / "tool.rb"
+    bundle_file.parent.mkdir(parents=True)
+    bundle_file.write_text("class Tool; end\n")
+
+    nested_vendor_file = tmp_path / "vendor" / "engines" / "blog" / "vendor" / "cache" / "tool.rb"
+    nested_vendor_file.parent.mkdir(parents=True)
+    nested_vendor_file.write_text("class Tool; end\n")
+
+    settings = SolidLSPSettings(ls_specific_settings={Language.RUBY: {"vendor_include_paths": ["vendor/engines"]}})
+    language_server = _build_ruby_lsp(settings)
+    language_server.repository_root_path = str(tmp_path)
+
+    assert language_server.is_ignored_path("vendor/bundle/tool.rb")
+    assert language_server.is_ignored_path("vendor/engines/blog/vendor/cache/tool.rb")
+
+
+def test_ruby_lsp_keeps_allowlisted_vendor_engines_paths(tmp_path: Path) -> None:
+    engine_file = tmp_path / "vendor" / "engines" / "blog" / "app" / "models" / "post.rb"
+    engine_file.parent.mkdir(parents=True)
+    engine_file.write_text("class Post; end\n")
+
+    settings = SolidLSPSettings(ls_specific_settings={Language.RUBY: {"vendor_include_paths": ["vendor/engines"]}})
+    language_server = _build_ruby_lsp(settings)
+    language_server.repository_root_path = str(tmp_path)
+
+    assert not language_server.is_ignored_path("vendor/engines/blog/app/models/post.rb", ignore_unsupported_files=False)


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Serena’s Ruby LSP integration currently excludes `**/vendor/**` entirely. That works well for dependency directories, but it also hides application code for Rails projects that keep local engines under `vendor/engines`.

This is especially relevant for older Rails applications. The Rails 4.1 engines guide shows vendored engines being added from `vendor/engines`, for example:

```ruby
gem 'blorgh', path: "vendor/engines/blorgh"
```

Source: https://guides.rubyonrails.org/v4.1/engines.html

In that setup, Serena ignores real application code inside the vendored engine, so symbols, definitions, and references from those engines are unavailable.

**Describe the solution you'd like**
Add a Ruby-specific `ls_specific_settings["ruby"].vendor_include_paths` setting that allows selected subtrees under `vendor/` to remain indexed while keeping the rest of `vendor/**` ignored.

Example:

```yml
ls_specific_settings:
  ruby:
    vendor_include_paths:
      - vendor/engines
```

With this change:

- `vendor/engines/**` is visible to Serena and ruby-lsp
- other `vendor/**` paths remain ignored
- nested vendored dependency trees inside an included engine, such as `vendor/engines/foo/vendor/**`, remain ignored

The implementation updates both Serena’s own path filtering and ruby-lsp’s `excludedPatterns`, so the allowlist works end-to-end.

**Describe alternatives you've considered**
- Removing the Ruby `vendor/**` exclusion entirely. This would index too many dependency files and hurt performance.
- Asking users to move engines outside `vendor/`. That may work for newer Rails layouts, but it does not help older applications that already follow the vendored engine convention.
- Using broad project-level ignore overrides. That does not provide a clean Ruby-specific allowlist for selected vendored engine paths.

For newer Rails applications, the current Rails engines guide commonly shows local engines outside `vendor/`, for example:

```ruby
gem "blorgh", path: "engines/blorgh"
```

Source: https://guides.rubyonrails.org/engines.html#inside-an-engine

Those layouts are already handled without special configuration, since `engines/` is not excluded by Ruby LSP.

**Additional context**
This PR adds:

- a new Ruby setting: `vendor_include_paths`
- path-aware vendor allowlisting in Serena’s Ruby ignore logic
- matching ruby-lsp exclude-pattern generation
- focused tests covering:
  - default `vendor/**` exclusion
  - allowlisting `vendor/engines`
  - keeping sibling vendor paths excluded
  - keeping nested `vendor/**` inside an included engine excluded

Author note: this PR was created with help from AI. The author is not very familiar with the Python codebase, but after reading the changed code and running the relevant tests, the result looks correct.