### PR TITLE
fix: query_project rejected read-only tools excluded by the current context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: context or mode argument referencing a known name (e.g. `--context anitgravity`) could result in   
     incorrect file access if a corresponding local file existed (e.g. `./antigravity` binary);
     file access is now guarded with path detection (file ending or path separator must be present)
+  - Allow `query_project` tool to access read-only tools that are not enabled in the current configuration
 
 * Language Servers:
   - `typescript_vts`: Add `initialization_options` setting in `ls_specific_settings.typescript_vts`.

--- a/src/serena/tools/query_project_tools.py
+++ b/src/serena/tools/query_project_tools.py
@@ -53,7 +53,6 @@ class QueryProjectTool(Tool, ToolMarkerOptional, ToolMarkerDoesNotRequireActiveP
         :param tool_params_json: the parameters to pass to the tool, encoded as a JSON string
         """
         tool = self.agent.get_tool_by_name(tool_name)
-        assert tool.is_active(), f"Tool {tool_name} is not active."
         assert tool.is_readonly(), f"Tool {tool_name} is not read-only and cannot be executed in another project."
         if self._is_project_server_required(tool):
             client = ProjectServerClient()


### PR DESCRIPTION
## Summary

Minimal follow-up to #1527 per @opcode81's review: drop the `is_active()` assertion in `QueryProjectTool.apply` so a read-only tool hidden by the caller's current context (e.g. `search_for_pattern` in the `claude-code` context, where the client has native grep) can still be forwarded to another registered project.

The `is_readonly()` guard is unchanged; nothing else is touched.

## Changes

- `src/serena/tools/query_project_tools.py`: remove the `assert tool.is_active()` line.
- `CHANGELOG.md`: short entry under `# Unreleased (main)` / `* Tools:`.

## Test plan

- [ ] CI green on ubuntu/macos/windows.
- [ ] Manual: in a `claude-code` context (which excludes `search_for_pattern`), forward `search_for_pattern` to another registered project via `query_project` and confirm it succeeds.