### PR TITLE
refactor: enforce Language enum usage across all language servers

### DIFF
--- a/src/solidlsp/language_servers/ada_language_server.py
+++ b/src/solidlsp/language_servers/ada_language_server.py
@@ -16,7 +16,7 @@ from typing import cast
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -147,7 +147,7 @@ class AdaLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "ada",
+            Language.ADA,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/al_language_server.py
+++ b/src/solidlsp/language_servers/al_language_server.py
@@ -137,7 +137,7 @@ class ALLanguageServer(SolidLanguageServer):
         request fails, preventing repeated unsuccessful attempts.
         """
 
-        super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path), "al", solidlsp_settings)
+        super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path), Language.AL, solidlsp_settings)
 
         # Cache mapping (file_path, line, char) -> original_full_name for hover injection
         self._al_original_names: dict[tuple[str, int, int], str] = {}

--- a/src/solidlsp/language_servers/angular_language_server.py
+++ b/src/solidlsp/language_servers/angular_language_server.py
@@ -233,7 +233,7 @@ class AngularLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=ng_cmd, cwd=repository_root_path),
-            "angular",
+            Language.ANGULAR,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/ansible_language_server.py
+++ b/src/solidlsp/language_servers/ansible_language_server.py
@@ -14,7 +14,7 @@ from overrides import override
 
 from solidlsp.language_servers.common import RuntimeDependency, RuntimeDependencyCollection, build_npm_install_command
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -153,7 +153,7 @@ class AnsibleLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "ansible",
+            Language.ANSIBLE,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/bash_language_server.py
+++ b/src/solidlsp/language_servers/bash_language_server.py
@@ -17,7 +17,7 @@ from solidlsp.ls import (
     LSPFileBuffer,
     SolidLanguageServer,
 )
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import FileUtils, PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
@@ -99,7 +99,7 @@ class BashLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "bash",
+            Language.BASH,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/bsl_language_server.py
+++ b/src/solidlsp/language_servers/bsl_language_server.py
@@ -26,7 +26,7 @@ from solidlsp.ls import (
     LanguageServerDependencyProviderSinglePath,
     SolidLanguageServer,
 )
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -115,7 +115,7 @@ class BSLLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "bsl",
+            Language.BSL,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/ccls_language_server.py
+++ b/src/solidlsp/language_servers/ccls_language_server.py
@@ -41,7 +41,7 @@ from solidlsp.ls import (
     LanguageServerDependencyProviderSinglePath,
     SolidLanguageServer,
 )
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -63,7 +63,7 @@ class CCLS(SolidLanguageServer):
         Creates a CclsLanguageServer instance. This class is not meant to be instantiated directly.
         Use LanguageServer.create() instead.
         """
-        super().__init__(config, repository_root_path, None, "cpp", solidlsp_settings)
+        super().__init__(config, repository_root_path, None, Language.CPP, solidlsp_settings)
         self.server_ready = threading.Event()
 
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:

--- a/src/solidlsp/language_servers/clangd_language_server.py
+++ b/src/solidlsp/language_servers/clangd_language_server.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, ProcessLaunchInfo, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -71,7 +71,7 @@ class ClangdLanguageServer(SolidLanguageServer):
         """
         Creates a ClangdLanguageServer instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
-        super().__init__(config, repository_root_path, None, "cpp", solidlsp_settings)
+        super().__init__(config, repository_root_path, None, Language.CPP, solidlsp_settings)
         self.server_ready = threading.Event()
         self.service_ready_event = threading.Event()
         self.initialize_searcher_command_available = threading.Event()

--- a/src/solidlsp/language_servers/clojure_lsp.py
+++ b/src/solidlsp/language_servers/clojure_lsp.py
@@ -14,7 +14,7 @@ from typing import cast
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -236,7 +236,7 @@ class ClojureLSP(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "clojure",
+            Language.CLOJURE,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/crystal_language_server.py
+++ b/src/solidlsp/language_servers/crystal_language_server.py
@@ -9,7 +9,7 @@ import shutil
 import time
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -45,7 +45,7 @@ class CrystalLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=crystal_ls_path, cwd=repository_root_path),
-            "crystal",
+            Language.CRYSTAL,
             solidlsp_settings,
         )
         self._initialization_timestamp: float | None = None

--- a/src/solidlsp/language_servers/csharp_language_server.py
+++ b/src/solidlsp/language_servers/csharp_language_server.py
@@ -21,7 +21,7 @@ from solidlsp.ls import (
     RawDocumentSymbol,
     SolidLanguageServer,
 )
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_exceptions import SolidLSPException
 from solidlsp.ls_types import Hover
 from solidlsp.ls_utils import FileUtils, PathUtils
@@ -215,7 +215,7 @@ class CSharpLanguageServer(SolidLanguageServer):
         Creates a CSharpLanguageServer instance. This class is not meant to be instantiated directly.
         Use LanguageServer.create() instead.
         """
-        super().__init__(config, repository_root_path, None, "csharp", solidlsp_settings)
+        super().__init__(config, repository_root_path, None, Language.CSHARP, solidlsp_settings)
         # Cache for original Roslyn symbol names with type annotations
         # Key: (relative_file_path, line, character) -> Value: original name
         self._original_symbol_names: dict[tuple[str, int, int], str] = {}

--- a/src/solidlsp/language_servers/dart_language_server.py
+++ b/src/solidlsp/language_servers/dart_language_server.py
@@ -62,7 +62,7 @@ class DartLanguageServer(SolidLanguageServer):
         """
         executable_path = self._setup_runtime_dependencies(solidlsp_settings)
         super().__init__(
-            config, repository_root_path, ProcessLaunchInfo(cmd=executable_path, cwd=repository_root_path), "dart", solidlsp_settings
+            config, repository_root_path, ProcessLaunchInfo(cmd=executable_path, cwd=repository_root_path), Language.DART, solidlsp_settings
         )
 
     @override

--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -20,7 +20,7 @@ from overrides import override
 
 from solidlsp import ls_types
 from solidlsp.ls import LanguageServerDependencyProvider, LSPFileBuffer, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_exceptions import SolidLSPException
 from solidlsp.ls_types import UnifiedSymbolInformation
 from solidlsp.ls_utils import FileUtils, PlatformUtils
@@ -237,7 +237,7 @@ class EclipseJDTLS(SolidLanguageServer):
         Creates a new EclipseJDTLS instance initializing the language server settings appropriately.
         This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
-        super().__init__(config, repository_root_path, None, "java", solidlsp_settings)
+        super().__init__(config, repository_root_path, None, Language.JAVA, solidlsp_settings)
 
         # Extract runtime_dependency_paths from the dependency provider
         assert isinstance(self._dependency_provider, self.DependencyProvider)

--- a/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
+++ b/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
@@ -207,7 +207,7 @@ class ElixirTools(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=f"{expert_executable_path} --stdio", cwd=repository_root_path),
-            "elixir",
+            Language.ELIXIR,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/elm_language_server.py
+++ b/src/solidlsp/language_servers/elm_language_server.py
@@ -57,7 +57,7 @@ class ElmLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=elm_lsp_executable_path, cwd=repository_root_path, env=env),
-            "elm",
+            Language.ELM,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/erlang_language_server.py
+++ b/src/solidlsp/language_servers/erlang_language_server.py
@@ -11,7 +11,7 @@ import time
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
 
@@ -37,7 +37,7 @@ class ErlangLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=[self.erlang_ls_path, "--transport", "stdio"], cwd=repository_root_path),
-            "erlang",
+            Language.ERLANG,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/fortran_language_server.py
+++ b/src/solidlsp/language_servers/fortran_language_server.py
@@ -12,7 +12,7 @@ from overrides import override
 
 from solidlsp import ls_types
 from solidlsp.ls import DocumentSymbols, LSPConstants, LSPFileBuffer, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -187,7 +187,7 @@ class FortranLanguageServer(SolidLanguageServer):
         fortls_cmd = f"{fortls_path}"
 
         super().__init__(
-            config, repository_root_path, ProcessLaunchInfo(cmd=fortls_cmd, cwd=repository_root_path), "fortran", solidlsp_settings
+            config, repository_root_path, ProcessLaunchInfo(cmd=fortls_cmd, cwd=repository_root_path), Language.FORTRAN, solidlsp_settings
         )
 
     @staticmethod

--- a/src/solidlsp/language_servers/fsharp_language_server.py
+++ b/src/solidlsp/language_servers/fsharp_language_server.py
@@ -50,7 +50,7 @@ class FSharpLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=fsharp_lsp_executable_path, cwd=repository_root_path),
-            "fsharp",
+            Language.FSHARP,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/godot_language_server.py
+++ b/src/solidlsp/language_servers/godot_language_server.py
@@ -12,7 +12,7 @@ import pathlib
 from collections.abc import Callable
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_process import LanguageServerInterface, TCPConnectionInfo, TCPLanguageServer
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo, StringDict
@@ -47,7 +47,7 @@ class GodotLanguageServer(SolidLanguageServer):
             log.warning("Could not detect Godot version for project at %s", repository_root_path)
 
         # Dummy ProcessLaunchInfo — _create_language_server_interface() ignores it
-        super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd=""), "gdscript", solidlsp_settings)
+        super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd=""), Language.GDSCRIPT, solidlsp_settings)
 
     @staticmethod
     def _detect_godot_version(repo_path: str) -> int | None:

--- a/src/solidlsp/language_servers/gopls.py
+++ b/src/solidlsp/language_servers/gopls.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 from overrides import override
 
 from solidlsp.ls import RawDocumentSymbol, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -100,7 +100,9 @@ class Gopls(SolidLanguageServer):
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
         self._setup_runtime_dependency()
 
-        super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd="gopls", cwd=repository_root_path), "go", solidlsp_settings)
+        super().__init__(
+            config, repository_root_path, ProcessLaunchInfo(cmd="gopls", cwd=repository_root_path), Language.GO, solidlsp_settings
+        )
         self.request_id = 0
 
     def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:

--- a/src/solidlsp/language_servers/groovy_language_server.py
+++ b/src/solidlsp/language_servers/groovy_language_server.py
@@ -101,7 +101,7 @@ class GroovyLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=cmd, env=proc_env, cwd=repository_root_path),
-            "groovy",
+            Language.GROOVY,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/haskell_language_server.py
+++ b/src/solidlsp/language_servers/haskell_language_server.py
@@ -12,7 +12,7 @@ from typing import Any
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -99,7 +99,7 @@ class HaskellLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=[hls_executable_path, "--lsp", "--cwd", working_dir], cwd=working_dir, env=env),
-            "haskell",
+            Language.HASKELL,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/haxe_language_server.py
+++ b/src/solidlsp/language_servers/haxe_language_server.py
@@ -19,7 +19,7 @@ from solidlsp.ls import (
     LSPFileBuffer,
     SolidLanguageServer,
 )
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_exceptions import SolidLSPException
 from solidlsp.ls_types import Hover
 from solidlsp.lsp_protocol_handler.lsp_types import DiagnosticSeverity, InitializeParams
@@ -58,7 +58,7 @@ class HaxeLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "haxe",
+            Language.HAXE,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/hlsl_language_server.py
+++ b/src/solidlsp/language_servers/hlsl_language_server.py
@@ -16,7 +16,7 @@ from solidlsp.ls import (
     LanguageServerDependencyProviderSinglePath,
     SolidLanguageServer,
 )
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -63,7 +63,7 @@ class HlslLanguageServer(SolidLanguageServer):
     """
 
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings) -> None:
-        super().__init__(config, repository_root_path, None, "hlsl", solidlsp_settings)
+        super().__init__(config, repository_root_path, None, Language.HLSL, solidlsp_settings)
 
     @override
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:

--- a/src/solidlsp/language_servers/intelephense.py
+++ b/src/solidlsp/language_servers/intelephense.py
@@ -11,7 +11,7 @@ from time import sleep
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import Definition, DefinitionParams, InitializeParams, LocationLink
 from solidlsp.settings import SolidLSPSettings
@@ -95,7 +95,7 @@ class Intelephense(SolidLanguageServer):
             return [core_path, "--stdio"]
 
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
-        super().__init__(config, repository_root_path, None, "php", solidlsp_settings)
+        super().__init__(config, repository_root_path, None, Language.PHP, solidlsp_settings)
         self.request_id = 0
 
         # For PHP projects, we should ignore:

--- a/src/solidlsp/language_servers/jedi_server.py
+++ b/src/solidlsp/language_servers/jedi_server.py
@@ -11,7 +11,7 @@ from typing import cast
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -32,7 +32,7 @@ class JediServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd="jedi-language-server", cwd=repository_root_path),
-            "python",
+            Language.PYTHON,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/json_language_server.py
+++ b/src/solidlsp/language_servers/json_language_server.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from solidlsp.language_servers.common import RuntimeDependency, RuntimeDependencyCollection, build_npm_install_command
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -43,7 +43,7 @@ class JsonLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "json",
+            Language.JSON,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/julia_server.py
+++ b/src/solidlsp/language_servers/julia_server.py
@@ -9,7 +9,7 @@ from typing import Any
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import DiagnosticTag, InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -45,7 +45,7 @@ class JuliaLanguageServer(SolidLanguageServer):
         log.info(f"[JULIA DEBUG] Command: {julia_ls_cmd}")
 
         super().__init__(
-            config, repository_root_path, ProcessLaunchInfo(cmd=julia_ls_cmd, cwd=repository_root_path), "julia", solidlsp_settings
+            config, repository_root_path, ProcessLaunchInfo(cmd=julia_ls_cmd, cwd=repository_root_path), Language.JULIA, solidlsp_settings
         )
 
     @staticmethod

--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -30,7 +30,7 @@ from solidlsp.ls import (
     LanguageServerDependencyProviderSinglePath,
     SolidLanguageServer,
 )
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import FileUtils, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
@@ -95,7 +95,7 @@ class KotlinLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "kotlin",
+            Language.KOTLIN,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/lean4_language_server.py
+++ b/src/solidlsp/language_servers/lean4_language_server.py
@@ -13,7 +13,7 @@ from typing import cast
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -85,7 +85,7 @@ class Lean4LanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "lean4",
+            Language.LEAN4,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/lua_ls.py
+++ b/src/solidlsp/language_servers/lua_ls.py
@@ -196,7 +196,7 @@ class LuaLanguageServer(SolidLanguageServer):
         lua_ls_path = self._setup_runtime_dependency(solidlsp_settings)
 
         super().__init__(
-            config, repository_root_path, ProcessLaunchInfo(cmd=lua_ls_path, cwd=repository_root_path), "lua", solidlsp_settings
+            config, repository_root_path, ProcessLaunchInfo(cmd=lua_ls_path, cwd=repository_root_path), Language.LUA, solidlsp_settings
         )
         self.request_id = 0
 

--- a/src/solidlsp/language_servers/luau_lsp.py
+++ b/src/solidlsp/language_servers/luau_lsp.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import FileUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
@@ -267,7 +267,7 @@ class LuauLanguageServer(SolidLanguageServer):
         return self.DependencyProvider(self._custom_settings, self._ls_resources_dir)
 
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
-        super().__init__(config, repository_root_path, None, "luau", solidlsp_settings)
+        super().__init__(config, repository_root_path, None, Language.LUAU, solidlsp_settings)
         self.server_ready = threading.Event()
 
     @staticmethod

--- a/src/solidlsp/language_servers/marksman.py
+++ b/src/solidlsp/language_servers/marksman.py
@@ -17,7 +17,7 @@ from solidlsp.ls import (
     LSPFileBuffer,
     SolidLanguageServer,
 )
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_types import SymbolKind, UnifiedSymbolInformation
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
@@ -155,7 +155,7 @@ class Marksman(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "markdown",
+            Language.MARKDOWN,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/matlab_language_server.py
+++ b/src/solidlsp/language_servers/matlab_language_server.py
@@ -40,7 +40,7 @@ import threading
 from typing import Any, cast
 
 from solidlsp.ls import LanguageServerDependencyProvider, LSPFileBuffer, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import FileUtils
 from solidlsp.lsp_protocol_handler.lsp_types import DocumentSymbol, InitializeParams, SymbolInformation
 from solidlsp.settings import SolidLSPSettings
@@ -101,7 +101,7 @@ class MatlabLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "matlab",
+            Language.MATLAB,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/msl_language_server.py
+++ b/src/solidlsp/language_servers/msl_language_server.py
@@ -15,7 +15,7 @@ import threading
 from solidlsp.ls import (
     SolidLanguageServer,
 )
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -41,7 +41,7 @@ class MslLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             process_launch_info=process_launch_info,
-            language_id="msl",
+            language_id=Language.MSL,
             solidlsp_settings=solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/nixd_ls.py
+++ b/src/solidlsp/language_servers/nixd_ls.py
@@ -17,7 +17,7 @@ from overrides import override
 
 from solidlsp import ls_types
 from solidlsp.ls import DocumentSymbols, LSPFileBuffer, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -247,7 +247,9 @@ class NixLanguageServer(SolidLanguageServer):
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
         nixd_path = self._setup_runtime_dependency()
 
-        super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd=nixd_path, cwd=repository_root_path), "nix", solidlsp_settings)
+        super().__init__(
+            config, repository_root_path, ProcessLaunchInfo(cmd=nixd_path, cwd=repository_root_path), Language.NIX, solidlsp_settings
+        )
         self.request_id = 0
 
     @staticmethod

--- a/src/solidlsp/language_servers/ocaml_lsp_server.py
+++ b/src/solidlsp/language_servers/ocaml_lsp_server.py
@@ -17,7 +17,7 @@ from typing import Any
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -310,7 +310,7 @@ class OcamlLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=ocaml_lsp_cmd, cwd=repository_root_path),
-            "ocaml",
+            Language.OCAML,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/omnisharp.py
+++ b/src/solidlsp/language_servers/omnisharp.py
@@ -116,7 +116,9 @@ class OmniSharp(SolidLanguageServer):
                 "formattingOptions:indentationSize=4",
             ]
         )
-        super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path), "csharp", solidlsp_settings)
+        super().__init__(
+            config, repository_root_path, ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path), Language.CSHARP, solidlsp_settings
+        )
 
         self.server_ready = threading.Event()
         self.definition_available = threading.Event()

--- a/src/solidlsp/language_servers/pascal_server.py
+++ b/src/solidlsp/language_servers/pascal_server.py
@@ -172,7 +172,7 @@ class PascalLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=pasls_executable_path, cwd=repository_root_path, env=proc_env),
-            "pascal",
+            Language.PASCAL,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/perl_language_server.py
+++ b/src/solidlsp/language_servers/perl_language_server.py
@@ -14,7 +14,7 @@ from typing import Any
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import DidChangeConfigurationParams, InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
@@ -104,7 +104,7 @@ class PerlLanguageServer(SolidLanguageServer):
         perl_ls_cmd = self._setup_runtime_dependencies()
 
         super().__init__(
-            config, repository_root_path, ProcessLaunchInfo(cmd=perl_ls_cmd, cwd=repository_root_path), "perl", solidlsp_settings
+            config, repository_root_path, ProcessLaunchInfo(cmd=perl_ls_cmd, cwd=repository_root_path), Language.PERL, solidlsp_settings
         )
         self.request_id = 0
 

--- a/src/solidlsp/language_servers/phpactor.py
+++ b/src/solidlsp/language_servers/phpactor.py
@@ -110,7 +110,7 @@ class PhpactorServer(SolidLanguageServer):
             return ["php", core_path, "language-server"]
 
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
-        super().__init__(config, repository_root_path, None, "php", solidlsp_settings)
+        super().__init__(config, repository_root_path, None, Language.PHP, solidlsp_settings)
         # Override internal language enum for correct file matching
         self.language = Language.PHP_PHPACTOR
 

--- a/src/solidlsp/language_servers/powershell_language_server.py
+++ b/src/solidlsp/language_servers/powershell_language_server.py
@@ -248,7 +248,7 @@ class PowerShellLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path),
-            "powershell",
+            Language.POWERSHELL,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/pyright_server.py
+++ b/src/solidlsp/language_servers/pyright_server.py
@@ -13,7 +13,7 @@ from typing import cast
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -35,7 +35,7 @@ class PyrightServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "python",
+            Language.PYTHON,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/r_language_server.py
+++ b/src/solidlsp/language_servers/r_language_server.py
@@ -7,7 +7,7 @@ from typing import Any
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -66,7 +66,9 @@ class RLanguageServer(SolidLanguageServer):
         # Set specific options to improve parsing stability
         r_cmd = 'R --vanilla --quiet --slave -e "options(languageserver.debug_mode = FALSE); languageserver::run()"'
 
-        super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd=r_cmd, cwd=repository_root_path), "r", solidlsp_settings)
+        super().__init__(
+            config, repository_root_path, ProcessLaunchInfo(cmd=r_cmd, cwd=repository_root_path), Language.R, solidlsp_settings
+        )
 
     @staticmethod
     def _get_initialize_params(repository_absolute_path: str) -> InitializeParams:

--- a/src/solidlsp/language_servers/regal_server.py
+++ b/src/solidlsp/language_servers/regal_server.py
@@ -7,7 +7,7 @@ import shutil
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import PathUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
@@ -49,7 +49,7 @@ class RegalLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=f"{regal_executable_path} language-server", cwd=repository_root_path),
-            "rego",
+            Language.REGO,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -43,7 +43,11 @@ class RubyLsp(SolidLanguageServer):
         """
         ruby_lsp_executable = self._setup_runtime_dependencies(config, repository_root_path, solidlsp_settings)
         super().__init__(
-            config, repository_root_path, ProcessLaunchInfo(cmd=ruby_lsp_executable, cwd=repository_root_path), "ruby", solidlsp_settings
+            config,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=ruby_lsp_executable, cwd=repository_root_path),
+            Language.RUBY,
+            solidlsp_settings,
         )
         self.analysis_complete = threading.Event()
         self.service_ready_event = threading.Event()

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -14,7 +14,7 @@ from typing import cast
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -195,7 +195,7 @@ class RustAnalyzer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "rust",
+            Language.RUST,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/scala_language_server.py
+++ b/src/solidlsp/language_servers/scala_language_server.py
@@ -122,7 +122,7 @@ class ScalaLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=scala_lsp_executable_path, cwd=repository_root_path),
-            config.code_language.value,
+            config.code_language,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/solargraph.py
+++ b/src/solidlsp/language_servers/solargraph.py
@@ -15,7 +15,7 @@ import threading
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -39,13 +39,11 @@ class Solargraph(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=f"{solargraph_executable_path} stdio", cwd=repository_root_path),
-            "ruby",
+            Language.RUBY,
             solidlsp_settings,
         )
         # Override internal language enum for file matching (excludes .erb files)
         # while keeping LSP languageId as "ruby" for protocol compliance
-        from solidlsp.ls_config import Language
-
         self.language = Language.RUBY_SOLARGRAPH
         self.analysis_complete = threading.Event()
         self.service_ready_event = threading.Event()

--- a/src/solidlsp/language_servers/solidity_language_server.py
+++ b/src/solidlsp/language_servers/solidity_language_server.py
@@ -18,7 +18,7 @@ from overrides import override
 from solidlsp import ls_types
 from solidlsp.language_servers.common import RuntimeDependency, RuntimeDependencyCollection, build_npm_install_command
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, LSPConstants, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -64,7 +64,7 @@ class SolidityLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "solidity",
+            Language.SOLIDITY,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/some_sass_language_server.py
+++ b/src/solidlsp/language_servers/some_sass_language_server.py
@@ -33,7 +33,7 @@ from overrides import override
 
 from solidlsp.language_servers.common import RuntimeDependency, RuntimeDependencyCollection, build_npm_install_command
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -91,7 +91,7 @@ class SomeSassLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "scss",
+            Language.SCSS,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/sourcekit_lsp.py
+++ b/src/solidlsp/language_servers/sourcekit_lsp.py
@@ -9,7 +9,7 @@ from overrides import override
 
 from solidlsp import ls_types
 from solidlsp.ls import RawDocumentSymbol, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_types import SymbolKind
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
@@ -52,7 +52,11 @@ class SourceKitLSP(SolidLanguageServer):
         log.info(f"Starting sourcekit lsp with version: {sourcekit_version}")
 
         super().__init__(
-            config, repository_root_path, ProcessLaunchInfo(cmd="sourcekit-lsp", cwd=repository_root_path), "swift", solidlsp_settings
+            config,
+            repository_root_path,
+            ProcessLaunchInfo(cmd="sourcekit-lsp", cwd=repository_root_path),
+            Language.SWIFT,
+            solidlsp_settings,
         )
         self.request_id = 0
         self._did_sleep_before_requesting_references = False

--- a/src/solidlsp/language_servers/svelte_language_server.py
+++ b/src/solidlsp/language_servers/svelte_language_server.py
@@ -259,7 +259,7 @@ class SvelteLanguageServer(SolidLanguageServer):
             config,
             resolved_root,
             None,
-            "svelte",
+            Language.SVELTE,
             solidlsp_settings,
         )
         self.repo_path: str = resolved_root

--- a/src/solidlsp/language_servers/systemverilog_server.py
+++ b/src/solidlsp/language_servers/systemverilog_server.py
@@ -10,7 +10,7 @@ import subprocess
 from typing import Any, cast
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -32,7 +32,7 @@ class SystemVerilogLanguageServer(SolidLanguageServer):
     """
 
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings) -> None:
-        super().__init__(config, repository_root_path, None, "systemverilog", solidlsp_settings)
+        super().__init__(config, repository_root_path, None, Language.SYSTEMVERILOG, solidlsp_settings)
 
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
         return self.DependencyProvider(self._custom_settings, self._ls_resources_dir)

--- a/src/solidlsp/language_servers/taplo_server.py
+++ b/src/solidlsp/language_servers/taplo_server.py
@@ -17,7 +17,7 @@ from typing import Any
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import FileUtils, PathUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
@@ -129,7 +129,7 @@ class TaploServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "toml",
+            Language.TOML,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/terraform_ls.py
+++ b/src/solidlsp/language_servers/terraform_ls.py
@@ -214,7 +214,7 @@ class TerraformLS(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=f"{terraform_ls_executable_path} serve", cwd=repository_root_path),
-            "terraform",
+            Language.TERRAFORM,
             solidlsp_settings,
         )
         self.request_id = 0

--- a/src/solidlsp/language_servers/ty_server.py
+++ b/src/solidlsp/language_servers/ty_server.py
@@ -39,7 +39,7 @@ class TyLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            str(config.code_language),
+            config.code_language,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -14,7 +14,7 @@ from sensai.util.logging import LogTime
 
 from solidlsp import ls_types
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
@@ -91,7 +91,7 @@ class TypeScriptLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "typescript",
+            Language.TYPESCRIPT,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/vscode_html_language_server.py
+++ b/src/solidlsp/language_servers/vscode_html_language_server.py
@@ -28,7 +28,7 @@ from overrides import override
 
 from solidlsp.language_servers.common import RuntimeDependency, RuntimeDependencyCollection, build_npm_install_command
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -56,7 +56,7 @@ class VsCodeHtmlLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "html",
+            Language.HTML,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/vts_language_server.py
+++ b/src/solidlsp/language_servers/vts_language_server.py
@@ -46,7 +46,7 @@ class VtsLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=vts_lsp_executable_path, cwd=repository_root_path),
-            "typescript",
+            Language.TYPESCRIPT,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/vue_language_server.py
+++ b/src/solidlsp/language_servers/vue_language_server.py
@@ -174,7 +174,7 @@ class VueLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             ProcessLaunchInfo(cmd=vue_lsp_executable_path, cwd=repository_root_path),
-            "vue",
+            Language.VUE,
             solidlsp_settings,
         )
         self.server_ready = threading.Event()

--- a/src/solidlsp/language_servers/yaml_language_server.py
+++ b/src/solidlsp/language_servers/yaml_language_server.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from solidlsp.language_servers.common import RuntimeDependency, RuntimeDependencyCollection, build_npm_install_command
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.settings import SolidLSPSettings
 
@@ -55,7 +55,7 @@ class YamlLanguageServer(SolidLanguageServer):
             config,
             repository_root_path,
             None,
-            "yaml",
+            Language.YAML,
             solidlsp_settings,
         )
 

--- a/src/solidlsp/language_servers/zls.py
+++ b/src/solidlsp/language_servers/zls.py
@@ -12,7 +12,7 @@ import subprocess
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -97,7 +97,9 @@ class ZigLanguageServer(SolidLanguageServer):
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
         self._setup_runtime_dependency()
 
-        super().__init__(config, repository_root_path, ProcessLaunchInfo(cmd="zls", cwd=repository_root_path), "zig", solidlsp_settings)
+        super().__init__(
+            config, repository_root_path, ProcessLaunchInfo(cmd="zls", cwd=repository_root_path), Language.ZIG, solidlsp_settings
+        )
         self.request_id = 0
 
     @staticmethod

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -474,7 +474,7 @@ class SolidLanguageServer(ABC):
         config: LanguageServerConfig,
         repository_root_path: str,
         process_launch_info: ProcessLaunchInfo | None,
-        language_id: str,
+        language_id: Language,
         solidlsp_settings: SolidLSPSettings,
         cache_version_raw_document_symbols: Hashable = 1,
     ):
@@ -489,8 +489,8 @@ class SolidLanguageServer(ABC):
             the command used to start the actual language server.
             The command must pass appropriate flags to the binary, so that it runs in the stdio mode,
             as opposed to HTTP, TCP modes supported by some language servers.
-        :param language_id: The language identifier which will be passed to the language server in the `textDocument/didOpen`
-            notification by default.
+        :param language_id: The language identifier (``Language`` enum member) passed to the language server
+            in the `textDocument/didOpen` notification by default.
             If the language server uses multiple language identifiers, it must override the method `get_language_id_for_file`
             to provide the appropriate identifier for each type of file.
         :param cache_version_raw_document_symbols: the version, for caching, of the raw document symbols coming
@@ -513,7 +513,7 @@ class SolidLanguageServer(ABC):
 
         self.language_id = language_id
         self.open_file_buffers: dict[str, LSPFileBuffer] = {}
-        self.language = Language(language_id)
+        self.language = language_id
         self._published_diagnostics: dict[str, list[ls_types.Diagnostic]] = {}
         self._published_diagnostics_generation_by_uri: dict[str, int] = {}
         self._published_diagnostics_generation = 0


### PR DESCRIPTION
## Motivation
Raw string literals were used as language IDs (e.g. `"ada"`, `"go"`) across all language server constructors, making it easy to introduce typos and inconsistencies. The `Language` enum already existed but was underused.

## Summary
Replace all raw language ID strings with `Language` enum members across 64 language server files, and update the base class to accept the enum type directly.

## Changes
- Replace raw string language identifiers with `Language` enum members in all 64 language server files
- Update `SolidLanguageServer.__init__` signature to accept `Language` instead of `str`
- Remove redundant `Language(language_id)` cast in `ls.py` since callers now pass the enum directly
- Update `language_id` param docstring to reflect the enum type

## Breaking changes
`SolidLanguageServer.__init__` now requires a `Language` enum member for `language_id` instead of a plain `str`. Any third-party subclass must update its constructor call.