### PR TITLE
TypeScript: stop hard-ignoring source directories named `coverage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Status of the `main` branch. Changes prior to the next official version change w
     The dict is forwarded to vtsls via `initializationOptions`, `workspace/didChangeConfiguration`,
     and `workspace/configuration` pulls. Enables Yarn PnP setups with `typescript.tsdk` pointing
     at the Yarn-generated SDK.
+  - `typescript` / `typescript_vts`: No longer ignore directories named `coverage`. This was intended to skip
+    coverage-report output, but matched by bare dirname and so also hid legitimate source directories named
+    `coverage` (e.g. `src/routes/coverage/`) from symbol tools. Generated report dirs are already covered by
+    gitignore. Fixes #1523.
 
 * Dashboard: 
   - Fix: Host validation required a local host regardless of the listen address (regression introduced in v1.5.2),

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -132,7 +132,6 @@ class TypeScriptLanguageServer(SolidLanguageServer):
             "node_modules",
             "dist",
             "build",
-            "coverage",
         ]
 
     @staticmethod

--- a/src/solidlsp/language_servers/vts_language_server.py
+++ b/src/solidlsp/language_servers/vts_language_server.py
@@ -71,7 +71,6 @@ class VtsLanguageServer(SolidLanguageServer):
             "node_modules",
             "dist",
             "build",
-            "coverage",
         ]
 
     @classmethod

--- a/test/solidlsp/typescript/test_typescript_ignored_dirs.py
+++ b/test/solidlsp/typescript/test_typescript_ignored_dirs.py
@@ -1,0 +1,35 @@
+"""
+Tests for TypeScript language server directory-ignoring behavior.
+
+Regression test for the case where a *source* directory named `coverage`
+(e.g. `src/routes/coverage/`) was hard-ignored by `is_ignored_dirname`,
+hiding it from symbol tools. Only generated coverage-report dirs should be
+excluded, and those are handled by gitignore.
+"""
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+
+pytestmark = pytest.mark.typescript
+
+
+@pytest.mark.parametrize("language_server", [Language.TYPESCRIPT], indirect=True)
+class TestTypescriptIgnoredDirectories:
+    """TypeScript-specific directory ignoring behavior."""
+
+    def test_generated_dirs_still_ignored(self, language_server: SolidLanguageServer) -> None:
+        assert language_server.is_ignored_dirname("node_modules"), "node_modules should be ignored"
+        assert language_server.is_ignored_dirname("dist"), "dist should be ignored"
+        assert language_server.is_ignored_dirname("build"), "build should be ignored"
+        # VCS dir handled by the base class
+        assert language_server.is_ignored_dirname(".git"), ".git should be ignored"
+
+    def test_source_dirs_not_ignored(self, language_server: SolidLanguageServer) -> None:
+        # `coverage` is a legitimate source/module name; only generated
+        # coverage-report dirs (which are gitignored) should be excluded.
+        assert not language_server.is_ignored_dirname("coverage"), "coverage source dir should not be ignored"
+        assert not language_server.is_ignored_dirname("src"), "src should not be ignored"
+        assert not language_server.is_ignored_dirname("lib"), "lib should not be ignored"
+        assert not language_server.is_ignored_dirname("routes"), "routes should not be ignored"


### PR DESCRIPTION
## Problem

The TypeScript language servers (`typescript_language_server.py` and `vts_language_server.py`) hard-ignore any directory named `coverage` in `is_ignored_dirname`:

```python
return super().is_ignored_dirname(dirname) or dirname in ["node_modules", "dist", "build", "coverage"]
```

The intent is to skip Jest/nyc coverage-**report** output, but the match is on bare dirname, so it also excludes legitimate **source** directories named `coverage` (e.g. a REST resource at `src/routes/coverage/`). Symbol tools then fail with `Cannot extract symbols` for every file under such a dir, even though it is not gitignored and `is_ignored_path` reports it as not ignored — and there is no config hook to override `is_ignored_dirname`.

Fixes #1523.

## Fix

Remove `"coverage"` from the hardcoded list in both TS servers. A real coverage-report directory is generated output and is essentially always gitignored, so gitignore already excludes it — mirroring the reasoning in #1203 (only hardcode what's universal; rely on gitignore for generated dirs).

`node_modules` / `dist` / `build` are intentionally left in place to keep this a single, well-scoped change.

## Test

Adds `test/solidlsp/typescript/test_typescript_ignored_dirs.py` (mirroring `test_toml_ignored_dirs.py`): asserts `coverage`, `src`, `lib`, `routes` are not ignored while `node_modules` / `dist` / `build` / `.git` still are.
