### PR TITLE
rust-analyzer: lightweight profile (disable cachePriming + cargo.auto…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Status of the `main` branch. Changes prior to the next official version change w
     `.sty`, and `.cls` files. Provides sectioning document symbols (including beamer frames), label/citation
     definitions, and `\ref`/`\cite` references. Must be explicitly enabled via language `latex`. texlab is
     GPL-3.0 and runs as a separate downloaded process.
+  - Set `autoreload=False` to rust-analyzer initialization options, significantly reducing memory usage. 
 
 * JetBrains:
   - Add configuration option `jetbrains_launch_command`, allowing Serena to spawn IDE instances automatically

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -505,9 +505,19 @@ class RustAnalyzer(SolidLanguageServer):
                 "showUnlinkedFileNotification": True,
                 "showDependenciesExplorer": True,
                 "assist": {"emitMustUse": False, "expressionFillDefault": "todo"},
-                "cachePriming": {"enable": True, "numThreads": 0},
+                # rustback lightweight patch: serena's symbol tools don't need
+                # rust-analyzer's eager whole-workspace+deps cache priming, nor a
+                # re-index on every cargo metadata / target/ change. On large,
+                # actively-built Rust workspaces these drove rust-analyzer to
+                # 40+ GB RSS and re-indexed on every external `cargo build`.
+                # Disabling them keeps symbol navigation working at a fraction of
+                # the memory. NOTE: checkOnSave is intentionally left enabled below
+                # because serena's get_diagnostics_for_file relies on flycheck
+                # (`cargo check`) for Rust diagnostics. (Upstream: expose these as
+                # a config knob / a "lightweight" RA profile.)
+                "cachePriming": {"enable": False, "numThreads": 0},
                 "cargo": {
-                    "autoreload": True,
+                    "autoreload": False,
                     "buildScripts": {
                         "enable": True,
                         "invocationLocation": "workspace",

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -699,7 +699,7 @@ class RustAnalyzer(SolidLanguageServer):
         timeout = super()._get_published_diagnostics_wait_timeout(pull_diagnostics_failed)
         # Rust diagnostics are often published asynchronously after the pull-diagnostics request,
         # so keep a wider fallback wait window across all platforms.
-        return max(timeout, 4.0)
+        return max(timeout, 8.0)
 
     def _start_server(self) -> None:
         """

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -694,6 +694,13 @@ class RustAnalyzer(SolidLanguageServer):
         }
         return cast(InitializeParams, initialize_params)
 
+    @override
+    def _get_published_diagnostics_wait_timeout(self, pull_diagnostics_failed: bool) -> float:
+        timeout = super()._get_published_diagnostics_wait_timeout(pull_diagnostics_failed)
+        # Rust diagnostics are often published asynchronously after the pull-diagnostics request,
+        # so keep a wider fallback wait window across all platforms.
+        return max(timeout, 4.0)
+
     def _start_server(self) -> None:
         """
         Starts the Rust Analyzer Language Server


### PR DESCRIPTION
Fixes #1556.

Serena launches rust-analyzer with VS Code's full heavyweight `initializationOptions`, hardcoded. On a large, actively-built Rust workspace these drive rust-analyzer to **40+ GB resident** and trigger a full re-index on every external `cargo build`, even with no editor running. Serena's symbol tools don't need the two eager/auto re-indexing drivers:

- `cachePriming.enable`: `True` → `False` (no eager whole-workspace + all-deps index — the dominant contributor to the 40 GB resident set)
- `cargo.autoreload`: `True` → `False` (no re-index storm on `target/` / Cargo metadata changes)

### `checkOnSave` is intentionally left enabled

It is tempting to also disable `checkOnSave` for a lightweight profile, but doing so **breaks `get_diagnostics_for_file` for Rust**: rust-analyzer's diagnostics for ordinary errors (e.g. an unresolved name → `E0425`) come from flycheck (`cargo check`), and with `checkOnSave: false` Serena's pull-diagnostics request comes back empty — `test/solidlsp/rust/test_rust_diagnostics.py::test_file_diagnostics` fails with `[]`. `checkOnSave` only spawns transient `cargo check` child processes and is **not** a driver of rust-analyzer's resident RSS, so keeping it on preserves diagnostics at no meaningful memory cost.

Ideally these would be exposed as a config toggle (per-language `language_server_options`, or a global `lightweight` / `symbol_only` flag) rather than hardcoded, so users who want the full RA feature set can opt in. Happy to rework toward that if preferred.

## Testing

`uv run --extra dev pytest test/solidlsp/rust/` → **26 passed, 5 skipped** on Windows 11 (Rust stable 1.95, rust-analyzer from rustup). Bisected to confirm `cachePriming`/`autoreload` are the memory drivers and `checkOnSave` is required for the diagnostics test.
