### PR TITLE
Include `.t` files in Perl::LanguageServer fileFilter

### DIFF
--- a/src/solidlsp/language_servers/perl_language_server.py
+++ b/src/solidlsp/language_servers/perl_language_server.py
@@ -28,6 +28,10 @@ class PerlLanguageServer(SolidLanguageServer):
     Provides Perl specific instantiation of the LanguageServer class using Perl::LanguageServer.
     """
 
+    # Keep in sync with Language.PERL.get_source_fn_matcher() in solidlsp/ls_config.py:
+    # extensions missing here are invisible to Perl::LanguageServer's project index.
+    _FILE_FILTER: list = [".pm", ".pl", ".t"]
+
     @staticmethod
     def _get_perl_version() -> str | None:
         """Get the installed Perl version or None if not found."""
@@ -162,7 +166,7 @@ class PerlLanguageServer(SolidLanguageServer):
 
             perl_config = {
                 "perlInc": [self.repository_root_path, "."],
-                "fileFilter": [".pm", ".pl"],
+                "fileFilter": self._FILE_FILTER,
                 "ignoreDirs": [".git", ".svn", "blib", "local", ".carton", "vendor", "_build", "cover_db"],
             }
 
@@ -198,7 +202,7 @@ class PerlLanguageServer(SolidLanguageServer):
             "settings": {
                 "perl": {
                     "perlInc": [self.repository_root_path, "."],
-                    "fileFilter": [".pm", ".pl"],
+                    "fileFilter": self._FILE_FILTER,
                     "ignoreDirs": [".git", ".svn", "blib", "local", ".carton", "vendor", "_build", "cover_db"],
                 }
             }

--- a/test/resources/repos/perl/test_repo/helper.t
+++ b/test/resources/repos/perl/test_repo/helper.t
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+
+use lib '.';
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+require helper;
+
+helper_function();
+ok(1, 'helper_function callable from .t file');

--- a/test/solidlsp/perl/test_perl_basic.py
+++ b/test/solidlsp/perl/test_perl_basic.py
@@ -78,6 +78,14 @@ class TestPerlLanguageServer:
         assert 20 in main_pl_lines, f"Expected reference at line 21 (0-indexed 20), found: {main_pl_lines}"
 
     @pytest.mark.parametrize("language_server", [Language.PERL], indirect=True)
+    def test_find_references_includes_t_files(self, language_server: SolidLanguageServer) -> None:
+        """References to a .pm/.pl sub must surface callers in .t test files (fileFilter includes .t)."""
+        reference_locations = language_server.request_references("helper.pl", 4, 5)
+
+        t_refs = [ref for ref in reference_locations if ref["uri"].endswith(".t")]
+        assert t_refs, f"Expected at least one reference in a .t file, got: {[r['uri'] for r in reference_locations]}"
+
+    @pytest.mark.parametrize("language_server", [Language.PERL], indirect=True)
     def test_bare_symbol_names(self, language_server) -> None:
         all_symbols = request_all_symbols(language_server)
         malformed_symbols = []


### PR DESCRIPTION
## Summary

`Language.PERL` in `solidlsp/ls_config.py:389` routes `.t` files to the
Perl LS, but `Perl::LanguageServer`'s own `fileFilter` was hardcoded to
`[".pm", ".pl"]` in `solidlsp/language_servers/perl_language_server.py`.
The LSP silently skipped `.t` files entirely - so any symbol or
reference query that depends on the LSP's index returned empty results
for tests.

This PR adds `.t` to the filter, deduplicates the two `fileFilter`
literals into a `_FILE_FILTER` class constant, and adds a comment
explicitly tying it to `Language.PERL.get_source_fn_matcher()` so the
two stay in sync if either is ever extended.

## How the bug manifests

Verified on a real Perl repo (Dancer2-Plugin-Argon2) before this fix:

- `get_symbols_overview("lib/Dancer2/Plugin/Argon2.pm")`
  -> `{"Variable": ["$VERSION"], "Function": ["passphrase"]}`  (works)
- `get_symbols_overview("t/01_default_settings.t")`
  -> `{}`  (empty - file is invisible to the LSP)

Local reproduction with the test added in this PR:

| Code state          | `test_find_references_includes_t_files` |
| ------------------- | --------------------------------------- |
| `main` (unpatched)  | FAILED                                  |
| this branch (fixed) | PASSED                                  |

So the visible behavior is closer to "the LSP ignores `.t` entirely"
than "per-file ops work but index queries miss them." The fix is the
same either way: include `.t` in the filter so the LSP indexes it.

## Test plan

- [x] New `test_find_references_includes_t_files` asserts cross-file
      references to a `.pm`/`.pl` sub surface callers in `.t` files.
- [x] All 7 perl tests pass locally with `Perl::LanguageServer` 2.x.
- [x] Verified the new test fails on unpatched `main` and passes on
      this branch.
- [x] `poe format` clean, `poe type-check` clean.

## Note for maintainers

Perl is currently the only language server in the codebase that pushes
a positive extension whitelist to its LSP, so this drift surface is
unique today. A structural fix (deriving `fileFilter` from
`Language.PERL.get_source_fn_matcher()`) would prevent the same class
of mismatch recurring, but seems heavier than warranted for a single
caller. Happy to do it as a follow-up if you'd prefer.

Pre-existing (not changed here, just noted for visibility): the
`ignoreDirs` payload at the same two sites partly overlaps with both
the base `_ALWAYS_IGNORED_DIRS` and the `is_ignored_dirname` override
in this file. Three lists in different layers. Out of scope for this
PR.