### PR TITLE
feat: forward user-provided initializationOptions to pasls

### DIFF
--- a/src/solidlsp/language_servers/pascal_server.py
+++ b/src/solidlsp/language_servers/pascal_server.py
@@ -177,6 +177,12 @@ class PascalLanguageServer(SolidLanguageServer):
         )
         self.server_ready = threading.Event()
 
+        # Generic pass-through of LSP initializationOptions, mirroring how editor
+        # LSP clients (Sublime LSP, VSCode) let users forward arbitrary options to
+        # pasls -- e.g. fpcOptions for third-party unit/include search paths such
+        # as mORMot. Configured via ls_specific_settings["pascal"]["initializationOptions"].
+        self._init_options_override: dict = pascal_settings.get("initializationOptions", {}) or {}
+
     # ============== Metadata Directory Management ==============
 
     @classmethod
@@ -777,8 +783,7 @@ class PascalLanguageServer(SolidLanguageServer):
         log.info(f"Using pasls at: {pasls_executable_path}")
         return quote_windows_path(pasls_executable_path)
 
-    @staticmethod
-    def _get_initialize_params(repository_absolute_path: str) -> InitializeParams:
+    def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
         """
         Returns the initialize params for the Pascal Language Server.
 
@@ -812,6 +817,13 @@ class PascalLanguageServer(SolidLanguageServer):
                 "showSyntaxErrors": True,
             }
         )
+
+        # User-provided initializationOptions take precedence and may carry
+        # arbitrary pasls options (e.g. fpcOptions for extra unit/include search
+        # paths). This makes Serena forward initializationOptions like other LSP
+        # clients (Sublime LSP, VSCode) instead of only a hard-coded subset.
+        if self._init_options_override:
+            initialization_options.update(self._init_options_override)
 
         initialize_params = {
             "locale": "en",


### PR DESCRIPTION
## What
Forward user-provided `initializationOptions` to `pasls`, so users can pass
arbitrary pasls options (e.g. `fpcOptions`) via Serena's
`ls_specific_settings["pascal"]["initializationOptions"]`.

## Why
Serena currently sends only a hard-coded subset of `initializationOptions`
to pasls. Editor LSP clients (Sublime LSP, VSCode) let users forward
arbitrary options. Without this, there is no way to tell pasls about
third-party unit/include search paths (e.g. mORMot), which breaks symbol
resolution for projects that depend on external FPC libraries.

## Change
- Read `initializationOptions` from `ls_specific_settings["pascal"]`.
- Merge them into the initialize params, user values taking precedence.
- `_get_initialize_params` becomes an instance method to access the override.

## Compatibility
Backward compatible: with no `initializationOptions` configured, behavior
is unchanged.
