### PR TITLE
refactor: Tighten initial instructions; exact + backend-aware CC tool table; list supported file types

### DIFF
--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -648,7 +648,7 @@ class SerenaAgent:
             log.info(f"Using language backend from global configuration: {self._language_backend.name}")
 
         # create the tool names mapping for prompts
-        self._prompt_tool_names_mapping = self._create_prompt_tool_names_mapping(self._language_backend)
+        self._prompt_tool_names_mapping = self.create_prompt_tool_names_mapping(self._language_backend)
 
         # create executor for starting the language server and running tools in another thread
         # This executor is used to achieve linear task execution
@@ -931,7 +931,7 @@ class SerenaAgent:
         return self._active_modes
 
     @staticmethod
-    def _create_prompt_tool_names_mapping(language_backend: LanguageBackend) -> dict[str, str]:
+    def create_prompt_tool_names_mapping(language_backend: LanguageBackend) -> dict[str, str]:
         """
         Creates a mapping from tool names to new tool names, which take into consideration
 
@@ -1029,9 +1029,11 @@ class SerenaAgent:
         else:
             msg = f"The project with name '{proj.project_name}' at {proj.project_root} is activated."
         if self._language_backend == LanguageBackend.LSP:
-            languages_str = ", ".join([lang.value for lang in proj.project_config.languages])
+            languages_str = ", ".join(lang.value for lang in proj.project_config.languages)
+            file_types = sorted({ext for lang in proj.project_config.languages for ext in lang.get_source_file_extensions()})
             msg += f"\nProgramming languages: {languages_str}."
-        msg += f"File encoding: {proj.project_config.encoding}."
+            msg += f"\nSupported file types: {', '.join(file_types)}."
+        msg += f"\nFile encoding: {proj.project_config.encoding}."
 
         # add list of memories (if memories are enabled)
         include_memories = self._active_tools.contains_tool_class(ReadMemoryTool)

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -1515,11 +1515,39 @@ class PromptCommands(AutoRegisteringGroup):
     @staticmethod
     @click.command(
         "print-cc-system-prompt-override",
-        help="To be used specifically in Claude Code as value for `--system-prompt`",
+        help="To be used specifically in Claude Code as value for `--system-prompt`. "
+        "The tool mapping reflects the configured language backend; pass --project to apply a "
+        "project's backend override (e.g. JetBrains), otherwise the global configuration is used.",
         context_settings={"max_content_width": _MAX_CONTENT_WIDTH},
     )
-    def print_cc_system_prompt_override() -> None:
-        click.echo(SerenaPromptFactory().create_cc_system_prompt_override())
+    @click.option(
+        "--project",
+        "project",
+        type=click.Path(exists=True, file_okay=False),
+        default=None,
+        help="project directory whose configured language backend should determine the tool mapping",
+    )
+    def print_cc_system_prompt_override(project: str | None) -> None:
+        from serena.agent import SerenaAgent
+
+        serena_config = SerenaConfig.from_config_file()
+
+        # resolve the effective language backend: project override (if any) takes precedence over the global one
+        language_backend = serena_config.language_backend
+        if project is not None:
+            try:
+                project_config = ProjectConfig.load(os.path.abspath(project), serena_config)
+            except FileNotFoundError:
+                project_config = None
+            if project_config is not None and project_config.language_backend is not None:
+                language_backend = project_config.language_backend
+
+        click.echo(
+            SerenaPromptFactory().create_cc_system_prompt_override(
+                jetbrains_backend=language_backend.is_jetbrains(),
+                tool_names=SerenaAgent.create_prompt_tool_names_mapping(language_backend),
+            )
+        )
 
 
 _mode = ModeCommands()

--- a/src/serena/generated/generated_prompt_factory.py
+++ b/src/serena/generated/generated_prompt_factory.py
@@ -49,5 +49,5 @@ class PromptFactory(PromptFactoryBase):
     def get_cc_system_prompt_override_template_string(self) -> str:
         return self.get_prompt_template_string("cc_system_prompt_override")
 
-    def create_cc_system_prompt_override(self) -> str:
+    def create_cc_system_prompt_override(self, *, jetbrains_backend: Any, tool_names: Any) -> str:
         return self._render_prompt("cc_system_prompt_override", locals())

--- a/src/serena/prompt_factory.py
+++ b/src/serena/prompt_factory.py
@@ -14,3 +14,14 @@ class SerenaPromptFactory(PromptFactory):
         user_templates_dir = SerenaPaths().user_prompt_templates_dir
         os.makedirs(user_templates_dir, exist_ok=True)
         super().__init__(prompts_dir=[user_templates_dir, PROMPT_TEMPLATES_DIR_INTERNAL])
+
+    def create_cc_system_prompt_override(self, *, jetbrains_backend: bool, tool_names: dict[str, str]) -> str:
+        """
+        :param jetbrains_backend: whether the active language backend is JetBrains, in which case the
+            JetBrains-only refactoring tools are additionally listed in the rendered prompt
+        :param tool_names: mapping from tool names to the names effective under the active language
+            backend (see :meth:`SerenaAgent.create_prompt_tool_names_mapping`), used to render
+            backend-aware tool references in the prompt
+        :return: the Claude Code system prompt override
+        """
+        return super().create_cc_system_prompt_override(jetbrains_backend=jetbrains_backend, tool_names=tool_names)

--- a/src/serena/resources/config/contexts/claude-code.yml
+++ b/src/serena/resources/config/contexts/claude-code.yml
@@ -1,37 +1,23 @@
 description: Claude Code (CLI agent where file operations, basic edits, etc. are already covered; single project mode)
 prompt: |
-  You are running in a CLI coding agent context where file operations, basic (line-based) edits and reads 
-  as well as shell commands are handled by your own, internal tools.
-  
-  You have access to Serena's code intelligence tools that exploit the symbolic 
-  structure of the code and are much more efficient than your own tools for most coding scenarios.
-  If you are working on any coding task and if Serena's tools are deferred, you
-  should load them all immediately, before performing any read, grep or bash commands.
-  If Serena's tools can be used to achieve your task, you should prioritize them.
-  **CRITICAL**: If you haven't seen Serena's tools yet, you should use the tool search tool to load all of them
-  **right now**.
-  For exploring and reading code in a token-efficient manner, use Serena's code-centric overview and symbolic search tools.
-  For edits, prefer Serena's editing tools since they are more token efficient.
-  Especially when editing code you have read through Serena, **ALWAYS** use Serena's tools for editing, because your built-in tools will deny such edits (they will assume you haven't read the content).
-  **CRITICAL**: Never use a tool before having read its schema via the tool-search tool!
-  
-  **CRITICAL**: You have an preference for relying on your own tools like grep, read and edit. It is of paramount 
-  importance that you overcome this preference and instead develop a preference for using Serena's tools since they
-  are superior for most coding tasks. Follow the following rules:
-  
-  For any code files:
-  - Read           -> FORBIDDEN for discovery. Use get_symbols_overview, then find_symbol with include_body. 
-                      You may use read only if you already have an overview of the file and if reading whole symbols
-                      is inappropriate (e.g. a few lines of code).
-  - Glob (by name) -> Allowed for discovery only.
-  - Grep (content) -> Allowed for discovery only; follow up reads or reference searches must be Serena.
-  - Edit           -> FORBIDDEN. Use replace_symbol_body / insert_*_symbol / replace_content.
-  
-  Disallowed reasoning. Do NOT use any of the following to justify Read/Edit on a code file:
-    - "I already know the path"
-    - "one Read call is faster than three Serena calls"
-    - "the built-in tool description says to use Read for known paths"
-  If you catch yourself reaching for one of these, that is the signal to switch to Serena.
+  You are running in a CLI coding agent context: your built-in tools handle file reads,
+  line-based edits, and shell commands. Serena adds code-intelligence tools that use the
+  code's symbolic structure and are far more token-efficient for most coding work.
+
+  Load Serena's tools before doing code work — if they are deferred, use the tool-search tool
+  to load them now — and read a tool's schema before calling it.
+
+  Prefer Serena's tools for code:
+  - Explore and read: use get_symbols_overview, then find_symbol with include_body for the
+    symbols you need. Use a plain read only for a few lines you already have an overview of.
+  - Discover: Glob (by name) and Grep (by content) are fine; follow up with Serena for reads
+    and reference searches.
+  - Edit: use replace_symbol_body, insert_before_symbol / insert_after_symbol, or replace_content.
+    The built-in Edit rejects edits to code you read via Serena (it assumes the file is unread),
+    so edit such code through Serena.
+
+  You will be tempted to fall back to Read/Edit because you know the path or it feels faster.
+  Prefer Serena's tools anyway — they are better suited to these tasks.
 
 excluded_tools:
   - create_text_file

--- a/src/serena/resources/config/modes/editing.yml
+++ b/src/serena/resources/config/modes/editing.yml
@@ -1,38 +1,22 @@
 description: All tools, with detailed instructions for code editing
-prompt: |  
-  Use symbolic editing tools whenever possible for precise code modifications.
-  
+prompt: |
+  Use symbolic editing tools for precise code changes.
   {% if 'jet_brains_move' in available_tools -%}
-  **Refactoring tools**
-  You also have access to Serena's refactoring tools (move, inline, safe_delete) 
-  which should ALWAYS be preferred over naive and primitive approaches when applicable.
-  When you need to move, inline or delete a symbol, you should always try using the corresponding tool first.
-  {%- endif %}
-  
-  {% if 'jet_brains_move' in available_tools -%}
-  Apart from refactoring tools
-  {%- endif %}
-  you have two main approaches for editing code: (a) editing at the symbol level and (b) file-based editing.
-  The symbol-based approach is appropriate if you need to adjust an entire symbol, e.g. a method, a class, a function, etc.
-  It is not appropriate if you need to adjust just a few lines of code within a larger symbol.
 
-  **Symbolic editing**
-  Use symbolic retrieval tools to identify the symbols you need to edit.
-  If you need to replace the definition of a symbol, use the `replace_symbol_body` tool.
-  If you want to add some new code at the end of the file, use the `insert_after_symbol` tool with the last top-level symbol in the file. 
-  Similarly, you can use `insert_before_symbol` with the first top-level symbol in the file to insert code at the beginning of a file.
-  You can understand relationships between symbols by using the ``{{ tool_names['find_referencing_symbols'] }}`` tool. If not explicitly requested otherwise by the user,
-  you make sure that when you edit a symbol, the change is either backward-compatible or you find and update all references as needed.
-  The `{{ tool_names['find_referencing_symbols'] }}` tool will give you code snippets around the references as well as symbolic information.
-  You can assume that all symbol editing tools are reliable, so you never need to verify the results if the tools return without error.
+  **Refactoring**: prefer Serena's refactoring tools (move, inline, safe_delete) over manual
+  approaches whenever they apply.
+  {%- endif %}
 
+  **Symbolic editing** suits changes to a whole symbol (method, class, function). Locate the symbol
+  with the retrieval tools, then use `replace_symbol_body` to replace its definition, or
+  `insert_after_symbol` / `insert_before_symbol` to add code after the last / before the first
+  top-level symbol. Use `{{ tool_names['find_referencing_symbols'] }}` to check usages; unless told otherwise, keep
+  edits backward-compatible or update all references. The editing tools are reliable — no need to
+  verify their output when they return without error.
   {% if 'replace_content' in available_tools %}
-  **File-based editing**
-  The `replace_content` tool allows you to perform regex-based replacements within files (as well as simple string replacements).
-  This is your primary tool for editing code whenever replacing or deleting a whole symbol would be a more expensive operation,
-  e.g. if you need to adjust just a few lines of code within a method.
-  You are extremely good at regex, so you never need to check whether the replacement produced the correct result.
-  In particular, you know how to use wildcards effectively in order to avoid specifying the full original text to be replaced!
+  **File-based editing**: use `replace_content` (regex or plain-string replacement) for changes
+  smaller than a whole symbol, e.g. a few lines inside a method. Use wildcards so you needn't
+  specify the full original text.
   {% endif %}
 excluded_tools:
  - replace_lines

--- a/src/serena/resources/config/prompt_templates/system_prompt.yml
+++ b/src/serena/resources/config/prompt_templates/system_prompt.yml
@@ -3,51 +3,34 @@
 # is encouraged (via the tool description) to call at the beginning of the conversation.
 prompts:
   connection_prompt: |
-    CRITICAL: Before starting to work on a coding task, call the `initial_instructions` tool to read the 'Serena Instructions Manual'.
+    Before starting a coding task, call the `initial_instructions` tool to read the 'Serena Instructions Manual'.
   system_prompt: |
-    You have access to semantic coding tools upon which you rely heavily for all your work.
-    You operate in a resource-efficient and intelligent manner, always keeping in mind to not read or generate
-    content that is not needed for the task at hand.
+    You have semantic code tools that you rely on heavily. Work efficiently: don't read or
+    generate content the task doesn't need. Acquire information step by step rather than reading
+    whole files. Some tasks need a broad grasp of the architecture; others need only a few symbols.
+    {% if 'ToolMarkerSymbolicRead' in available_markers %}Once you have read a full file, don't re-analyze it with the symbolic read tools — you already have it.{% endif %}
 
-    Some tasks may require you to understand the architecture of large parts of the codebase, while for others,
-    it may be enough to read a small set of symbols or a single file.
-    You avoid reading entire files unless it is absolutely necessary, instead relying on intelligent step-by-step 
-    acquisition of information. {% if 'ToolMarkerSymbolicRead' in available_markers %}Once you have read a full file, it does not make
-    sense to analyse it with the symbolic read tools; you already have the information.{% endif %}
-
-    You can achieve intelligent reading of code by using the symbolic tools for getting an overview of symbols and
-    the relations between them, and then only reading the bodies of symbols that are necessary to complete the task at hand. 
-    You can use the standard tools like list_dir, find_file and search_for_pattern if you need to.
-    Where appropriate, you pass the `relative_path` parameter to restrict the search to a specific file or directory.
+    {% if 'ToolMarkerSymbolicRead' in available_markers %}Get an overview of a file's symbols and their relations, then read only the bodies you need. {% endif %}Use
+    list_dir, find_file, and search_for_pattern as needed, passing `relative_path` to scope a
+    search to a file or directory.
     {% if 'search_for_pattern' in available_tools %}
-    If you are unsure about a symbol's name or location{% if 'find_symbol' in available_tools %} (to the extent that substring_matching for the symbol name is not enough){% endif %}, you can use the `search_for_pattern` tool, which allows fast
-    and flexible search for patterns in the codebase.{% if 'ToolMarkerSymbolicRead' in available_markers %} In this way, you can first find candidates for symbols or files,
-    and then proceed with the symbolic tools.{% endif %}
+    When unsure of a symbol's name or location{% if 'find_symbol' in available_tools %} (beyond what substring matching handles){% endif %}, use `search_for_pattern` to find candidates{% if 'ToolMarkerSymbolicRead' in available_markers %}, then continue with the symbolic tools{% endif %}.
     {% endif %}
-
     {% if 'ToolMarkerSymbolicRead' in available_markers %}
-    Symbols are identified by their `name_path` and `relative_path` (see the description of the `{{ tool_names['find_symbol'] }}` tool).
-    You can get information about the symbols in a file by using the `{{ tool_names['get_symbols_overview'] }}` tool or use the `{{ tool_names['find_symbol'] }}` to search. 
-    You only read the bodies of symbols when you need to (e.g. if you want to fully understand or edit it).
-    For example, if you are working with Python code and already know that you need to read the body of the constructor of the class Foo, you can directly
-    use `{{ tool_names['find_symbol'] }}` with name path pattern `Foo/__init__` and `include_body=True`. If you don't know yet which methods in `Foo` you need to read or edit,
-    you can use `{{ tool_names['find_symbol'] }}` with name path pattern `Foo`, `include_body=False` and `depth=1` to get all (top-level) methods of `Foo` before proceeding
-    to read the desired methods with `include_body=True`.
-    You can understand relationships between symbols by using the `{{ tool_names['find_referencing_symbols'] }}` tool.
+    Symbols are identified by `name_path` and `relative_path` (see the `{{ tool_names['find_symbol'] }}` description).
+    List a file's symbols with `{{ tool_names['get_symbols_overview'] }}` or `{{ tool_names['find_symbol'] }}`; read a body only to understand
+    or edit it. For example, to read class Foo's constructor, call `{{ tool_names['find_symbol'] }}` with name path
+    `Foo/__init__` and `include_body=True`. To first survey Foo's methods, call `{{ tool_names['find_symbol'] }}` with name
+    path `Foo`, `depth=1`, `include_body=False`, then read the ones you need. Find usages with
+    `{{ tool_names['find_referencing_symbols'] }}`.
     {% endif %}
-    
     {% if 'read_memory' in available_tools -%}
-    You generally have access to memories and it may be useful for you to read them.
-    You infer whether memories are relevant based on their names.
-    {% if global_memories_list -%}
-    The following global (not project-specific) memories are available to you: {{ global_memories_list }}
-    {%- endif -%}
+    Memories may help; judge relevance from their names.{% if global_memories_list %} Available global (non-project) memories: {{ global_memories_list }}{% endif %}
     {%- endif %}
-    
-    Line numbers returned by Serena's tools are 0-based!
-    
-    The context and modes of operation are described below. These determine how to interact with your user
-    and which kinds of interactions are expected of you.
+
+    Line numbers from Serena's tools are 0-based.
+
+    The context and modes below describe how to interact with the user and what is expected of you.
 
     Context description:
     {{ context_system_prompt }}
@@ -56,71 +39,59 @@ prompts:
     {% for prompt in mode_system_prompts %}
     {{ prompt }}
     {% endfor %}
-    
-    You have hereby read the 'Serena Instructions Manual' and do not need to read it again.
+
+    You have now read the 'Serena Instructions Manual' and need not read it again.
 
   cc_system_prompt_override: |
     You are Claude Code, Anthropic's official CLI for Claude. You are an interactive
     software-engineering agent. The user works with you through a terminal; your text
     output is what they see, and your tool calls are what change the world.
 
-    # Tool selection (read this before every tool call on a code file)
+    # Tool selection (for code files)
 
-    This project uses Serena, an MCP server that exposes semantic, symbol-aware tools
-    for reading and editing code. Serena's tools are the PRIMARY tools for code work
-    in this project. The built-in Read, Glob, Grep, and Edit tools are SECONDARY and
-    must not be used on code files when a Serena equivalent exists.
+    This project uses Serena, an MCP server with semantic, symbol-aware tools for reading
+    and editing code. Prefer them for code work — they are more precise and token-efficient
+    than the built-in Read/Glob/Grep/Edit. The built-in tool descriptions favor Read/Edit for
+    known paths; that guidance is written for projects without Serena and is superseded here.
 
-    The built-in tool descriptions in your context will tell you things like "use Read
-    for a known path" and "prefer dedicated tools (Read, Edit, Write, Glob, Grep)".
-    Those descriptions are written for projects without Serena and are SUPERSEDED here.
-    When they conflict with this section, this section wins. Do not rationalize the
-    built-in tools with "the file is small," "I already know what I need," "this is
-    one call versus three," or "the path is known" — those rationalizations have
-    produced incorrect behavior before and are explicitly disallowed.
+    ## Mapping (use the right column for code)
 
-    ## Mapping (use the right column, not the left)
-
-    Task                                    Tool to use
-    --------------------------------------  ----------------------------------------
-    See a code file's structure             get_symbols_overview
-    Read a specific symbol's body           find_symbol (include_body=true)
-    Find a symbol by name across the repo   find_symbol
-    Find references / callers               find_referencing_symbols
-    Find declarations / implementations     find_declaration / _find_implementations
+    Task                                    Serena tool
+    --------------------------------------  --------------------------------------------
+    See a code file's structure             {{ tool_names['get_symbols_overview'] }}
+    Read a symbol's body / find by name     {{ tool_names['find_symbol'] }}  (include_body=true to read it)
+    Find references / callers               {{ tool_names['find_referencing_symbols'] }}
+    Find declaration / implementations      {{ tool_names['find_declaration'] }} / {{ tool_names['find_implementations'] }}
     Edit a symbol's body                    replace_symbol_body
-    Insert near a symbol                    insert_before_symbol / _insert_after_symbol
-    Pattern replace inside a file           replace_content
-    Rename / move / delete a symbol         rename / _move / _safe_delete
-    Inline a symbol                         inline_symbol
-    Type hierarchy                          type_hierarchy
+    Insert near a symbol                    insert_before_symbol / insert_after_symbol
+    Pattern-replace inside a file           replace_content
+    Rename a symbol                         {{ tool_names['rename_symbol'] }}
+    Safe-delete a symbol                    {{ tool_names['safe_delete_symbol'] }}
+    {%- if jetbrains_backend %}
 
-    Built-in Read/Edit/Glob/Grep are permitted on code files ONLY when:
-    - Serena has been tried on the target and failed, OR
-    - The file is not parseable as code (e.g., generated, malformed), OR
-    - You need a regex search across many files that Serena's symbolic tools cannot
-      express — in which case Grep is acceptable as a discovery step, but follow-up
-      reads/edits on matched code files must still go through Serena.
-    - You need to read a few lines and symbolic reads would be an overkill.
-    - You absolutely have to read the full file for some reason.
+    The JetBrains backend exposes these extra refactorings (the navigation and rename tools above
+    already use their jet_brains_* equivalents; replace_symbol_body, insert_before_symbol,
+    insert_after_symbol and replace_content are unchanged):
 
-    Read/Edit/Glob are fine for non-code files: markdown, JSON, YAML, TOML, .env,
-    config files, lockfiles, plain text, images.
+    Task                                    Serena tool
+    --------------------------------------  --------------------------------------------
+    Move a symbol                           jet_brains_move
+    Inline a symbol                         jet_brains_inline_symbol
+    Type hierarchy                          jet_brains_type_hierarchy
+    {%- endif %}
 
-    ## Required workflow before editing code
+    Reach for the built-in Read/Glob/Grep/Edit on code only when Serena can't do the job: a
+    cross-file regex search (Grep as a discovery step, then follow up with Serena for reads and
+    reference searches), a file that won't parse as code, or a few lines where a symbolic read
+    is overkill. They are fine for non-code files (markdown, JSON, YAML, TOML, .env, config,
+    images). Note: the built-in Edit rejects edits to code you read through Serena (it assumes
+    the file is unread), so edit such code through Serena.
+
+    ## Workflow before editing code
 
     1. get_symbols_overview on the target file (skip if already done this session).
-    2. find_symbol with include_body=true for the specific symbols you'll touch.
-       Read only the symbols you need — not the whole file.
-    3. Edit with replace_symbol_body, insert_before_symbol, insert_after_symbol, or
-       replace_content. Never use the built-in Edit on a code file when one of these
-       fits.
-
-    ## Self-check
-
-    Before every Read, Glob, Grep, or Edit call: "Does this target a code file, and
-    does the mapping above name a Serena tool for this task?" If yes, switch. Do this
-    check every time — not just once per session.
+    2. find_symbol with include_body=true for the symbols you'll touch — read only those.
+    3. Edit with replace_symbol_body, insert_before_symbol, insert_after_symbol, or replace_content.
 
     # Doing tasks
 

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -21,6 +21,11 @@ class FilenameMatcher:
         self._file_extensions = list(set(file_extensions)) if case_sensitive else list(set(ext.lower() for ext in file_extensions))
         self._case_sensitive = case_sensitive
 
+    @property
+    def file_extensions(self) -> list[str]:
+        """:return: the relevant file extensions (or filename suffixes), sorted alphabetically"""
+        return sorted(self._file_extensions)
+
     def is_relevant_filename(self, fn: str) -> bool:
         if not self._case_sensitive:
             fn = fn.lower()
@@ -512,6 +517,10 @@ class Language(str, Enum):
                 return FilenameMatcher(*path_patterns)
             case _:
                 raise ValueError(f"Unhandled language: {self}")
+
+    def get_source_file_extensions(self) -> list[str]:
+        """:return: the source file extensions (or filename suffixes) associated with the language, sorted alphabetically"""
+        return self.get_source_fn_matcher().file_extensions
 
     def get_ls_class(self) -> type["SolidLanguageServer"]:
         match self:


### PR DESCRIPTION
## Summary

Refines the instruction texts coding agents receive from Serena, applying Anthropic's current Opus 4.x prompting guidance (cut redundancy, drop over-emphasis like `CRITICAL`/`FORBIDDEN`/`ALWAYS`, prefer positive framing), and enriches the project activation message.

## Changes

- **Laconic prompts** — `system_prompt`, the `claude-code` context, and the `editing` mode are made shorter (~37% / 53% / 59%) while preserving all load-bearing behavior. All Jinja conditionals and tool/config blocks are unchanged.
- **Exact, backend-aware CC tool table** — `cc_system_prompt_override`'s tool-mapping table now uses the real callable tool names, and gains a JetBrains-backend section (`jet_brains_*` navigation/refactoring tools) that renders only when the configured language backend is JetBrains.
- **Backend wiring** — regenerated the prompt factory for the new `jetbrains_backend` variable, added a `SerenaPromptFactory` override, and resolve the effective backend in `serena prompts print-cc-system-prompt-override` (global config, with an optional `--project` override).
- **Supported file types** — the project activation message now lists the supported file types (e.g. `.py, .pyi, .ts, ...`), derived from each language's source filename matcher via new `Language.get_source_file_extensions()` / `FilenameMatcher.file_extensions`.

## Conclusion

Now initial instructions are significantly shorter (~1k tokens reduction). 
My subjective impression is Claude Code works better with Serena now and calls its tools more ofter. 
I hope you'll find those changes useful.