### PR TITLE
Prevent Julia LS setup from clobbering Serena's stdio MCP pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Status of the `main` branch. Changes prior to the next official version change w
     results in svelte-only mode (`languages: [svelte]`). They are now routed to the companion TS server,
     so symbols defined in plain `.ts`/`.js` files are again discoverable via `find_symbol`/
     `get_symbols_overview`, and `find_referencing_symbols` no longer fails to locate `.ts`/`.js` symbols. #1552
+  - `JuliaLanguageServer`: Fix the stdio MCP server exiting right after `initialize` ("tools fetch failed")
+    when `julia` is enabled. The runtime probe/install subprocesses now run with `stdin=subprocess.DEVNULL`,
+    so they can no longer inherit and clobber Serena's stdin, which is the JSON-RPC pipe under the stdio
+    transport. #1577
   - Improve quoting of arguments in shell executions
 
 * JetBrains:

--- a/src/solidlsp/language_servers/julia_server.py
+++ b/src/solidlsp/language_servers/julia_server.py
@@ -78,10 +78,14 @@ class JuliaLanguageServer(SolidLanguageServer):
                 f"Checked locations: {common_locations}"
             )
 
-        # Check if LanguageServer.jl is installed
+        # Check if LanguageServer.jl is installed.
+        # stdin=DEVNULL: when Serena runs over the stdio MCP transport, the JSON-RPC
+        # channel *is* the process stdin/stdout. Without this, the Julia child inherits
+        # Serena's stdin (the MCP pipe) and clobbers it, killing the server right after
+        # initialize ("tools fetch failed"). See https://github.com/oraios/serena/issues/1577
         check_cmd = [julia_path, "-e", "using LanguageServer"]
         try:
-            result = subprocess.run(check_cmd, check=False, capture_output=True, text=True, timeout=10)
+            result = subprocess.run(check_cmd, check=False, capture_output=True, text=True, timeout=10, stdin=subprocess.DEVNULL)
             if result.returncode != 0:
                 # LanguageServer.jl not found, install it
                 JuliaLanguageServer._install_language_server(julia_path)
@@ -99,7 +103,9 @@ class JuliaLanguageServer(SolidLanguageServer):
         install_cmd = [julia_path, "-e", 'using Pkg; Pkg.add("LanguageServer")']
 
         try:
-            result = subprocess.run(install_cmd, check=False, capture_output=True, text=True, timeout=300)  # 5 minutes for installation
+            result = subprocess.run(
+                install_cmd, check=False, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL
+            )  # 5 minutes for installation
 
             if result.returncode == 0:
                 log.info("LanguageServer.jl installed successfully!")


### PR DESCRIPTION
## Problem

Fixes #1577.

With `julia` in a project's `languages:` list, Serena's **stdio** MCP server exits a few milliseconds after `initialize`, before it can answer `tools/list`. The client reports **"tools fetch failed"** and, because the process exits, the dashboard shows "Error loading configuration". Removing `julia` makes everything work. This bites Claude Code specifically, since it launches Serena over stdio.

## Root cause

The stdio transport uses the process's stdin/stdout for the JSON-RPC protocol. On startup, the Julia LS setup in `julia_server.py` runs probe/install subprocesses:

```python
subprocess.run(check_cmd, check=False, capture_output=True, text=True, timeout=10)
subprocess.run(install_cmd, check=False, capture_output=True, text=True, timeout=300)
```

`capture_output=True` redirects the child's stdout/stderr but **not stdin**, so the Julia child **inherits Serena's stdin — the MCP pipe**. That disrupts/closes the stream, and the stdio server exits (`anyio.ClosedResourceError` on the client) right after `initialize`.

SSE / streamable-http transports are not affected, since they don't use stdin/stdout for the protocol — a standalone `--transport sse` Serena with Julia stays alive indefinitely, confirming the protocol stream is what's being clobbered.

## Fix

Pass `stdin=subprocess.DEVNULL` to both `subprocess.run` calls in `julia_server.py` so the probe/install children can't inherit and disrupt the MCP channel. Added a comment explaining the stdio-transport hazard.

## Verification

A/B repro (full script in #1577) spins up Serena over stdio against a one-file Julia project, once with `languages: ["julia"]` and once with `languages: []`:

Before:
```
languages: ["julia"] : FAILED — server exited after initialize -> 'tools fetch failed'
languages: []        : OK — initialize + list_tools succeeded (20 tools)
```

After this patch both print `OK`, and Julia symbol tools (`find_symbol`, `get_symbols_overview`, …) work over stdio.

`ruff format --check` and `ruff check` pass on the changed file.

## Note / follow-up

More generally, any subprocess Serena spawns while running the stdio transport should avoid inheriting the process stdin/stdout, so a language-server runtime probe can never clobber the MCP channel. Other language backends that shell out during setup may have the same latent issue — left out of this PR to keep it focused, but happy to follow up.

This is distinct from #900 (Julia LS slow init causing a *client timeout*); here the server exits within milliseconds because the probe disrupts the stdin pipe, and the fix differs accordingly.