### PR TITLE
JetBrains: add jet_brains_find_unused_code tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: Host validation required a local host regardless of the listen address (regression introduced in v1.5.2),
     preventing remote connections
 
+* JetBrains:
+  - Add new tool `jet_brains_find_unused_code`: reports code symbols (classes, methods, fields, ...) declared in a
+    file that have no references in the project — likely-dead code (usage-based heuristic via the IDE's reference
+    search). Requires Serena JetBrains plugin version 2023.2.17+.
+
 # v1.5.3 (2026-05-26)
 
 Add meta-data for the GitHub MCP registry

--- a/src/serena/jetbrains/jetbrains_plugin_client.py
+++ b/src/serena/jetbrains/jetbrains_plugin_client.py
@@ -633,6 +633,20 @@ class JetBrainsPluginClient(ToStringMixin):
         self._postprocess_symbol_collection_response(symbol_collection)
         return symbol_collection
 
+    def find_unused_code(self, relative_path: str, include_quick_info: bool = False) -> jb.SymbolCollectionResponse:
+        """
+        Finds code symbols (classes, methods, fields, ...) declared in the given file that have no references
+        anywhere in the project, i.e. code that is likely unused.
+
+        :param relative_path: the relative path to the file to analyze for unused code
+        :param include_quick_info: whether to include quick info (typically the signature) for each unused symbol
+        """
+        self._require_version_at_least(2023, 2, 17)
+        request_data = {"relativePath": relative_path, "includeQuickInfo": include_quick_info}
+        symbol_collection = cast(jb.SymbolCollectionResponse, self._make_request("POST", "/findUnusedCode", request_data))
+        self._postprocess_symbol_collection_response(symbol_collection)
+        return symbol_collection
+
     def debug_eval(self, repl_key: str, expression: str) -> dict[str, Any]:
         """
         Evaluates a Groovy expression in the persistent debug REPL.

--- a/src/serena/resources/config/internal_modes/jetbrains.yml
+++ b/src/serena/resources/config/internal_modes/jetbrains.yml
@@ -6,6 +6,8 @@ prompt: |
     * `jet_brains_find_referencing_symbols` replaces `find_referencing_symbols`
     * `jet_brains_get_symbols_overview` replaces `get_symbols_overview`
     * `jet_brains_rename` replaces `rename_symbol`
+  In addition, `jet_brains_find_unused_code` reports code symbols in a file that have no references in the
+  project (a usage-based heuristic for finding likely-dead code).
 excluded_tools:
   - find_symbol
   - find_referencing_symbols
@@ -32,3 +34,4 @@ included_optional_tools:
   - serena_info
   - jet_brains_run_inspections
   - jet_brains_list_inspections
+  - jet_brains_find_unused_code

--- a/src/serena/tools/jetbrains_tools.py
+++ b/src/serena/tools/jetbrains_tools.py
@@ -668,3 +668,45 @@ class JetBrainsListInspectionsTool(Tool, ToolMarkerSymbolicRead, ToolMarkerOptio
             )
         result = self._to_json(response_dict)
         return self._limit_length(result, max_answer_chars)
+
+
+class JetBrainsFindUnusedCodeTool(Tool, ToolMarkerSymbolicRead, ToolMarkerOptional, ToolMarkerBeta):
+    """
+    Finds likely-unused code symbols (classes, methods, fields, ...) in a file using the JetBrains backend
+    """
+
+    symbol_dict_grouper = JetBrainsSymbolDictGrouper(["relative_path", "type"], ["type"], collapse_singleton=True)
+
+    def apply(
+        self,
+        relative_path: str,
+        include_quick_info: bool = False,
+        max_answer_chars: int = -1,
+    ) -> str:
+        """
+        Finds code symbols (classes, methods, fields, etc.) declared in the given file that have no references
+        anywhere in the project, i.e. code that is likely unused and may be safe to remove.
+        This is a usage-based heuristic computed via the IDE's reference search: entry points (e.g. main methods,
+        public API that is consumed outside the project) and reflective/framework usages are NOT accounted for, and
+        transitively dead code (a private member used only by other dead code) is not reported. Review results
+        before deleting anything.
+
+        :param relative_path: the relative path to the file to analyze for unused code.
+        :param include_quick_info: whether to include quick info (typically the signature) for each unused symbol.
+        :param max_answer_chars: max characters for the result (-1 for default). If exceeded, no content/a shortened
+            result is returned.
+        :return: the unused symbols grouped by file and type; a message stating that none were found if the file has
+            no unused symbols.
+        """
+        relative_path = self._sanitize_input_param(relative_path)
+        with JetBrainsPluginClient.from_project(self.project) as client:
+            response_dict = client.find_unused_code(
+                relative_path=relative_path,
+                include_quick_info=include_quick_info,
+            )
+        symbols = response_dict["symbols"]
+        if not symbols:
+            return f"No unused code symbols found in {relative_path}."
+        grouped = self.symbol_dict_grouper.group(symbols)
+        result = self._to_json(grouped)
+        return self._limit_length(result, max_answer_chars)


### PR DESCRIPTION
## Summary

Adds a new JetBrains-backend tool, **`jet_brains_find_unused_code`**, which reports code symbols
(classes, methods, fields, …) declared in a file that have **no references anywhere in the project** —
i.e. code that is likely unused/dead.

It is a thin client over a new `/findUnusedCode` endpoint in the Serena JetBrains plugin: the plugin
walks the IDE's structure-view declaration tree and flags each declaration whose PSI reference search
comes back empty.

## Changes

- `jetbrains/jetbrains_plugin_client.py`: new `find_unused_code(relative_path, include_quick_info)`
  client method (calls `/findUnusedCode`; version-gated to plugin **2023.2.17+**).
- `tools/jetbrains_tools.py`: new `JetBrainsFindUnusedCodeTool` (`ToolMarkerSymbolicRead`,
  `ToolMarkerOptional`, `ToolMarkerBeta`); groups results by file/type, or returns a "none found" message.
- `resources/config/internal_modes/jetbrains.yml`: register `jet_brains_find_unused_code` in
  `included_optional_tools` (so the `JetBrains` language backend exposes it) and mention it in the mode prompt.
- `CHANGELOG.md`: entry under *Unreleased → JetBrains*.

## Caveats (documented in the tool description)

This is a **usage-based heuristic** via the IDE's reference search:

- entry points (e.g. `main` methods, public API consumed *outside* the project) and reflective/framework
  usages are **not** accounted for and may produce false positives;
- transitively-dead code (a private member used only by other dead code) is not reported.

So results should be reviewed before deletion.

## Requirements

Requires the **Serena JetBrains plugin 2023.2.17+** (which adds the `/findUnusedCode` endpoint). The
client raises a clear "update the plugin" error against older versions.

## Testing

Verified end-to-end against the plugin's headless Docker harness (the serena MCP server built from this
checkout, driving the plugin in IntelliJ): on a sample project the tool reports the one unused private
method and omits the used members, via the full round-trip
`MCP client → serena → plugin /findUnusedCode → IntelliJ PSI`. `poe format` and `poe type-check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
