### PR TITLE
fix(matlab): acknowledge server->client refresh requests so the MATLAB LSP doesn't crash

### DIFF
--- a/src/solidlsp/language_servers/matlab_language_server.py
+++ b/src/solidlsp/language_servers/matlab_language_server.py
@@ -457,6 +457,14 @@ class MatlabLanguageServer(SolidLanguageServer):
         self.server.on_request("workspace/configuration", workspace_configuration_handler)
         self.server.on_notification("$/progress", do_nothing)
         self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        # The MathWorks server sends server->client "refresh" requests (e.g. after
+        # documentSymbol). If the client replies MethodNotFound, the node server treats
+        # the rejected promise as fatal and exits, killing the LSP on every symbol query.
+        # Acknowledge them with a null result so the server stays alive.
+        self.server.on_request("workspace/semanticTokens/refresh", do_nothing)
+        self.server.on_request("workspace/inlayHint/refresh", do_nothing)
+        self.server.on_request("workspace/diagnostic/refresh", do_nothing)
+        self.server.on_request("workspace/codeLens/refresh", do_nothing)
 
         log.info("Starting MATLAB server process")
         self.server.start()


### PR DESCRIPTION
## Problem

On Windows (MATLAB R2025b, Node v24), every MATLAB symbol query crashes and restarts the language server, so `find_symbol` / `find_referencing_symbols` never return results for `.m` files — the MATLAB LSP is effectively unusable for navigation.

## Root cause

The MathWorks MATLAB language server sends server→client requests such as `workspace/semanticTokens/refresh` (e.g. right after a `textDocument/documentSymbol` request). `solidlsp` registers handlers for `workspace/configuration`, `workspace/workspaceFolders`, `client/registerCapability`, etc., but **not** for the `*/refresh` requests, so the client replies `MethodNotFound (-32601)`. The node-based MathWorks server treats the rejected promise as fatal:

```
ResponseError: method 'workspace/semanticTokens/refresh' not handled on client.
LanguageServerTerminatedException: Language server stdout read process terminated unexpectedly
```

Serena auto-restarts the LSP, but the next `documentSymbol` triggers the same crash, so MATLAB symbol/reference queries never complete.

## Fix

Register no-op handlers that reply with a null result for the workspace refresh requests — `semanticTokens` / `inlayHint` / `diagnostic` / `codeLens` — matching the existing handler pattern (e.g. `workspace/configuration`). The existing `do_nothing` helper returns `None`, so the client now sends a valid (null) result instead of `MethodNotFound`, and the server stays alive.

```python
self.server.on_request("workspace/semanticTokens/refresh", do_nothing)
self.server.on_request("workspace/inlayHint/refresh", do_nothing)
self.server.on_request("workspace/diagnostic/refresh", do_nothing)
self.server.on_request("workspace/codeLens/refresh", do_nothing)
```

## Verification

Windows 11 + MATLAB R2025b + Node v24, on a ~377-file MATLAB project:
- **before:** the MATLAB LSP terminates on every `documentSymbol` call; `find_symbol` / `find_referencing_symbols` error with `LanguageServerTerminatedException`.
- **after:** the LSP no longer crashes and `find_symbol` resolves MATLAB definitions.

Scope note: this PR only fixes the fatal crash that prevented any MATLAB symbol query from completing. The *quality* of cross-file find-references returned by the MathWorks server (which appears limited to within-file resolution in my testing) is a separate concern and out of scope here.
