### PR TITLE
fix: normalize project_root in is_path_in_project to handle Windows path separator mismatch (#1602)

### DIFF
--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -36,7 +36,7 @@ class Project(ToStringMixin):
         is_newly_created: bool = False,
     ):
         assert serena_config is not None
-        self.project_root = project_root
+        self.project_root = os.path.normpath(project_root)
         self.project_config = project_config
         self.serena_config = serena_config
         self._serena_data_folder = serena_config.get_project_serena_folder(self.project_root)
@@ -268,7 +268,7 @@ class Project(ToStringMixin):
         path = os.path.normpath(path)
 
         try:
-            return os.path.commonpath([self.project_root, path]) == os.path.normpath(self.project_root)
+            return os.path.commonpath([self.project_root, path]) == self.project_root
         except ValueError:
             # occurs, in particular, if paths are on different drives on Windows
             return False

--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -268,7 +268,7 @@ class Project(ToStringMixin):
         path = os.path.normpath(path)
 
         try:
-            return os.path.commonpath([self.project_root, path]) == self.project_root
+            return os.path.commonpath([self.project_root, path]) == os.path.normpath(self.project_root)
         except ValueError:
             # occurs, in particular, if paths are on different drives on Windows
             return False
@@ -295,7 +295,10 @@ class Project(ToStringMixin):
         :param require_not_ignored: if True, the path must not be ignored according to the project's ignore settings
         """
         if not self.is_path_in_project(relative_path):
-            raise ValueError(f"{relative_path=} points to path outside of the repository root; cannot access for safety reasons")
+            raise ValueError(
+                f"{relative_path=} points to path outside of the repository root "
+                f"(project root: {self.project_root}); please use a path relative to the project root"
+            )
 
         if require_not_ignored:
             if self.is_ignored_path(relative_path):

--- a/test/serena/test_project.py
+++ b/test/serena/test_project.py
@@ -1,0 +1,206 @@
+import contextlib
+import os
+import platform
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from serena.config.serena_config import ProjectConfig, SerenaConfig
+from serena.project import Project
+from solidlsp.ls_config import Language
+
+
+def _create_project(
+    project_root: str,
+    project_ignored_paths: list[str] | None = None,
+) -> Project:
+    """Helper to create a minimal Project with the given root."""
+    config = ProjectConfig(
+        project_name="test_project",
+        languages=[Language.PYTHON],
+        ignored_paths=project_ignored_paths or [],
+        ignore_all_files_in_gitignore=False,
+    )
+    serena_config = SerenaConfig(
+        gui_log_window=False, web_dashboard=False
+    ).with_headless_mode_overrides()
+    return Project(
+        project_root=project_root,
+        project_config=config,
+        serena_config=serena_config,
+    )
+
+
+class TestIsPathInProject:
+    """Tests for Project.is_path_in_project."""
+
+    def setup_method(self) -> None:
+        self.test_dir = tempfile.mkdtemp()
+        self.project_path = Path(self.test_dir)
+        # Create a subdirectory and file
+        os.makedirs(self.project_path / "subdir", exist_ok=True)
+        (self.project_path / "main.py").write_text("print('hello')")
+        (self.project_path / "subdir" / "helper.py").write_text("def helper(): pass")
+
+        # Store project_root in both separator styles
+        self.project_root_backslash = str(self.project_path)  # native Windows backslashes
+        self.project_root_forward = str(self.project_path).replace(os.sep, "/")
+
+    def teardown_method(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_absolute_path_equal_to_project_root(self) -> None:
+        """The project root itself should always be considered inside the project."""
+        project = _create_project(self.project_root_backslash)
+        assert project.is_path_in_project(self.project_root_backslash)
+
+    def test_relative_path(self) -> None:
+        """A relative path should be considered inside the project."""
+        project = _create_project(self.project_root_backslash)
+        assert project.is_path_in_project("main.py")
+        assert project.is_path_in_project("subdir/helper.py")
+
+    def test_subdirectory_absolute_path(self) -> None:
+        """An absolute path to a subdirectory should be inside the project."""
+        project = _create_project(self.project_root_backslash)
+        subdir_path = str(self.project_path / "subdir")
+        assert project.is_path_in_project(subdir_path)
+
+    def test_sibling_path_outside_project(self) -> None:
+        """A sibling directory should be outside the project."""
+        project = _create_project(self.project_root_backslash)
+        outside_path = str(self.project_path.parent / "sibling")
+        os.makedirs(outside_path, exist_ok=True)
+        assert not project.is_path_in_project(outside_path)
+
+    def test_path_with_dot_dot_escape(self) -> None:
+        """A path with '..' trying to escape the project root should be rejected."""
+        project = _create_project(self.project_root_backslash)
+        escape_path = os.path.join(self.test_dir, "..", "..", "etc")
+        assert not project.is_path_in_project(escape_path)
+
+    def test_non_existent_path_inside_project(self) -> None:
+        """A non-existent path that would be inside the project should be accepted."""
+        project = _create_project(self.project_root_backslash)
+        nonexistent = str(self.project_path / "nonexistent" / "file.txt")
+        assert project.is_path_in_project(nonexistent)
+
+    def test_forward_slash_project_root_with_backslash_absolute_path(self) -> None:
+        """Windows: forward-slash project_root must not break is_path_in_project.
+
+        When project_root is stored with forward slashes (common in Git Bash/MSYS
+        environments on Windows) and os.path.commonpath returns backslashes,
+        the equality check must handle the separator mismatch.
+        """
+        project = _create_project(self.project_root_forward)
+        # Pass a native backslash path (like Windows native tools produce)
+        path = str(self.project_path / "main.py")
+        assert project.is_path_in_project(
+            path
+        ), f"Forward-slash project_root should match backslash paths: {self.project_root_forward} vs {path}"
+        # Also check subdirectory
+        subdir_path = str(self.project_path / "subdir")
+        assert project.is_path_in_project(subdir_path)
+        # Check the project root itself
+        assert project.is_path_in_project(self.test_dir)
+
+    def test_forward_slash_project_root_rejects_outside_paths(self) -> None:
+        """Forward-slash project_root must still reject paths outside the project."""
+        project = _create_project(self.project_root_forward)
+        outside_path = str(self.project_path.parent / "sibling")
+        os.makedirs(outside_path, exist_ok=True)
+        assert not project.is_path_in_project(outside_path)
+        # Path with .. should also be rejected
+        escape_path = os.path.join(self.test_dir, "..", "..", "etc")
+        assert not project.is_path_in_project(escape_path)
+
+    def test_forward_slash_project_root_with_forward_slash_path(self) -> None:
+        """Forward-slash project_root with a forward-slash path should work."""
+        project = _create_project(self.project_root_forward)
+        fwd_path = str(self.project_path / "main.py").replace(os.sep, "/")
+        assert project.is_path_in_project(fwd_path)
+
+    def test_project_root_itself_not_ignored_when_empty_string(self) -> None:
+        """The project root (empty string or '.') should never be ignored."""
+        project = _create_project(self.project_root_backslash)
+        assert not project.is_ignored_path(".")
+        assert not project.is_ignored_path("")
+
+    def test_different_drive_path_on_windows(self) -> None:
+        """A path on a different drive should be outside the project."""
+        project = _create_project(self.project_root_backslash)
+        if os.name == "nt":
+            diff_drive = "Z:\\nonexistent\\path"
+            assert not project.is_path_in_project(diff_drive)
+        else:
+            # On Linux, test with a path anchored to a different root
+            assert not project.is_path_in_project("/nonexistent")
+
+
+class TestValidateRelativePath:
+    """Tests for Project.validate_relative_path."""
+
+    def setup_method(self) -> None:
+        self.test_dir = tempfile.mkdtemp()
+        self.project_path = Path(self.test_dir)
+        (self.project_path / "main.py").write_text("print('hello')")
+        self.project = _create_project(str(self.project_path))
+        # Forward-slash project root version
+        self.project_fwd = _create_project(str(self.project_path).replace(os.sep, "/"))
+
+    def teardown_method(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_validate_nonexistent_relative_path(self) -> None:
+        """A non-existent relative path should be accepted (allows creating new files)."""
+        # Should not raise
+        self.project.validate_relative_path("new_file.py")
+
+    def test_validate_relative_path_outside_project(self) -> None:
+        """A relative path pointing outside the project should raise."""
+        with pytest.raises(ValueError, match="outside of the repository root"):
+            self.project.validate_relative_path("../outside.py")
+
+    def test_validate_relative_path_outside_project_forward_root(self) -> None:
+        """Forward-slash project_root must also reject paths outside the project."""
+        with pytest.raises(ValueError, match="outside of the repository root"):
+            self.project_fwd.validate_relative_path("../outside.py")
+
+
+class TestForwardSlashProjectRootRegression:
+    """Regression: Project is_ignored_path with forward-slash project_root.
+
+    This mimics the real-world scenario reported in the bug:
+    - project_root comes from external config (e.g. RegisteredProject)
+      and may be stored with forward slashes (Git Bash / MSYS on Windows)
+    - The path to check is an absolute native Windows path with backslashes
+    """
+
+    def setup_method(self) -> None:
+        self.test_dir = tempfile.mkdtemp()
+        self.project_path = Path(self.test_dir)
+        (self.project_path / "main.py").write_text("print('hello')")
+        os.makedirs(self.project_path / ".git", exist_ok=True)
+        (self.project_path / ".git" / "config").write_text("[core]\n")
+
+    def teardown_method(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_is_ignored_path_with_forward_slash_project_root(self) -> None:
+        """is_ignored_path must handle forward-slash project_root correctly."""
+        project_root_forward = str(self.project_path).replace(os.sep, "/")
+        project = _create_project(project_root_forward)
+        # Check an absolute path within the project
+        abs_path = str(self.project_path / "main.py")
+        # main.py is a Python source file, should not be ignored by default
+        assert not project.is_ignored_path(abs_path)
+
+    def test_is_ignored_path_outside_project(self) -> None:
+        """is_ignored_path must return True for paths outside the project."""
+        project_root_forward = str(self.project_path).replace(os.sep, "/")
+        project = _create_project(project_root_forward)
+        # Check a path outside the project
+        outside_path = str(self.project_path.parent / "outside.py")
+        assert project.is_ignored_path(outside_path)


### PR DESCRIPTION
### Issue for this PR

Closes #1602

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

### What does this PR do?

**Problem:** When `project_root` is stored with forward slashes (common in Git Bash/MSYS on Windows), `is_path_in_project` produces false negatives. `os.path.commonpath()` normalizes all paths to backslashes on Windows, but the equality check against `self.project_root` (still with forward slashes) fails — even though both refer to the same directory.

**Impact:** All file tools that call `validate_relative_path` are affected — `list_dir`, `read_file`, `create_text_file`, `find_file`, `replace_text`, `delete_lines`, `insert`, etc. Users on Windows who run Serena via Claude Code (Git Bash) hit "outside of the repository root" errors when passing valid absolute paths.

**Fix:** Apply `os.path.normpath()` to `self.project_root` before the comparison, ensuring consistent separator style on both sides. Also improve the error message to include the project root and suggest using relative paths.

### How did you verify your code works?

1. Created a test project with forward-slash `project_root`, verified `is_path_in_project` returns `True` for:
   - Absolute path equal to project root (the original bug)
   - Relative paths within the project
   - Subdirectory paths (absolute)
2. Verified security boundaries still hold:
   - Sibling directory paths are correctly rejected
   - Paths with ".." escape attempts are rejected
   - Different drive paths are rejected
3. Ran existing test suite (15 tests in `test_global_ignored_paths.py`) — all pass
4. Environment: Windows 11, Python 3.13

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR