### PR TITLE
refactor(mcp): use public ToolManager(tools=) constructor instead of private dict mutation

### DIFF
--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -258,15 +258,36 @@ class SerenaMCPFactory:
         assert self.agent is not None
         yield from self.agent.get_exposed_tool_instances()
 
-    # noinspection PyProtectedMember
     def _set_mcp_tools(self, mcp: FastMCP, openai_tool_compatible: bool = False) -> None:
-        """Update the tools in the MCP server"""
-        if mcp is not None:
-            mcp._tool_manager._tools = {}
-            for tool in self._iter_tools():
-                mcp_tool = self.make_mcp_tool(tool, openai_tool_compatible=openai_tool_compatible)
-                mcp._tool_manager._tools[tool.get_name()] = mcp_tool
-            log.info(f"Starting MCP server with {len(mcp._tool_manager._tools)} tools: {list(mcp._tool_manager._tools.keys())}")
+        """Update the tools in the MCP server.
+
+        Implementation note (2026-05-17 PoC #30):
+        Original code mutated the private ``mcp._tool_manager._tools`` dict directly.
+        This version replaces ``mcp._tool_manager`` with a fresh ``ToolManager`` built
+        via its public constructor's ``tools=`` keyword argument — a documented contract
+        that is far less likely to break across mcp-python-sdk 1.x→2.x than dict-level
+        access to a private member named ``_tools``.
+
+        We still assign to ``mcp._tool_manager`` (a private attribute on FastMCP), but
+        this is a one-shot component replacement rather than ongoing dict mutation, and
+        the right-hand side uses only public, advertised API surface.
+        """
+        if mcp is None:
+            return
+        from mcp.server.fastmcp.tools.tool_manager import ToolManager
+
+        tools = [
+            self.make_mcp_tool(tool, openai_tool_compatible=openai_tool_compatible)
+            for tool in self._iter_tools()
+        ]
+        new_tm = ToolManager(
+            warn_on_duplicate_tools=mcp.settings.warn_on_duplicate_tools,
+            tools=tools,
+        )
+        mcp._tool_manager = new_tm
+        log.info(
+            f"Starting MCP server with {len(tools)} tools: {[t.name for t in tools]}"
+        )
 
     def _create_serena_agent(self, serena_config: SerenaConfig, modes: ModeSelectionDefinition | None = None) -> SerenaAgent:
         return SerenaAgent(


### PR DESCRIPTION
# refactor(mcp): use public ToolManager(tools=) constructor instead of private dict mutation

## Summary

Replaces direct mutation of the private `mcp._tool_manager._tools` dict in `_set_mcp_tools` with a fresh `ToolManager` constructed via its public `tools=` keyword argument. Reduces the breaking-change surface across mcp-python-sdk 1.x→2.x upgrades.

## Motivation

The current implementation in `src/serena/mcp.py:265-269` (now `262-291` in this branch) carries `# noinspection PyProtectedMember` because it mutates `mcp._tool_manager._tools` directly:

```python
mcp._tool_manager._tools = {}
for tool in self._iter_tools():
    mcp_tool = self.make_mcp_tool(tool, ...)
    mcp._tool_manager._tools[tool.get_name()] = mcp_tool
```

This is a known pain point — if `mcp-python-sdk` ever renames `_tools` (e.g., to `_items`, or restructures `ToolManager` internals), serena breaks silently with no obvious error path.

## Change

```python
from mcp.server.fastmcp.tools.tool_manager import ToolManager

tools = [self.make_mcp_tool(t, openai_tool_compatible=openai_tool_compatible)
         for t in self._iter_tools()]
new_tm = ToolManager(
    warn_on_duplicate_tools=mcp.settings.warn_on_duplicate_tools,
    tools=tools,
)
mcp._tool_manager = new_tm
```

Why this works:

- `ToolManager.__init__(*, tools: list[Tool] | None = None)` is a **documented public** keyword argument — see `mcp/server/fastmcp/tools/tool_manager.py:22-30`
- We pass pre-built `Tool` (from `mcp.server.fastmcp.tools.base`) instances into the constructor; `ToolManager` copies them into its internal dict
- Subsequent `mcp.list_tools()` / `mcp.call_tool()` work without modification

## Trade-offs

The change still assigns `mcp._tool_manager = new_tm`, which is a private attribute write. Unfortunately `FastMCP` exposes no public `swap_tool_manager()` method, so this single assignment is unavoidable. However:

- This is now a **one-shot component replacement** instead of ongoing **dict-level mutation**
- The right-hand side (`ToolManager(tools=...)`) uses only **public, documented contract**
- Future SDK refactors that change `_tools` internal structure will not break this code (only changes to the `tools=` kwarg or to `_tool_manager` attribute name would)

## Verification

E2E test (in our local fork's `poc/` dir, not included in this PR but reproducible):

```python
from mcp.server.fastmcp import FastMCP
from mcp.server.fastmcp.tools.base import Tool as MCPTool
from serena.mcp import SerenaMCPFactory

mcp = FastMCP(name="e2e")
fake_tools = [MCPTool.from_function(lambda x: x, name=f"stub-{i}", description=f"stub {i}")
              for i in range(3)]
factory = MagicMock(spec=SerenaMCPFactory)
factory._iter_tools = MagicMock(return_value=iter([MagicMock()] * 3))
factory.make_mcp_tool = MagicMock(side_effect=fake_tools)

SerenaMCPFactory._set_mcp_tools(factory, mcp)

tools_after = asyncio.run(mcp.list_tools())
assert sorted(t.name for t in tools_after) == ["stub-0", "stub-1", "stub-2"]
```

Result: `PASS: list_tools returned ['stub-0', 'stub-1', 'stub-2']` (✅).

## Test plan

- [ ] Run existing serena test suite locally
- [ ] Start serena MCP server (stdio mode) — verify `tools/list` returns expected count
- [ ] Call one tool end-to-end — verify same response as before

## Notes

- No behavior change visible to MCP clients
- No new dependencies
- One import added: `from mcp.server.fastmcp.tools.tool_manager import ToolManager` (lazy, inside the method)

---

Reference: this refactor came out of a private investigation into serena's mcp-python-sdk integration patterns (mem_1779016403249_jfkwgg in our local memory store).
