### PR TITLE
SvelteLanguageServer: Fix diagnostics requests for TypeScript/JavaScript files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     The dict is forwarded to vtsls via `initializationOptions`, `workspace/didChangeConfiguration`,
     and `workspace/configuration` pulls. Enables Yarn PnP setups with `typescript.tsdk` pointing
     at the Yarn-generated SDK.
+  - `SvelteLanguageServer`: Fix diagnostics requests for TypeScript/JavaScript files incorrectly being
+    processed by the Svelte LS instead of the TypeScript LS.
 
 * Dashboard:
   - Make list of trusted hosts configurable, fixing host validation introduced in v1.5.2 allowing only

--- a/src/solidlsp/language_servers/svelte_language_server.py
+++ b/src/solidlsp/language_servers/svelte_language_server.py
@@ -648,6 +648,19 @@ class SvelteLanguageServer(SolidLanguageServer):
         return super().request_definition(relative_file_path, line, column)
 
     @override
+    def request_text_document_diagnostics(
+        self,
+        relative_file_path: str,
+        start_line: int = 0,
+        end_line: int = -1,
+        min_severity: int = 4,
+    ) -> list[ls_types.Diagnostic]:
+        if _is_ts_file(relative_file_path) and self._ts_server is not None:
+            with self._ts_server.open_file(relative_file_path):
+                return self._ts_server.request_text_document_diagnostics(relative_file_path, start_line, end_line, min_severity)
+        return super().request_text_document_diagnostics(relative_file_path, start_line, end_line, min_severity)
+
+    @override
     def _get_language_id_for_file(self, relative_file_path: str) -> str:
         ext = os.path.splitext(relative_file_path)[1].lower()
         if ext in TS_EXT:


### PR DESCRIPTION
... incorrectly being processed by the Svelte LS instead of the TypeScript LS