### PR TITLE
fix: handle empty projects config key

### DIFF
--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -871,7 +871,7 @@ class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
         if "projects" not in loaded_commented_yaml:
             raise SerenaConfigError("`projects` key not found in Serena configuration. Please update your `serena_config.yml` file.")
         instance.projects = []
-        for path in loaded_commented_yaml["projects"]:
+        for path in loaded_commented_yaml["projects"] or []:
             path = Path(path).resolve()
             try:
                 path_exists = path.exists()

--- a/test/serena/config/test_serena_config.py
+++ b/test/serena/config/test_serena_config.py
@@ -523,6 +523,20 @@ class TestSerenaConfigFromConfigFileRobustness:
             body_lines.append(f"  - {p}")
         self.master_config_path.write_text("\n".join(body_lines) + "\n")
 
+    def test_empty_projects_key_is_treated_as_empty_list(self, monkeypatch):
+        """A bare ``projects:`` key should not abort config loading."""
+        self.master_config_path.write_text("projects:\n")
+
+        monkeypatch.setattr(
+            SerenaConfig,
+            "_determine_config_file_path",
+            classmethod(lambda cls: str(self.master_config_path)),
+        )
+
+        config = SerenaConfig.from_config_file(generate_if_missing=False)
+
+        assert config.projects == []
+
     def test_malformed_project_is_skipped_with_warning(self, caplog, monkeypatch):
         """A malformed project.yml must not abort loading of the others."""
         good_project = self._make_project_dir(


### PR DESCRIPTION
## Summary
- treat a bare `projects:` value as an empty project list when loading `serena_config.yml`
- keep the existing missing-key error for configs without a `projects` key
- add a regression test for the `projects: null` YAML case

Fixes #1407

## Tests
- `git diff --check`
- `uv run --extra dev ruff check src/serena/config/serena_config.py test/serena/config/test_serena_config.py`
- `uv run --extra dev poe test test/serena/config/test_serena_config.py -k empty_projects_key`
- `uv run --extra dev pytest test/serena/config/test_serena_config.py -q`