### PR TITLE
fix(gdscript): detect broken TCP connection and fail fast on send error

### DIFF
--- a/src/solidlsp/language_servers/godot_language_server.py
+++ b/src/solidlsp/language_servers/godot_language_server.py
@@ -46,8 +46,16 @@ class GodotLanguageServer(SolidLanguageServer):
         else:
             log.warning("Could not detect Godot version for project at %s", repository_root_path)
 
+        self._configured_request_timeout: float | None = None
+
         # Dummy ProcessLaunchInfo — _create_language_server_interface() ignores it
         super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd=""), "gdscript", solidlsp_settings)
+
+    def set_request_timeout(self, timeout: float | None) -> None:
+        """Cap the timeout at the value configured in ls_specific_settings, if set."""
+        if timeout is not None and self._configured_request_timeout is not None:
+            timeout = min(timeout, self._configured_request_timeout)
+        super().set_request_timeout(timeout)
 
     @staticmethod
     def _detect_godot_version(repo_path: str) -> int | None:
@@ -75,6 +83,7 @@ class GodotLanguageServer(SolidLanguageServer):
         settings: dict = self._custom_settings or {}
         port = settings.get("port", DEFAULT_GODOT_LS_PORT)
         request_timeout = settings.get("request_timeout", DEFAULT_GODOT_REQUEST_TIMEOUT)
+        self._configured_request_timeout = settings.get("request_timeout")
         self._conn_info = TCPConnectionInfo(host="127.0.0.1", port=port)
         return TCPLanguageServer(
             connection_info=self._conn_info,

--- a/src/solidlsp/ls_process.py
+++ b/src/solidlsp/ls_process.py
@@ -727,6 +727,11 @@ class TCPLanguageServer(LanguageServerInterface):
                 sock.sendall(data)
             except OSError as e:
                 log.error("Failed to write to TCP language server: %s", e)
+                self._sock = None
+                self._file = None
+                self._cancel_pending_requests(
+                    LanguageServerTerminatedException("TCP send error", self.language, cause=e)
+                )
 
     def _read_loop(self) -> None:
         """Read Content-Length-framed LSP messages from the TCP socket and dispatch them."""
@@ -775,3 +780,7 @@ class TCPLanguageServer(LanguageServerInterface):
                 exception = LanguageServerTerminatedException("TCP language server read loop terminated unexpectedly", self.language)
             log.error(str(exception))
             self._cancel_pending_requests(exception)
+            # Clear the socket so is_running() returns False, allowing _ensure_functional_ls
+            # to detect the broken connection and restart the language server.
+            self._sock = None
+            self._file = None

--- a/src/solidlsp/ls_process.py
+++ b/src/solidlsp/ls_process.py
@@ -729,9 +729,7 @@ class TCPLanguageServer(LanguageServerInterface):
                 log.error("Failed to write to TCP language server: %s", e)
                 self._sock = None
                 self._file = None
-                self._cancel_pending_requests(
-                    LanguageServerTerminatedException("TCP send error", self.language, cause=e)
-                )
+                self._cancel_pending_requests(LanguageServerTerminatedException("TCP send error", self.language, cause=e))
 
     def _read_loop(self) -> None:
         """Read Content-Length-framed LSP messages from the TCP socket and dispatch them."""


### PR DESCRIPTION
## Summary

- **`TCPLanguageServer._send_payload`**: when `sendall` raises `OSError` (e.g. broken pipe after Godot restarts), immediately clear `self._sock`/`self._file` and cancel all pending requests. Previously the error was logged silently and callers would block for the full tool timeout (235 s by default) before receiving a `TimeoutError`.
- **`TCPLanguageServer._read_loop`**: after an unexpected exit (connection dropped by remote), clear `self._sock`/`self._file` so `is_running()` returns `False`. This allows `_ensure_functional_ls` to detect the dead connection and trigger an automatic reconnect on the next tool call.
- **`GodotLanguageServer.set_request_timeout`**: the `ls_specific_settings.gdscript.request_timeout` value was already read in `_create_language_server_interface` but was then unconditionally overridden by the tool-timeout-derived value passed to `set_request_timeout()`. Now `set_request_timeout` applies `min(incoming, configured)` so users can cap GDScript LSP request timeouts in their project config without touching the global `tool_timeout`.

## Background

Observed in a Godot 4.6 project with VS Code also connected to the Godot LSP on port 6008. When the Godot editor was restarted (or the connection dropped for any reason), the `_read_loop` thread exited and called `_cancel_pending_requests` — but left `self._sock` non-`None`. All subsequent symbol queries (`get_symbols_overview`, `find_symbol`, etc.) would then send to the dead socket, receive a broken-pipe `OSError` that was silently swallowed, and wait 235 s before timing out. File-editing tools appeared to succeed because they only send notifications (no response awaited).

## Test plan

- [ ] Confirm existing tests pass (`pytest`)
- [ ] Manually verify: start Serena against a Godot project, restart the Godot editor mid-session, confirm the next tool call fails fast (within `request_timeout`) and subsequent calls reconnect successfully rather than hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)