### PR TITLE
solidlsp: recognize Arduino .ino files as C++

### DIFF
--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -350,6 +350,11 @@ class Language(str, Enum):
                     # OpenCL
                     ".cl",
                     ".clcpp",
+                    # Arduino sketch: not in clang's extension table, but it is C++.
+                    # Routing it here lets clangd serve symbols; the project must
+                    # tell clangd it is C++ (a .clangd with CompileFlags Add: [-xc++],
+                    # or a compile DB), since the clang driver can't infer a job from .ino.
+                    ".ino",
                     case_sensitive=False,
                 )
             case self.CPP_CCLS:
@@ -375,6 +380,8 @@ class Language(str, Enum):
                     # Objective-C
                     ".m",
                     ".mm",
+                    # Arduino sketch (C++); see note in the CPP case above.
+                    ".ino",
                     case_sensitive=False,
                 )
             case self.KOTLIN:

--- a/test/solidlsp/cpp/test_cpp_basic.py
+++ b/test/solidlsp/cpp/test_cpp_basic.py
@@ -24,6 +24,20 @@ if language_tests_enabled(Language.CPP_CCLS):
     _cpp_servers.append(Language.CPP_CCLS)
 
 
+@pytest.mark.parametrize("language", [Language.CPP, Language.CPP_CCLS])
+def test_source_fn_matcher_includes_ino(language: Language) -> None:
+    """Arduino .ino sketches are C++ and must route to the C++ language server.
+
+    This is a pure matcher check; it needs no running language server.
+    """
+    matcher = language.get_source_fn_matcher()
+    assert matcher.is_relevant_filename("sketch.ino")
+    assert matcher.is_relevant_filename("BLINK.INO")  # case-insensitive
+    assert matcher.is_relevant_filename("/path/to/s3_camera.ino")
+    assert matcher.is_relevant_filename("main.cpp")  # regression: ordinary C++ still matches
+    assert not matcher.is_relevant_filename("notes.md")
+
+
 @pytest.mark.cpp
 @pytest.mark.skipif(not _cpp_servers, reason="No C++ language server (clangd or ccls) available")
 class TestCppLanguageServer:


### PR DESCRIPTION
## What

`.ino` (Arduino sketch) files are C++, but they were absent from the `CPP` and `CPP_CCLS` source-file matchers in `Language.get_source_fn_matcher()`. So Serena routed them to no language server and rejected every symbol operation with:

> Cannot extract symbols from file ....ino. Active languages: [...]

even with `cpp` configured as a project language. This adds `.ino` to both matchers.

## Why the matcher alone isn't the whole story (and that's fine)

clangd builds its compile command from the filename, and the clang driver doesn't recognise `.ino`, so on its own clangd reports `fe_expected_compiler_job` ("Unable to handle compilation, expected exactly one compiler job") and returns no AST. The project just needs to declare the language, the same as any non-standard C++ extension. A `.clangd` in the source tree does it:

```yaml
If:
  PathMatch: .*\.ino
CompileFlags:
  Add: [-xc++]
```

With that present, clangd returns the full document-symbol tree. Verified against a real 1872-line ESP32 sketch: hard-rejected by the matcher before (0 symbols), 204 symbols after. Without this matcher change no project config can help, because the file never reaches clangd.

## Changes

- `.ino` added to the `CPP` (clangd) and `CPP_CCLS` (ccls) matchers, with a comment pointing at the `.clangd` / `-xc++` requirement.
- Server-independent unit test asserting `.ino` (any case) matches for both languages, ordinary `.cpp` still matches, and unrelated files don't.

## Test plan

- [x] `test_source_fn_matcher_includes_ino` assertions verified (parametrized over `CPP` and `CPP_CCLS`): `.ino` / `.INO` / path-qualified `.ino` match, `.cpp` still matches, `.md` is rejected.
- [x] End-to-end with clangd 22.1.0 over raw LSP: `didOpen` (languageId `cpp`) + `documentSymbol` on a real `.ino` returns 204 symbols when a `.clangd` supplies `-xc++`, and reproduces `fe_expected_compiler_job` without it.
- [ ] Full `pytest -m cpp` suite not run in this environment; the new test is independent of the language-server fixtures.
