### PR TITLE
Add support for Dexter, an alternative Elixir language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Allow `query_project` tool to access read-only tools that are not enabled in the current configuration
 
 * Language Servers:
+  - Add support for [Dexter](https://github.com/remoteoss/dexter), a fast Elixir language server optimized
+    for large codebases, as an alternative to Expert (language `elixir_dexter`). Requires the `dexter`
+    binary to be installed and on PATH; the executable can be overridden via the `ls_path` setting in
+    `ls_specific_settings.elixir_dexter`, and `initialization_options` are forwarded to the server.
   - `typescript_vts`: Add `initialization_options` setting in `ls_specific_settings.typescript_vts`.
     The dict is forwarded to vtsls via `initializationOptions`, `workspace/didChangeConfiguration`,
     and `workspace/configuration` pulls. Enables Yarn PnP setups with `typescript.tsdk` pointing

--- a/docs/01-about/020_programming-languages.md
+++ b/docs/01-about/020_programming-languages.md
@@ -63,7 +63,9 @@ Some languages require additional installations or setup steps, as noted.
 * **CUE**
 * **Dart**
 * **Elixir**  
-  (requires Elixir installation; Expert language server is downloaded automatically)
+  (by default, uses the Expert language server (language `elixir`), which requires an Elixir installation and is downloaded automatically;
+  we also support [Dexter](https://github.com/remoteoss/dexter) (language `elixir_dexter`), a fast Elixir LSP optimized for large codebases,
+  which requires the `dexter` binary to be installed and available on PATH, or `ls_path` to be set under `ls_specific_settings.elixir_dexter`)
 * **Elm**  
   (requires Elm compiler)
 * **Erlang**  

--- a/docs/02-usage/050_configuration.md
+++ b/docs/02-usage/050_configuration.md
@@ -465,6 +465,27 @@ Supported settings:
 |---|---|---|
 | `expert_version` | `v0.1.0-rc.6` | Override the Expert version Serena downloads when it does not use an `expert` executable already found in PATH. |
 
+#### Elixir (Dexter)
+
+As an alternative to Expert, Serena supports [Dexter](https://github.com/remoteoss/dexter), a fast Elixir LSP
+optimized for large codebases. Set the project language to `elixir_dexter` to use it. The `dexter` binary
+must be installed and available on PATH (e.g. via `brew install dexter-lsp`), or be configured via `ls_path`.
+
+Supported settings (under `ls_specific_settings.elixir_dexter`):
+
+| Setting | Default | Description |
+|---|---|---|
+| `ls_path` | `null` | Path to the `dexter` executable, used instead of looking up `dexter` on PATH. |
+| `initialization_options` | `{}` | Dict forwarded to Dexter via LSP `initializationOptions` (e.g. `followDelegates`, `stdlibPath`, `debug`). |
+
+Example (in `.serena/project.yml` or `serena_config.yml`):
+
+```yaml
+ls_specific_settings:
+  elixir_dexter:
+    ls_path: "/path/to/dexter"
+```
+
 #### Elm
 
 Serena uses `@elm-tooling/elm-language-server` for Elm support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,6 +316,7 @@ markers = [
   "perl: language server running for Perl",
   "csharp: language server running for C#",
   "elixir: language server running for Elixir",
+  "elixir_dexter: language server running for Elixir (Dexter)",
   "elm: language server running for Elm",
   "terraform: language server running for Terraform",
   "swift: language server running for Swift",

--- a/src/solidlsp/language_servers/dexter_language_server.py
+++ b/src/solidlsp/language_servers/dexter_language_server.py
@@ -1,0 +1,214 @@
+"""
+Dexter language server support for Elixir.
+
+Dexter (https://github.com/remoteoss/dexter) is a fast, full-featured Elixir
+language server optimized for large codebases. Unlike Expert (the default
+Elixir language server, see ``elixir_tools``), Dexter parses source files
+directly as text and stores its index in SQLite, so it does not need to
+compile the project before answering requests.
+
+Installation
+------------
+The ``dexter`` binary must be installed manually and be available on PATH
+(or configured via ``ls_specific_settings.elixir_dexter.ls_path``):
+
+- Homebrew: ``brew install dexter-lsp``
+- Mise: ``mise use -g aqua:remoteoss/dexter@latest``
+- ASDF: ``asdf plugin add dexter https://github.com/remoteoss/dexter.git && asdf install dexter latest``
+
+Official documentation: https://github.com/remoteoss/dexter
+"""
+
+import logging
+import os
+import pathlib
+import shutil
+import threading
+from collections.abc import Hashable
+from typing import Any, cast
+
+from overrides import override
+
+from solidlsp.ls import (
+    LanguageServerDependencyProvider,
+    LanguageServerDependencyProviderSinglePath,
+    RawDocumentSymbol,
+    SolidLanguageServer,
+)
+from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
+from solidlsp.settings import SolidLSPSettings
+
+log = logging.getLogger(__name__)
+
+
+class DexterLanguageServer(SolidLanguageServer):
+    """
+    Elixir language server implementation using Dexter (https://github.com/remoteoss/dexter),
+    an alternative to Expert, which is the default for the language ``elixir``.
+
+    You can pass the following entries in ``ls_specific_settings["elixir_dexter"]``:
+        - ls_path: Path to the ``dexter`` executable, bypassing the PATH lookup.
+        - initialization_options: Dict forwarded to Dexter via LSP ``initializationOptions``
+          (e.g. ``followDelegates``, ``stdlibPath``, ``debug``; see the Dexter documentation).
+    """
+
+    def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
+        """
+        Creates a DexterLanguageServer instance. This class is not meant to be instantiated directly.
+        Use LanguageServer.create() instead.
+        """
+        super().__init__(config, repository_root_path, None, "elixir", solidlsp_settings)
+        self.server_ready = threading.Event()
+
+    def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
+        return self.DependencyProvider(self._custom_settings, self._ls_resources_dir)
+
+    class DependencyProvider(LanguageServerDependencyProviderSinglePath):
+        def _get_or_install_core_dependency(self) -> str:
+            """
+            Resolve the dexter executable from PATH or raise a helpful error if missing.
+            Allows override via ls_specific_settings.elixir_dexter.ls_path.
+            """
+            dexter_path = shutil.which("dexter")
+            if not dexter_path:
+                raise FileNotFoundError(
+                    "dexter is not installed or not found on PATH.\n"
+                    "Please install Dexter, e.g.:\n"
+                    "  Homebrew: brew install dexter-lsp\n"
+                    "  Mise:     mise use -g aqua:remoteoss/dexter@latest\n"
+                    "  ASDF:     asdf plugin add dexter https://github.com/remoteoss/dexter.git && asdf install dexter latest\n\n"
+                    "Alternatively, set 'ls_path' in ls_specific_settings.elixir_dexter to the dexter executable.\n"
+                    "For more details, see: https://github.com/remoteoss/dexter"
+                )
+            log.info(f"Using dexter at {dexter_path}")
+            return dexter_path
+
+        def _create_launch_command(self, core_path: str) -> list[str]:
+            # Dexter speaks LSP over stdio via the "lsp" subcommand
+            return [core_path, "lsp"]
+
+    @override
+    def _get_wait_time_for_cross_file_referencing(self) -> float:
+        return 5.0  # give Dexter a moment to finish indexing before cross-file references are requested
+
+    @override
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        # For Elixir projects, we should ignore:
+        # - _build: compiled artifacts
+        # - deps: dependencies
+        # - node_modules: if the project has JavaScript components
+        # - .elixir_ls / .expert: artifacts of other Elixir language servers
+        # - .dexter: Dexter's SQLite index
+        # - cover: coverage reports
+        return super().is_ignored_dirname(dirname) or dirname in [
+            "_build",
+            "deps",
+            "node_modules",
+            ".elixir_ls",
+            ".expert",
+            ".dexter",
+            "cover",
+        ]
+
+    @override
+    def is_ignored_path(self, relative_path: str, ignore_unsupported_files: bool = True) -> bool:
+        """Check if a path should be ignored for symbol indexing."""
+        if relative_path.endswith("mix.exs"):
+            # These are project configuration files, not source code with symbols to index
+            return True
+
+        return super().is_ignored_path(relative_path, ignore_unsupported_files)
+
+    @override
+    def _document_symbols_cache_fingerprint(self) -> Hashable:
+        normalize_symbol_name_version = 1
+        return normalize_symbol_name_version
+
+    @override
+    def _normalize_symbol_name(self, symbol: RawDocumentSymbol, relative_file_path: str) -> str:
+        # Dexter reports function symbols with an arity suffix (e.g. "create_user/5"); strip it
+        name = symbol["name"]
+        base, sep, arity = name.rpartition("/")
+        if sep and arity.isdigit():
+            return base
+        return name
+
+    def _get_initialize_params(self) -> InitializeParams:
+        """
+        Returns the initialize params for the Dexter language server.
+        """
+        abs_path = os.path.abspath(self.repository_root_path)
+        root_uri = pathlib.Path(abs_path).as_uri()
+        initialization_options = self._custom_settings.get("initialization_options", {})
+        initialize_params = {
+            "processId": os.getpid(),
+            "locale": "en",
+            "rootPath": abs_path,
+            "rootUri": root_uri,
+            "initializationOptions": initialization_options,
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {"didSave": True, "dynamicRegistration": True},
+                    "definition": {"dynamicRegistration": True},
+                    "references": {"dynamicRegistration": True},
+                    "documentSymbol": {
+                        "dynamicRegistration": True,
+                        "hierarchicalDocumentSymbolSupport": True,
+                        "symbolKind": {"valueSet": list(range(1, 27))},
+                    },
+                    "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                },
+                "workspace": {
+                    "workspaceFolders": True,
+                    "didChangeConfiguration": {"dynamicRegistration": True},
+                },
+                "window": {
+                    "workDoneProgress": True,
+                },
+            },
+            "workspaceFolders": [{"uri": root_uri, "name": os.path.basename(abs_path)}],
+        }
+        return cast(InitializeParams, initialize_params)
+
+    def _start_server(self) -> None:
+        """Start the Dexter language server process and initialize the LSP connection."""
+
+        def register_capability_handler(params: Any) -> None:
+            log.debug(f"LSP: client/registerCapability: {params}")
+            return
+
+        def window_log_message(msg: Any) -> None:
+            """Handle window/logMessage notifications from Dexter."""
+            message_type = msg.get("type", 4)  # 1=Error, 2=Warning, 3=Info, 4=Log
+            message_text = msg.get("message", "")
+            if message_type == 1:
+                log.error(f"Dexter: {message_text}")
+            elif message_type == 2:
+                log.warning(f"Dexter: {message_text}")
+            else:
+                log.debug(f"Dexter: {message_text}")
+
+        def do_nothing(params: Any) -> None:
+            return
+
+        self.server.on_request("client/registerCapability", register_capability_handler)
+        self.server.on_request("window/workDoneProgress/create", do_nothing)
+        self.server.on_notification("window/logMessage", window_log_message)
+        self.server.on_notification("window/showMessage", window_log_message)
+        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+
+        log.debug("Starting Dexter server process")
+        self.server.start()
+        initialize_params = self._get_initialize_params()
+
+        log.debug("Sending initialize request to Dexter")
+        init_response = self.server.send.initialize(initialize_params)
+        assert "capabilities" in init_response, f"Missing capabilities in initialize response: {init_response}"
+
+        self.server.notify.initialized({})
+
+        # Dexter builds its index in the background after initialization; indexing is fast
+        # (seconds even on large codebases), so no explicit readiness signal needs to be awaited.
+        self.server_ready.set()

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -154,6 +154,12 @@ class Language(str, Enum):
     """Phpactor language server for PHP (instead of Intelephense, which is the default).
     Requires PHP 8.1+ on the system. Fully open-source (MIT license).
     """
+    ELIXIR_DEXTER = "elixir_dexter"
+    """Dexter language server for Elixir (instead of Expert, which is the default).
+    A fast Elixir LSP optimized for large codebases (https://github.com/remoteoss/dexter).
+    Requires the ``dexter`` binary to be installed and available on PATH
+    (or configure ``ls_path`` in ``ls_specific_settings.elixir_dexter``).
+    """
     MARKDOWN = "markdown"
     """Marksman language server for Markdown (experimental).
     Must be explicitly specified as the main language, not auto-detected.
@@ -247,6 +253,7 @@ class Language(str, Enum):
             self.CSHARP_OMNISHARP,
             self.RUBY_SOLARGRAPH,
             self.PHP_PHPACTOR,
+            self.ELIXIR_DEXTER,
             self.MARKDOWN,
             self.YAML,
             self.JSON,
@@ -389,7 +396,7 @@ class Language(str, Enum):
                 return FilenameMatcher(".pl", ".pm", ".t")
             case self.CLOJURE:
                 return FilenameMatcher(".clj", ".cljs", ".cljc", ".edn")  # codespell:ignore edn
-            case self.ELIXIR:
+            case self.ELIXIR | self.ELIXIR_DEXTER:
                 return FilenameMatcher(".ex", ".exs")
             case self.ELM:
                 return FilenameMatcher(".elm")
@@ -607,6 +614,10 @@ class Language(str, Enum):
                 from solidlsp.language_servers.elixir_tools.elixir_tools import ElixirTools
 
                 return ElixirTools
+            case self.ELIXIR_DEXTER:
+                from solidlsp.language_servers.dexter_language_server import DexterLanguageServer
+
+                return DexterLanguageServer
             case self.ELM:
                 from solidlsp.language_servers.elm_language_server import ElmLanguageServer
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -40,6 +40,7 @@ class LanguageParamRequest:
 
 _LANGUAGE_REPO_ALIASES: dict[Language, Language] = {
     Language.CPP_CCLS: Language.CPP,
+    Language.ELIXIR_DEXTER: Language.ELIXIR,
     Language.PHP_PHPACTOR: Language.PHP,
     Language.PYTHON_JEDI: Language.PYTHON,
     Language.PYTHON_TY: Language.PYTHON,

--- a/test/solidlsp/elixir_dexter/__init__.py
+++ b/test/solidlsp/elixir_dexter/__init__.py
@@ -1,0 +1,12 @@
+import shutil
+
+
+def _test_dexter_available() -> str:
+    """Test if Dexter is available and return error reason if not."""
+    if shutil.which("dexter") is None:
+        return "dexter binary not found in PATH (install from https://github.com/remoteoss/dexter)"
+    return ""  # No error, Dexter should be available
+
+
+DEXTER_UNAVAILABLE_REASON = _test_dexter_available()
+DEXTER_UNAVAILABLE = bool(DEXTER_UNAVAILABLE_REASON)

--- a/test/solidlsp/elixir_dexter/test_elixir_dexter_basic.py
+++ b/test/solidlsp/elixir_dexter/test_elixir_dexter_basic.py
@@ -1,0 +1,95 @@
+"""
+Basic integration tests for the Dexter language server (alternative Elixir LSP).
+
+These tests validate the functionality of the language server APIs
+like request_document_symbols and request_references using the Elixir test repository.
+They require the ``dexter`` binary to be available on PATH and are skipped otherwise.
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+
+from . import DEXTER_UNAVAILABLE, DEXTER_UNAVAILABLE_REASON
+
+# These marks will be applied to all tests in this module
+pytestmark = [
+    pytest.mark.elixir_dexter,
+    pytest.mark.skipif(DEXTER_UNAVAILABLE, reason=f"Dexter not available: {DEXTER_UNAVAILABLE_REASON}"),
+]
+
+
+def _iter_symbols(symbols: list[dict[str, Any]]):
+    for symbol in symbols:
+        yield symbol
+        yield from _iter_symbols(symbol.get("children", []))
+
+
+def _find_function_symbol(symbols: list[dict[str, Any]], module_name: str, function_name: str) -> dict[str, Any] | None:
+    """Find a function symbol within a (possibly nested) module.
+
+    Matches plain names ("create_user") as well as Dexter's arity-style names ("create_user/5").
+    """
+    for symbol in _iter_symbols(symbols):
+        if symbol.get("name") == module_name:
+            for child in symbol.get("children", []):
+                child_name = child.get("name", "")
+                if child_name == function_name or child_name.rpartition("/")[0] == function_name:
+                    return child
+    return None
+
+
+class TestElixirDexterBasic:
+    """Basic Dexter language server functionality tests."""
+
+    @pytest.mark.parametrize("language_server", [Language.ELIXIR_DEXTER], indirect=True)
+    def test_request_document_symbols(self, language_server: SolidLanguageServer):
+        """Test finding document symbols (modules and functions) in an Elixir file."""
+        file_path = os.path.join("lib", "models.ex")
+        symbols = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+
+        root_symbols = symbols[0]
+        assert root_symbols, "Should find symbols in models.ex"
+        symbol_names = [s.get("name") for s in root_symbols]
+
+        # The User, Item and Order modules must be discovered
+        for module_name in ["User", "Item", "Order"]:
+            assert module_name in symbol_names, f"Should find module '{module_name}' in {symbol_names}"
+
+    @pytest.mark.parametrize("language_server", [Language.ELIXIR_DEXTER], indirect=True)
+    def test_request_references_within_file(self, language_server: SolidLanguageServer):
+        """Test finding references to a function defined and used in the same file."""
+        file_path = os.path.join("lib", "models.ex")
+        symbols = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+
+        calculate_total_symbol = _find_function_symbol(symbols[0], "Order", "calculate_total")
+        assert calculate_total_symbol is not None, "Should find Order.calculate_total in models.ex"
+        assert "selectionRange" in calculate_total_symbol
+
+        sel_start = calculate_total_symbol["selectionRange"]["start"]
+        references = language_server.request_references(file_path, sel_start["line"], sel_start["character"])
+
+        assert references, "Should find references to Order.calculate_total"
+        assert any(ref["uri"].endswith("models.ex") for ref in references), "Should find a reference to calculate_total within models.ex"
+
+    @pytest.mark.parametrize("language_server", [Language.ELIXIR_DEXTER], indirect=True)
+    def test_request_references_cross_file(self, language_server: SolidLanguageServer):
+        """Test finding cross-file references to UserService.create_user (used in examples.ex)."""
+        file_path = os.path.join("lib", "services.ex")
+        symbols = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+
+        create_user_symbol = _find_function_symbol(symbols[0], "UserService", "create_user")
+        assert create_user_symbol is not None, "Should find UserService.create_user in services.ex"
+        assert "selectionRange" in create_user_symbol
+
+        sel_start = create_user_symbol["selectionRange"]["start"]
+        references = language_server.request_references(file_path, sel_start["line"], sel_start["character"])
+
+        assert references, "Should find references to UserService.create_user"
+        assert any(ref["uri"].endswith("examples.ex") for ref in references), (
+            "Should find cross-file references to create_user in examples.ex"
+        )


### PR DESCRIPTION
Adds the language `elixir_dexter`, using Dexter (https://github.com/remoteoss/dexter) instead of Expert. The dexter binary is expected on PATH, or its location can be configured via ls_specific_settings.elixir_dexter.ls_path; initialization_options are forwarded to the server. Function symbol names reported with arity suffixes (e.g. create_user/5) are normalized for symbol matching.

https://claude.ai/code/session_01GBjSiwaH1G8sLYjjRGtTsC