### PR TITLE
fix(nix): Add Linux-support for the tray manager in AppIndicator trays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Decouple configuration computation from the agent's task queue by introducing events for agent config/status updates.
     This allows the dashboard to display the configuration while the project provided at startup is still initialising. #1064
   - Fix empty executions queue displaying "Loading..."
+  - Tray manager: Add NixOS-support for AppIndicator-based trays (e.g., most Wayland-trays) to the package in flake.nix.
 
 # v1.5.3 (2026-05-26)
 

--- a/docs/02-usage/060_dashboard.md
+++ b/docs/02-usage/060_dashboard.md
@@ -25,7 +25,7 @@ The dashboard is a web application, which is opened in one of three ways:
   * via a tray manager that aggregates multiple instances (on supported platforms) 
   * via your default web browser (supported on all platforms)
 
-Configure your preferred interface via the setting `web_dashoard_interface` in [Serena's global configuration file](global-config) (see below).
+Configure your preferred interface via the setting `web_dashboard_interface` in [Serena's global configuration file](global-config) (see below).
 
 By default, the dashboard can be accessed at `http://localhost:24282/dashboard/index.html`,
 but a higher port may be used if the default port is unavailable/multiple instances are running.

--- a/flake.nix
+++ b/flake.nix
@@ -50,27 +50,79 @@
         sourcePreference = "wheel"; # or sourcePreference = "sdist";
       };
 
-      pyprojectOverrides = final: prev: {
-        # Add setuptools for packages that need it during build
-        ruamel-yaml-clib = prev.ruamel-yaml-clib.overrideAttrs (old: {
-          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-            final.setuptools
-          ];
-        });
-        proxy-tools = prev.proxy-tools.overrideAttrs (old: {
-          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-            final.setuptools
-          ];
-        });
-        pywebview = prev.pywebview.overrideAttrs (old: {
-          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-            final.setuptools
-            final.setuptools-scm
-          ];
-        });
-      };
-
       python = pkgs.python311;
+      pyprojectHacks = pkgs.callPackage pyproject-nix.build.hacks {};
+
+      pyprojectOverrides = final: prev:
+        {
+          # Add setuptools for packages that need it during build
+          ruamel-yaml-clib = prev.ruamel-yaml-clib.overrideAttrs (old: {
+            nativeBuildInputs =
+              (old.nativeBuildInputs or [])
+              ++ [
+                final.setuptools
+              ];
+          });
+          proxy-tools = prev.proxy-tools.overrideAttrs (old: {
+            nativeBuildInputs =
+              (old.nativeBuildInputs or [])
+              ++ [
+                final.setuptools
+              ];
+          });
+          pywebview = prev.pywebview.overrideAttrs (old: {
+            nativeBuildInputs =
+              (old.nativeBuildInputs or [])
+              ++ [
+                final.setuptools
+                final.setuptools-scm
+              ];
+          });
+        }
+        // lib.optionalAttrs pkgs.stdenv.isLinux {
+          # pyproject-nix's virtualenv resolver follows pyproject-style
+          # passthru.dependencies, while these GI bindings are already packaged
+          # by nixpkgs' Python infrastructure. nixpkgsPrebuilt is the upstream
+          # adapter for that case:
+          # https://pyproject-nix.github.io/pyproject.nix/builders/hacks.html#using-prebuilt-packages-from-nixpkgs
+          pycairo = pyprojectHacks.nixpkgsPrebuilt {
+            from = python.pkgs.pycairo;
+            prev = {
+              passthru = {
+                dependencies = {};
+                optional-dependencies = {};
+                dependency-groups = {};
+              };
+            };
+          };
+          pygobject3 = pyprojectHacks.nixpkgsPrebuilt {
+            from = python.pkgs.pygobject3;
+            prev = {
+              passthru = {
+                dependencies = {
+                  pycairo = [];
+                };
+                optional-dependencies = {};
+                dependency-groups = {};
+              };
+            };
+          };
+
+          # pystray has an optional AppIndicator backend on Linux. Its uv lock
+          # metadata does not encode the GI dependency, so add the runtime edge
+          # here while keeping pystray itself lockfile-driven.
+          pystray = prev.pystray.overrideAttrs (old: {
+            passthru =
+              (old.passthru or {})
+              // {
+                dependencies =
+                  (old.passthru.dependencies or {})
+                  // {
+                    pygobject3 = [];
+                  };
+              };
+          });
+        };
 
       pythonSet =
         (pkgs.callPackage pyproject-nix.build.packages {
@@ -88,20 +140,48 @@
 
       packages = {
         serena-env = pythonSet.mkVirtualEnv "serena-env" workspace.deps.default;
-        serena = pkgs.runCommand "serena" {
-            meta = {
-              description = "A powerful coding agent toolkit providing semantic retrieval and editing capabilities (MCP server & Agno integration)";
-              homepage = "https://oraios.github.io/serena";
-              changelog = "https://github.com/oraios/serena/blob/main/CHANGELOG.md";
-              mainProgram = "serena";
-              license = pkgs.lib.licenses.mit;
-              platforms = lib.platforms.all;
-            };
-          } ''
-          mkdir -p $out/bin
-          ln -s ${packages.serena-env}/bin/serena $out/bin/serena
-          ln -s ${packages.serena-env}/bin/serena-hooks $out/bin/serena-hooks
-        '';
+        serena = pkgs.stdenv.mkDerivation {
+          name = "serena";
+          dontUnpack = true;
+          dontWrapGApps = true;
+          nativeBuildInputs =
+            [pkgs.makeWrapper]
+            ++ lib.optionals pkgs.stdenv.isLinux [
+              pkgs.wrapGAppsHook3
+              pkgs.gobject-introspection
+            ];
+          buildInputs = lib.optionals pkgs.stdenv.isLinux [
+            pkgs.gtk3
+            pkgs.libayatana-appindicator
+          ];
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/bin
+            ${
+              lib.optionalString (!pkgs.stdenv.isLinux) ''
+                ln -s ${packages.serena-env}/bin/serena $out/bin/serena
+              ''
+            }
+            ln -s ${packages.serena-env}/bin/serena-hooks $out/bin/serena-hooks
+
+            runHook postInstall
+          '';
+          # Run the GApps fixup phase so the wrapper gets GI_TYPELIB_PATH for
+          # Gtk and AyatanaAppIndicator3. This is the same pattern nixpkgs uses
+          # for pystray consumers such as plex-mpv-shim and jellyfin-mpv-shim.
+          preFixup = lib.optionalString pkgs.stdenv.isLinux ''
+            makeWrapper ${packages.serena-env}/bin/serena $out/bin/serena "''${gappsWrapperArgs[@]}"
+          '';
+          meta = {
+            description = "A powerful coding agent toolkit providing semantic retrieval and editing capabilities (MCP server & Agno integration)";
+            homepage = "https://oraios.github.io/serena";
+            changelog = "https://github.com/oraios/serena/blob/main/CHANGELOG.md";
+            mainProgram = "serena";
+            license = pkgs.lib.licenses.mit;
+            platforms = lib.platforms.all;
+          };
+        };
         default = packages.serena;
       };
 

--- a/src/serena/resources/serena_config.template.yml
+++ b/src/serena/resources/serena_config.template.yml
@@ -61,6 +61,8 @@ web_dashboard_open_on_launch: True
 #      opening the dashboard in browser tabs when selected from the tray menu.
 #      This is EXPERIMENTAL. It is tested on Windows only. We will establish macOS support, but it is yet untested.
 #      On Linux, this cannot be universally supported, but it may work in some desktop environments.
+#      On NixOS, when using the package from flake.nix, both modern AppIndicator trays as well as
+#      older Xorg-/XEmbed-based trays should be supported.
 # See https://oraios.github.io/serena/02-usage/060_dashboard.html
 web_dashboard_interface:
 


### PR DESCRIPTION
## What this means for users

With this PR, users of Serena's Nix package can use `web_dashboard_interface: tray_manager` on Linux desktops whose tray uses StatusNotifier/AppIndicator, including common Wayland setups.
Existing Xorg/XEmbed tray behavior is not removed, and non-Linux package outputs are unchanged.

This PR only touches `flake.nix`.

## Background

In Wayland-based environments, which usually use StatusNotifier/AppIndicator trays, `web_dashboard_interface: tray_manager` needs pystray's AppIndicator backend.
The current Nix package does not provide this, and pystray instead falls back to its Xorg/XEmbed backend.
The result is that no tray icon will appear for StatusNotifier/AppIndicator trays, even if the tray manager started successfully.
Explicitly setting `PYSTRAY_BACKEND=appindicator` exposes the failure, causing the tray manager to fail startup, because the Python GI bindings and GTK/AppIndicator typelibs are not available in the virtualenv/wrapper, and it is not allowed to fall back to other backends.

## Reproducing the Issue

Build Serena using Nix (under Linux), for example with `nix build .#serena --no-link --print-out-paths`, run:

```sh
serena_out=/nix/store/...-serena
serena_wrapper="$serena_out/bin/serena"
serena_entry="$(strings "$serena_wrapper" | grep '/serena-env/bin/serena$' | head -1)"
serena_python="$(head -1 "$serena_entry" | sed 's|^#!||')"

export PYSTRAY_BACKEND=appindicator
export GI_TYPELIB_PATH="$(strings "$serena_wrapper" | grep '^/nix/store/.*/lib/girepository-1.0' | head -1)"
export XDG_DATA_DIRS="$(strings "$serena_wrapper" | grep '^/nix/store/.*/share/gsettings-schemas' | head -1)"
export GIO_EXTRA_MODULES="$(strings "$serena_wrapper" | grep '^/nix/store/.*/lib/gio/modules' | paste -sd: -)"

"$serena_python" - <<'PY'
import pystray
print(f"pystray backend: {pystray.Icon.__module__}")
from gi.repository import Gtk, AyatanaAppIndicator3
print("gtk/appindicator typelibs: ok")
from serena.dashboard import SerenaDashboardTrayManager
manager = SerenaDashboardTrayManager()
print(f"constructed: {manager.__class__.__name__}")
PY
```

This reconstructs the relevant environment from the Nix-built `serena` wrapper and confirms that pystray selects the AppIndicator backend and that GTK/Ayatana typelibs are visible.

## Additional Environment Note

In sandboxed MCP hosts such as Codex, the Serena process may not inherit desktop session variables even when the parent desktop has them. For the tray manager to interact with the desktop session, the launcher may need to pass through variables such as:

- `DISPLAY`
- `WAYLAND_DISPLAY`
- `XDG_CURRENT_DESKTOP`
- `DESKTOP_SESSION`
- `XDG_SESSION_DESKTOP`
- `XDG_SESSION_TYPE`
- `XDG_RUNTIME_DIR`
- `DBUS_SESSION_BUS_ADDRESS`

That environment setup is separate from this Nix packaging fix.
The packaging change makes the AppIndicator backend importable and correctly wrapped; the launcher still has to provide access to the user's graphical/session D-Bus environment.
In my Nix config I provide this environment through a simple wrapper script: https://github.com/futile/nixos-config/blob/27b3f6bd35537cf1dbb755cef9e2547b3f4f13d1/bin/serena-mcp-with-desktop-env

This is NOT anything that needs to (or can) be handled in this repo, but it might be necessary to reproduce the issue and fix successfully, and might be relevant for other Linux/Codex users as well.

## Additional Option/Follow-Up Possibility

For non-Nix installs, we could also (in this PR or a follow-up) add a Python optional extra such as `tray-appindicator = ["pygobject"]`, although I'm not familiar with this at all to give more info/trade-offs on this.

While that could help document/install the Python-level dependency, it would not replace this Nix change because GTK/AppIndicator native libraries and typelibs still need to be present in the runtime environment.

## Validation

- `nix fmt flake.nix`
- `nix flake check`
- `nix build .#serena --no-link --print-out-paths`
- Reproduction from above succeeds, output:
  - `pystray backend: pystray._appindicator`
  - `gtk/appindicator typelibs: ok`
  - `constructed: SerenaDashboardTrayManager`

---

Assisted-by: gpt-5.5