### PR TITLE
Use validate_relative_path (not assert) for new-file path confinement in create_text_file

### DIFF
--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -69,9 +69,10 @@ class CreateTextFileTool(EditingToolWithDiagnostics):
             if will_overwrite_existing:
                 self.project.validate_relative_path(relative_path, require_not_ignored=True)
             else:
-                assert abs_path.is_relative_to(self.get_project_root()), (
-                    f"Cannot create file outside of the project directory, got {relative_path=}"
-                )
+                # Use the always-on containment guard rather than a bare `assert`, which is
+                # compiled out under `python -O` / PYTHONOPTIMIZE and would otherwise leave the
+                # new-file branch with no path-containment check.
+                self.project.validate_relative_path(relative_path)
 
             # writing the file
             abs_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
`CreateTextFileTool.apply` guards the **new-file** branch with
`assert abs_path.is_relative_to(project_root)`, while the overwrite branch uses the
always-on `validate_relative_path`. Python strips `assert` statements under `-O` /
`PYTHONOPTIMIZE`, so when the server runs optimized, the new-file branch performs no
path-containment check and a `create_text_file` call with a `../` relative path can
write outside the project root (`Path.resolve()` collapses the `..`).

This change makes the new-file branch use the same always-on guard as the overwrite
branch — consistent behavior, not dependent on assertions being enabled. It also keeps
the new-file path consistent with Serena's documented symlink stance
(`validate_relative_path` → `is_path_in_project` is lexical), unlike the prior
`.resolve()`-based check.

Low severity (requires running under `-O`); filed as a defense-in-depth hardening fix.
