### PR TITLE
Disable mcp tools by language

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,24 +3,27 @@ project_name: "serena"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  ansible             bash                clojure             cpp
-#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
-#   elixir              elm                 erlang              fortran             fsharp
-#   go                  groovy              haskell             haxe                hlsl
-#   java                json                julia               kotlin              lean4
-#   lua                 luau                markdown            matlab              msl
-#   nix                 ocaml               pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         python_ty
-#   r                   rego                ruby                ruby_solargraph     rust
-#   scala               solidity            swift               systemverilog       terraform
-#   toml                typescript          typescript_vts      vue                 yaml
-#   zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -155,3 +158,21 @@ added_modes:
 #     - ../sibling-package
 #     - ../shared-lib
 additional_workspace_folders: []
+
+# Per-language tool disabling: maps a configured language (a key of `languages` above) to a list of
+# tool names that shall be disabled *for that language only*.
+# Disabling tool T for language L makes T behave as if L's files did not exist:
+#   - calls that pin an L file (e.g. replace_symbol_body on a .hx file) are refused with an explanation,
+#   - whole-project / search calls (find_symbol without a path, search_for_pattern) are transparently
+#     scoped to the non-L languages and a short coverage note is appended when L files were skipped,
+#   - language-agnostic tools (e.g. read_memory) are unaffected (configuring one logs a warning).
+# This is useful when a particular language server produces unreliable symbol information, so you want
+# symbolic tools restricted to the languages where they are trustworthy while keeping text-based tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+# Example:
+#   excluded_tools_by_language:
+#     haxe:
+#       - find_symbol
+#       - replace_symbol_body
+#       - find_referencing_symbols
+excluded_tools_by_language: {}

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -76,7 +76,7 @@ initial_prompt: |
   Comments:
   When describing parameters, methods/functions and classes, you use a precise style, where the initial (elliptical) phrase
   clearly defines *what* it is. Any details then follow in subsequent sentences.
-  
+
   Pull requests:
   Read `mem:creating_pull_requests` when asked to participate in the creation of a pull request.
 
@@ -139,8 +139,8 @@ ignored_memory_patterns: []
 
 # advanced configuration option allowing to configure language server-specific options.
 # Maps the language key to the options.
-# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
-# No documentation on options means no options are available.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
 ls_specific_settings: {}
 
 # list of mode names to be activated additionally for this project, e.g. ["query-projects"]
@@ -176,3 +176,16 @@ additional_workspace_folders: []
 #       - replace_symbol_body
 #       - find_referencing_symbols
 excluded_tools_by_language: {}
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ Status of the `main` branch. Changes prior to the next official version change w
     (which does not correctly unpack structured output) #1042
   - Fix: Project-specific filtering of files for source files ignored the language backend. 
     The check is really only possible for LSP. 
+  - Add project configuration option `excluded_tools_by_language`, which disables a specific tool for a
+    specific language only (useful in multi-language projects where a tool is unreliable for one language
+    but should remain available for the others). A disabled tool behaves as if that language's files did
+    not exist: calls that pin such a file are refused, while whole-project/search tools (e.g. `find_symbol`,
+    `search_for_pattern`) are transparently scoped to the remaining languages and report skipped files via
+    a short coverage note. The disabled tools are also summarised in the initial instructions and noted in
+    the affected tools' descriptions.
 
 * CLI:
   - Fix `--project-from-cwd` hijacking git worktrees nested under a Serena project. `find_project_root`
@@ -63,6 +70,8 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Add configuration option `jetbrains_launch_command`, allowing Serena to spawn IDE instances automatically
     upon project activation
   - Fix: `jet_brains_list_inspections` failed when only default parameters were used #1615 
+  - `jet_brains_find_symbol`: honour `excluded_tools_by_language` for whole-project searches, scoping the
+    results to the non-excluded languages and appending a coverage note (parity with the LSP backend)
 
 * Dashboard:
   - Make list of trusted hosts configurable, fixing host validation introduced in v1.5.2 allowing only

--- a/docs/02-usage/050_configuration.md
+++ b/docs/02-usage/050_configuration.md
@@ -191,6 +191,61 @@ When a project is loaded, Serena uses the following fallback logic:
 
 This ensures backward compatibility: existing projects that already have a `.serena` folder in the project root will continue to work, even after changing the `project_serena_folder_location` setting.
 
+(excluded-tools-by-language)=
+### Disabling Tools per Language
+
+In a project that uses multiple languages, you may want to disable a specific tool for *one* language while
+keeping it available for the others. A common motivation is an unreliable language server: if the symbol
+information produced for one language is imprecise, you can disable Serena's symbolic tools for that language
+(so the agent does not act on bad data) while continuing to use them for the languages where they are
+trustworthy.
+
+This is configured per project via the `excluded_tools_by_language` key in `project.yml` (and overridable in
+`project.local.yml`). It maps a configured language (a key of the `languages` list) to a list of tool names
+to disable for that language:
+
+```yaml
+languages: [typescript, haxe, python]
+
+excluded_tools_by_language:
+  haxe:
+    - find_symbol
+    - replace_symbol_body
+    - find_referencing_symbols
+  python:
+    - replace_content
+```
+
+**Semantics.** Disabling tool `T` for language `L` makes `T` behave as if `L`'s files did not exist:
+
+- **File-pinned calls are refused.** A call that targets a specific `L` file (e.g.
+  `replace_symbol_body` on a `.hx` file) returns an explanatory error instead of executing, suggesting
+  text-based alternatives.
+- **Whole-project / search calls are transparently scoped.** `find_symbol` (without a `relative_path`) and
+  `search_for_pattern` run against the *non-`L`* languages only. When `L` files were actually present in the
+  search scope and skipped, a short one-line coverage note is appended to the result, e.g.
+  `⚠ Coverage: skipped 12 haxe file(s) (tool disabled for haxe).` — so the agent does not mistake a partial
+  result for a complete one. No note is added when nothing was skipped.
+- **Language-agnostic tools are unaffected.** Tools that do not operate on source files (e.g. `read_memory`,
+  `execute_shell_command`) are never affected; listing one here has no effect and logs a warning at load time.
+
+In addition, the agent is informed about the disabled tools upfront (in the project activation message) and via
+a caveat appended to each affected tool's description, so it can plan to use fallbacks such as
+`search_for_pattern` or `read_file`.
+
+**Notes and limitations.**
+
+- Tool names and language keys are validated when the project is loaded; an unknown tool name, an invalid
+  language, or a language that is not among the project's configured `languages` is a hard error (to catch
+  typos early).
+- File-type resolution uses each configured language's source-file extensions. If two configured languages
+  share an extension, a file matching either of them is treated as belonging to both; a file-pinned call is
+  refused if the tool is disabled for *any* matching language (conservative behaviour).
+- Disabling `find_referencing_symbols` for `L` removes references *anchored in* `L` files; cross-language
+  references were already limited by the single-language-server model and are not affected here.
+- Under the **JetBrains backend**, only the file-pinned refusal and the `search_for_pattern` scoping apply;
+  whole-project JetBrains symbol search is not scoped per language in this version.
+
 (ls-specific-settings)=
 ### Language Server-Specific Settings
 

--- a/docs/02-usage/050_configuration.md
+++ b/docs/02-usage/050_configuration.md
@@ -243,8 +243,11 @@ a caveat appended to each affected tool's description, so it can plan to use fal
   refused if the tool is disabled for *any* matching language (conservative behaviour).
 - Disabling `find_referencing_symbols` for `L` removes references *anchored in* `L` files; cross-language
   references were already limited by the single-language-server model and are not affected here.
-- Under the **JetBrains backend**, only the file-pinned refusal and the `search_for_pattern` scoping apply;
-  whole-project JetBrains symbol search is not scoped per language in this version.
+- Under the **JetBrains backend**, the file-pinned refusal, `search_for_pattern` scoping, and whole-project
+  `jet_brains_find_symbol` scoping all apply. Note that the JetBrains symbol tools are exposed under their own
+  names (e.g. `jet_brains_find_symbol`), so list those names in `excluded_tools_by_language` rather than the LSP
+  names (e.g. `find_symbol`) when running this backend. Cross-language *references* returned by
+  `jet_brains_find_referencing_symbols` are not filtered (matching the LSP behaviour).
 
 (ls-specific-settings)=
 ### Language Server-Specific Settings

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -35,6 +35,7 @@ from serena.config.serena_config import (
     ModeSelectionDefinitionWithAddedModes,
     ModeSelectionDefinitionWithBaseModes,
     NamedToolInclusionDefinition,
+    ProjectConfig,
     RegisteredProject,
     SerenaConfig,
     SerenaPaths,
@@ -851,7 +852,24 @@ class SerenaAgent:
         return self._context
 
     def get_tool_description_override(self, tool_name: str) -> str | None:
-        return self._context.tool_description_overrides.get(tool_name, None)
+        """
+        :param tool_name: the name of the tool
+        :return: an overriding tool description, or ``None`` to use the tool's default description.
+            This composes the active context's description override (if any) with a per-language
+            caveat when the tool is disabled for one or more languages in the active project.
+        """
+        base_override = self._context.tool_description_overrides.get(tool_name, None)
+        caveat: str | None = None
+        if self._active_project is not None:
+            excluded_langs = self._active_project.project_config.excluded_languages_for_tool(tool_name)
+            if excluded_langs:
+                langs_str = ", ".join(sorted(lang.value for lang in excluded_langs))
+                caveat = f"Note: disabled for {langs_str} in this project (their files are skipped / refused)."
+        if caveat is None:
+            return base_override
+        if base_override is not None:
+            return f"{base_override.rstrip()}\n{caveat}"
+        return caveat
 
     def _check_shell_settings(self) -> None:
         # On Windows, Claude Code sets COMSPEC to Git-Bash (often even with a path containing spaces),
@@ -1052,6 +1070,11 @@ class SerenaAgent:
                 msg += f"\n{mode.prompt}"
         self._project_prompt_status.mark_mode_prompts_as_provided(session_id)
 
+        # inform about per-language tool disabling (so the agent can plan fallbacks)
+        per_language_tool_summary = self._format_excluded_tools_by_language_summary(proj.project_config)
+        if per_language_tool_summary:
+            msg += f"\n{per_language_tool_summary}"
+
         # add project-specific prompt
         if proj.project_config.initial_prompt:
             msg += f"\nProject-specific instructions:\n {proj.project_config.initial_prompt}"
@@ -1059,6 +1082,29 @@ class SerenaAgent:
         self._project_prompt_status.mark_project_activation_message_as_provided(session_id)
 
         return msg
+
+    @staticmethod
+    def _format_excluded_tools_by_language_summary(project_config: "ProjectConfig") -> str | None:
+        """
+        Builds the upfront summary of per-language tool disabling for the project activation message.
+
+        :param project_config: the active project's configuration
+        :return: a short summary, or ``None`` if no tools are disabled per language
+        """
+        excluded = project_config.excluded_tools_by_language
+        if not excluded:
+            return None
+        per_language = [
+            f"{lang.value} → {', '.join(tools)}" for lang, tools in sorted(excluded.items(), key=lambda item: item[0].value) if tools
+        ]
+        if not per_language:
+            return None
+        return (
+            "In this project the following tools are disabled per language: "
+            + "; ".join(per_language)
+            + ". For those languages, the tools' files are skipped (whole-project/search tools) or "
+            "refused (file-pinned tools); use text-based search (search_for_pattern) or read files directly instead."
+        )
 
     def _update_active_modes(self, log_message: bool = True) -> None:
         """

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -3,6 +3,7 @@ The Serena Model Context Protocol (MCP) Server
 """
 
 import dataclasses
+import inspect
 import os
 import re
 import shutil
@@ -662,9 +663,7 @@ class ProjectConfig(SharedConfig, ModeSelectionDefinitionWithAddedModes):
             search tools find_symbol/search_for_pattern, which accept an optional ``relative_path``).
             Language-agnostic tools (e.g. read_memory, execute_shell_command) return ``False``.
         """
-        import inspect
-
-        apply_fn = tool_class.__dict__.get("apply") or getattr(tool_class, "apply", None)
+        apply_fn = getattr(tool_class, "apply", None)
         if apply_fn is None:
             return False
         try:

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -298,6 +298,21 @@ Uses $projectDir and $projectFolderName as placeholders.
 """
 
 
+def languages_for_path(path: str, configured_languages: Sequence[Language]) -> set[Language]:
+    """
+    Resolves the path to the configured language(s) whose source-file matcher considers it relevant.
+
+    Resolution is scoped to the project's configured languages (rather than all of :class:`Language`)
+    to avoid spurious matches caused by file-extension overlap between languages.
+
+    :param path: a (relative or absolute) file path
+    :param configured_languages: the project's configured languages
+    :return: the set of configured languages matching the given path (usually a singleton, but may
+        contain multiple entries when configured languages share a file extension)
+    """
+    return {lang for lang in configured_languages if lang.get_source_fn_matcher().is_relevant_filename(path)}
+
+
 @dataclass(kw_only=True)
 class ProjectConfig(SharedConfig, ModeSelectionDefinitionWithAddedModes):
     project_name: str
@@ -310,6 +325,13 @@ class ProjectConfig(SharedConfig, ModeSelectionDefinitionWithAddedModes):
     encoding: str = DEFAULT_SOURCE_FILE_ENCODING
     activation_command: str | None = None
     activation_command_timeout: float = 180.0
+    excluded_tools_by_language: dict[Language, list[str]] = field(default_factory=dict)
+    """
+    maps a configured language to the list of tool names that shall be disabled for that language.
+    Disabling tool `T` for language `L` means that `T` behaves as if `L`'s files did not exist:
+    calls that pin an `L` file are refused, whole-project/search calls are transparently scoped to
+    the non-`L` languages, and language-agnostic tools are unaffected (a no-op).
+    """
 
     # internal fields which are not mapped to/from the configuration file (must start with "_")
     _local_override_keys: list[str] = field(default_factory=list)
@@ -326,6 +348,14 @@ class ProjectConfig(SharedConfig, ModeSelectionDefinitionWithAddedModes):
 
     def _tostring_includes(self) -> list[str]:
         return ["project_name"]
+
+    def excluded_languages_for_tool(self, tool_name: str) -> set[Language]:
+        """
+        :param tool_name: the name of a tool
+        :return: the set of configured languages for which the given tool is disabled
+            (see :attr:`excluded_tools_by_language`)
+        """
+        return {lang for lang, tools in self.excluded_tools_by_language.items() if tool_name in tools}
 
     @classmethod
     def autogenerate(
@@ -531,12 +561,17 @@ class ProjectConfig(SharedConfig, ModeSelectionDefinitionWithAddedModes):
         if "base_modes" in data and data["base_modes"] is not None:
             log.warning("The base_modes setting in project.yml is deprecated and will be ignored.")
 
+        excluded_tools_by_language = cls._parse_excluded_tools_by_language(
+            data.get("excluded_tools_by_language") or {}, languages, lang_name_mapping
+        )
+
         return cls(
             project_name=data["project_name"],
             languages=languages,
             ignored_paths=ignored_paths,
             additional_workspace_folders=additional_workspace_folders,
             excluded_tools=excluded_tools,
+            excluded_tools_by_language=excluded_tools_by_language,
             fixed_tools=fixed_tools,
             included_optional_tools=included_optional_tools,
             read_only=data["read_only"],
@@ -556,6 +591,87 @@ class ProjectConfig(SharedConfig, ModeSelectionDefinitionWithAddedModes):
             _local_override_keys=local_override_keys,
         )
 
+    @staticmethod
+    def _parse_excluded_tools_by_language(
+        raw: dict[str, Any],
+        configured_languages: list[Language],
+        lang_name_mapping: dict[str, str],
+    ) -> dict[Language, list[str]]:
+        """
+        Parses and validates the ``excluded_tools_by_language`` configuration.
+
+        :param raw: the raw mapping from language string to list of tool names
+        :param configured_languages: the project's configured languages; each key must be one of these
+        :param lang_name_mapping: mapping of language aliases (e.g. ``javascript`` -> ``typescript``)
+        :return: the validated mapping from :class:`Language` to list of tool names
+        :raises ValueError: if a key is not a valid/configured language or a tool name is unknown
+        """
+        from serena.tools import ToolRegistry
+
+        if not isinstance(raw, dict):
+            raise ValueError(f"excluded_tools_by_language must be a mapping of language to tool names, got: {raw!r}")
+
+        registry = ToolRegistry()
+        configured_set = set(configured_languages)
+        result: dict[Language, list[str]] = {}
+        for language_str, tool_names in raw.items():
+            # resolve the language, applying the same alias normalisation as the `languages` field
+            orig_language_str = language_str
+            normalised = str(language_str).lower()
+            normalised = lang_name_mapping.get(normalised, normalised)
+            try:
+                language = Language(normalised)
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid language '{orig_language_str}' in excluded_tools_by_language.\n"
+                    f"Valid language strings are: {[l.value for l in Language]}"
+                ) from e
+            if language not in configured_set:
+                raise ValueError(
+                    f"Language '{orig_language_str}' in excluded_tools_by_language is not among the project's "
+                    f"configured languages: {[l.value for l in configured_languages]}"
+                )
+
+            tool_names = tool_names or []
+            if not isinstance(tool_names, list):
+                raise ValueError(f"excluded_tools_by_language['{orig_language_str}'] must be a list of tool names, got: {tool_names!r}")
+            for tool_name in tool_names:
+                if not registry.is_valid_tool_name(tool_name):
+                    raise ValueError(
+                        f"Unknown tool name '{tool_name}' in excluded_tools_by_language['{orig_language_str}']. "
+                        f"See the list of valid tools (e.g. via `serena tools list`)."
+                    )
+                # warn if the tool does not target files at all (gating it has no effect)
+                if not ProjectConfig._tool_targets_files(registry.get_tool_class_by_name(tool_name)):
+                    log.warning(
+                        "Tool '%s' configured in excluded_tools_by_language for language '%s' is language-agnostic "
+                        "(it does not target source files); the entry will have no effect.",
+                        tool_name,
+                        language.value,
+                    )
+            result[language] = list(tool_names)
+        return result
+
+    @staticmethod
+    def _tool_targets_files(tool_class: "type[Tool]") -> bool:
+        """
+        :param tool_class: a tool class
+        :return: whether the tool concretely targets source files (and is therefore affected by
+            per-language disabling). A tool targets files if its ``apply`` method accepts a
+            ``relative_path`` parameter (covering both pinned-file tools and the whole-project
+            search tools find_symbol/search_for_pattern, which accept an optional ``relative_path``).
+            Language-agnostic tools (e.g. read_memory, execute_shell_command) return ``False``.
+        """
+        import inspect
+
+        apply_fn = tool_class.__dict__.get("apply") or getattr(tool_class, "apply", None)
+        if apply_fn is None:
+            return False
+        try:
+            return "relative_path" in inspect.signature(apply_fn).parameters
+        except (TypeError, ValueError):
+            return False
+
     def _to_yaml_dict(self) -> dict:
         """
         :return: a yaml-serializable dictionary representation of this configuration
@@ -572,6 +688,7 @@ class ProjectConfig(SharedConfig, ModeSelectionDefinitionWithAddedModes):
         d["languages"] = [lang.value for lang in self.languages]
         d["language_backend"] = self.language_backend.value if self.language_backend is not None else None
         d["line_ending"] = self.line_ending.value if self.line_ending is not None else None
+        d["excluded_tools_by_language"] = {lang.value: list(tools) for lang, tools in self.excluded_tools_by_language.items()}
 
         return d
 

--- a/src/serena/ls_manager.py
+++ b/src/serena/ls_manager.py
@@ -229,8 +229,19 @@ class LanguageServerManager:
             log.info(f"Stopping language server for language {ls.language} ...")
             ls.stop(shutdown_timeout=timeout)
 
-    def iter_language_servers(self) -> Iterator[SolidLanguageServer]:
-        for ls in self._language_servers.values():
+    def iter_language_servers(
+        self, exclude_languages: "frozenset[Language] | set[Language]" = frozenset()
+    ) -> Iterator[SolidLanguageServer]:
+        """
+        Iterates over the managed language servers.
+
+        :param exclude_languages: languages whose language servers shall be skipped. This is used by the
+            per-language tool-disabling mechanism to transparently scope whole-project symbol searches.
+        :return: an iterator over the (functional) language servers, excluding those for ``exclude_languages``
+        """
+        for language, ls in self._language_servers.items():
+            if language in exclude_languages:
+                continue
             yield self._ensure_functional_ls(ls)
 
     def stop_all(self, save_cache: bool = False, timeout: float = 2.0) -> None:

--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -70,7 +70,9 @@ class SerenaFastMCPTool(FastMCPTool):
 
         # Mount the tool description as a combination of the docstring description and
         # the return value description, if it exists.
-        overridden_description = tool.agent.get_context().tool_description_overrides.get(func_name, None)
+        # Uses the agent's resolver so that, in addition to the context's static override, a
+        # per-language tool-disabling caveat is appended when applicable (see excluded_tools_by_language).
+        overridden_description = tool.agent.get_tool_description_override(func_name)
 
         if overridden_description is not None:
             func_doc = overridden_description

--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -28,6 +28,20 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _filter_out_languages(relative_file_paths: list[str], exclude_languages: "set[Language] | frozenset[Language]") -> list[str]:
+    """
+    Removes from the given list the paths that belong to any of the excluded languages.
+
+    :param relative_file_paths: the candidate relative file paths
+    :param exclude_languages: the languages whose files shall be removed
+    :return: the filtered list of relative file paths
+    """
+    if not exclude_languages:
+        return relative_file_paths
+    matchers = [lang.get_source_fn_matcher() for lang in exclude_languages]
+    return [p for p in relative_file_paths if not any(m.is_relevant_filename(p) for m in matchers)]
+
+
 class Project(ToStringMixin):
     def __init__(
         self,
@@ -359,6 +373,31 @@ class Project(ToStringMixin):
                         )
             return rel_file_paths
 
+    def count_source_files_for_languages(
+        self, languages: "set[Language] | frozenset[Language]", relative_path: str = ""
+    ) -> dict[Language, int]:
+        """
+        Counts the (non-ignored) source files in scope that belong to each of the given languages.
+
+        This is used by the per-language tool-disabling mechanism to decide whether to emit a coverage
+        note when a whole-project/search call is scoped to exclude one or more languages (and to report
+        how many files were skipped).
+
+        :param languages: the languages to count source files for
+        :param relative_path: if provided, restrict the count to this file or subdirectory
+        :return: a mapping from language to the number of in-scope source files of that language;
+            languages with no in-scope files are omitted
+        """
+        if not languages:
+            return {}
+        matchers = {lang: lang.get_source_fn_matcher() for lang in languages}
+        counts: dict[Language, int] = {}
+        for rel_file_path in self.gather_source_files(relative_path=relative_path):
+            for lang, matcher in matchers.items():
+                if matcher.is_relevant_filename(rel_file_path):
+                    counts[lang] = counts.get(lang, 0) + 1
+        return counts
+
     def search_project_files_for_pattern(
         self,
         pattern: str,
@@ -369,6 +408,7 @@ class Project(ToStringMixin):
         paths_exclude_glob: str | None = None,
         multiline: bool = True,
         code_files_only: bool = True,
+        exclude_languages: "set[Language] | frozenset[Language]" = frozenset(),
     ) -> list[MatchedConsecutiveLines]:
         """
         Search for a pattern across all (non-ignored) source files
@@ -380,24 +420,27 @@ class Project(ToStringMixin):
         :param paths_include_glob: Glob pattern to filter which files to include in the search
         :param paths_exclude_glob: Glob pattern to filter which files to exclude from the search. Takes precedence over paths_include_glob.
         :param multiline: Whether to compile the regex with the DOTALL flag (``.`` matches newlines).
+        :param exclude_languages: languages whose source files shall be excluded from the search
+            (used by the per-language tool-disabling mechanism)
         :return: List of matched consecutive lines with context
         """
         if code_files_only:
             relative_file_paths = self.gather_source_files(relative_path=relative_path)
-            file_collection = FileCollection.from_local_project_paths(relative_file_paths, self)
         else:
             abs_path = os.path.join(self.project_root, relative_path)
             if os.path.isfile(abs_path):
-                rel_paths_to_search = [relative_path]
+                relative_file_paths = [relative_path]
             else:
-                _dirs, rel_paths_to_search = scan_directory(
+                _dirs, relative_file_paths = scan_directory(
                     path=abs_path,
                     recursive=True,
                     is_ignored_dir=self.is_ignored_path,
                     is_ignored_file=self.is_ignored_path,
                     relative_to=self.project_root,
                 )
-            file_collection = FileCollection.from_local_project_paths(rel_paths_to_search, self)
+        if exclude_languages:
+            relative_file_paths = _filter_out_languages(relative_file_paths, exclude_languages)
+        file_collection = FileCollection.from_local_project_paths(relative_file_paths, self)
 
         return search_files(
             file_collection,

--- a/src/serena/resources/project.template.yml
+++ b/src/serena/resources/project.template.yml
@@ -97,6 +97,24 @@ read_only: false
 # Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
+# Per-language tool disabling: maps a configured language (a key of `languages` above) to a list of
+# tool names that shall be disabled *for that language only*.
+# Disabling tool T for language L makes T behave as if L's files did not exist:
+#   - calls that pin an L file (e.g. replace_symbol_body on a .hx file) are refused with an explanation,
+#   - whole-project / search calls (find_symbol without a path, search_for_pattern) are transparently
+#     scoped to the non-L languages and a short coverage note is appended when L files were skipped,
+#   - language-agnostic tools (e.g. read_memory) are unaffected (configuring one logs a warning).
+# This is useful when a particular language server produces unreliable symbol information, so you want
+# symbolic tools restricted to the languages where they are trustworthy while keeping text-based tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+# Example:
+#   excluded_tools_by_language:
+#     haxe:
+#       - find_symbol
+#       - replace_symbol_body
+#       - find_referencing_symbols
+excluded_tools_by_language: {}
+
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
 # Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html

--- a/src/serena/symbol.py
+++ b/src/serena/symbol.py
@@ -15,6 +15,7 @@ import serena.jetbrains.jetbrains_types as jb
 from solidlsp import SolidLanguageServer, ls_types
 from solidlsp.ls import LSPFileBuffer
 from solidlsp.ls import ReferenceInSymbol as LSPReferenceInSymbol
+from solidlsp.ls_config import Language
 from solidlsp.ls_types import Position, SymbolKind, UnifiedSymbolInformation
 from solidlsp.ls_utils import TextUtils
 
@@ -738,10 +739,15 @@ class LanguageServerSymbolRetriever:
         exclude_kinds: Sequence[SymbolKind] | None = None,
         substring_matching: bool = False,
         within_relative_path: str | None = None,
+        exclude_languages: "frozenset[Language] | set[Language]" = frozenset(),
     ) -> list[LanguageServerSymbol]:
         """
         Finds all symbols that match the given name path pattern (see class :class:`NamePathMatcher` for details),
         optionally limited to a specific file and filtered by kind.
+
+        :param exclude_languages: when no specific file is targeted (whole-project search), language servers
+            for these languages are skipped (used by the per-language tool-disabling mechanism to scope the
+            search to non-excluded languages). Ignored when ``within_relative_path`` pins a single file.
         """
         symbols: list[LanguageServerSymbol] = []
         if within_relative_path and os.path.isfile(os.path.join(self.project.project_root, within_relative_path)):
@@ -752,7 +758,7 @@ class LanguageServerSymbolRetriever:
             """
             lang_servers: Iterable[SolidLanguageServer] = [self._ls_manager.get_language_server(within_relative_path)]
         else:
-            lang_servers = self._ls_manager.iter_language_servers()
+            lang_servers = self._ls_manager.iter_language_servers(exclude_languages=exclude_languages)
         for lang_server in lang_servers:
             symbol_roots = lang_server.request_full_symbol_tree(within_relative_path=within_relative_path)
             for root in symbol_roots:

--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -642,6 +642,4 @@ class SearchForPatternTool(Tool):
         limited = self._limit_length(
             result, max_answer_chars, shortened_result_factories=[make_lines_only, make_per_file_counts, make_summary]
         )
-        if scoping.coverage_note:
-            return f"{scoping.coverage_note}\n{limited}"
-        return limited
+        return scoping.with_note(limited)

--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -598,6 +598,10 @@ class SearchForPatternTool(Tool):
         if not os.path.exists(abs_path):
             raise FileNotFoundError(f"Relative path {relative_path} does not exist.")
 
+        # per-language tool disabling (Behaviour 2): scope the search to exclude files of languages
+        # for which this tool is disabled, appending a coverage note if any were skipped
+        scoping = self.get_language_scoping(relative_path=relative_path)
+
         matches = self.project.search_project_files_for_pattern(
             pattern=substring_pattern,
             relative_path=relative_path,
@@ -607,6 +611,7 @@ class SearchForPatternTool(Tool):
             paths_exclude_glob=paths_exclude_glob.strip(),
             multiline=multiline,
             code_files_only=restrict_search_to_code_files,
+            exclude_languages=scoping.excluded_languages,
         )
 
         # group matches by file
@@ -634,6 +639,9 @@ class SearchForPatternTool(Tool):
             return f"Found {len(matches)} matches in {len(match_lines_by_file)} files."
 
         result = self._to_json(file_to_matches)
-        return self._limit_length(
+        limited = self._limit_length(
             result, max_answer_chars, shortened_result_factories=[make_lines_only, make_per_file_counts, make_summary]
         )
+        if scoping.coverage_note:
+            return f"{scoping.coverage_note}\n{limited}"
+        return limited

--- a/src/serena/tools/jetbrains_tools.py
+++ b/src/serena/tools/jetbrains_tools.py
@@ -8,7 +8,7 @@ from serena.jetbrains.jetbrains_plugin_client import JetBrainsPluginClient
 from serena.jetbrains.jetbrains_types import SymbolDTO, SymbolDTOUtil
 from serena.project import _filter_out_languages
 from serena.symbol import JetBrainsSymbolDictGrouper
-from serena.tools import Tool, ToolMarkerBeta, ToolMarkerOptional, ToolMarkerSymbolicEdit, ToolMarkerSymbolicRead
+from serena.tools import LanguageScoping, Tool, ToolMarkerBeta, ToolMarkerOptional, ToolMarkerSymbolicEdit, ToolMarkerSymbolicRead
 from serena.util.text_utils import find_text_coordinates
 
 log = logging.getLogger(__name__)
@@ -112,13 +112,10 @@ class JetBrainsFindSymbolTool(Tool, ToolMarkerSymbolicRead, ToolMarkerOptional):
         # file would already have been refused by Behaviour 1 (in apply_ex); searches of external
         # dependencies are not language-scoped.
         is_external_search = relative_path is not None and relative_path.startswith(jb.JB_EXTERNAL_FILE_PREFIX)
-        scoping = None if is_external_search else self.get_language_scoping(relative_path=(relative_path or "").strip())
-        if scoping is not None and scoping.excluded_languages:
+        scoping = LanguageScoping.none() if is_external_search else self.get_language_scoping(relative_path=(relative_path or "").strip())
+        if scoping.excluded_languages:
             allowed_paths = set(_filter_out_languages([s["relative_path"] for s in symbols], scoping.excluded_languages))
             symbols = [s for s in symbols if SymbolDTOUtil.is_external_symbol(s) or s["relative_path"] in allowed_paths]
-
-        def with_coverage_note(text: str) -> str:
-            return f"{scoping.coverage_note}\n{text}" if scoping is not None and scoping.coverage_note else text
 
         def create_shortened_result() -> str:
             """Shortened results containing symbol types and identifiers (path + name_path) only, without children"""
@@ -130,13 +127,11 @@ class JetBrainsFindSymbolTool(Tool, ToolMarkerSymbolicRead, ToolMarkerOptional):
 
         n_matches = len(symbols)
         if 0 < max_matches < n_matches:
-            return with_coverage_note(f"Matched {n_matches}>{max_matches=} symbols.\n" + create_shortened_result())
+            return scoping.with_note(f"Matched {n_matches}>{max_matches=} symbols.\n" + create_shortened_result())
 
         grouped_symbols = self.symbol_dict_grouper.group(symbols)
         result = self._to_json(grouped_symbols)
-        return with_coverage_note(
-            self._limit_length(result, max_answer_chars, shortened_result_factories=[create_shortened_result])
-        )
+        return scoping.with_note(self._limit_length(result, max_answer_chars, shortened_result_factories=[create_shortened_result]))
 
     @classmethod
     def get_param_aliases(cls) -> dict[str, str]:

--- a/src/serena/tools/jetbrains_tools.py
+++ b/src/serena/tools/jetbrains_tools.py
@@ -6,6 +6,7 @@ import serena.jetbrains.jetbrains_types as jb
 from serena.code_editor import JetBrainsCodeEditor
 from serena.jetbrains.jetbrains_plugin_client import JetBrainsPluginClient
 from serena.jetbrains.jetbrains_types import SymbolDTO, SymbolDTOUtil
+from serena.project import _filter_out_languages
 from serena.symbol import JetBrainsSymbolDictGrouper
 from serena.tools import Tool, ToolMarkerBeta, ToolMarkerOptional, ToolMarkerSymbolicEdit, ToolMarkerSymbolicRead
 from serena.util.text_utils import find_text_coordinates
@@ -106,6 +107,19 @@ class JetBrainsFindSymbolTool(Tool, ToolMarkerSymbolicRead, ToolMarkerOptional):
             )
         symbols = symbol_collection_response["symbols"]
 
+        # per-language tool disabling (Behaviour 2): scope a whole-project / directory search to the
+        # non-excluded languages and append a coverage note when files were skipped. A pinned project
+        # file would already have been refused by Behaviour 1 (in apply_ex); searches of external
+        # dependencies are not language-scoped.
+        is_external_search = relative_path is not None and relative_path.startswith(jb.JB_EXTERNAL_FILE_PREFIX)
+        scoping = None if is_external_search else self.get_language_scoping(relative_path=(relative_path or "").strip())
+        if scoping is not None and scoping.excluded_languages:
+            allowed_paths = set(_filter_out_languages([s["relative_path"] for s in symbols], scoping.excluded_languages))
+            symbols = [s for s in symbols if SymbolDTOUtil.is_external_symbol(s) or s["relative_path"] in allowed_paths]
+
+        def with_coverage_note(text: str) -> str:
+            return f"{scoping.coverage_note}\n{text}" if scoping is not None and scoping.coverage_note else text
+
         def create_shortened_result() -> str:
             """Shortened results containing symbol types and identifiers (path + name_path) only, without children"""
             dicts: list[SymbolDTO] = [
@@ -116,11 +130,13 @@ class JetBrainsFindSymbolTool(Tool, ToolMarkerSymbolicRead, ToolMarkerOptional):
 
         n_matches = len(symbols)
         if 0 < max_matches < n_matches:
-            return f"Matched {n_matches}>{max_matches=} symbols.\n" + create_shortened_result()
+            return with_coverage_note(f"Matched {n_matches}>{max_matches=} symbols.\n" + create_shortened_result())
 
         grouped_symbols = self.symbol_dict_grouper.group(symbols)
         result = self._to_json(grouped_symbols)
-        return self._limit_length(result, max_answer_chars, shortened_result_factories=[create_shortened_result])
+        return with_coverage_note(
+            self._limit_length(result, max_answer_chars, shortened_result_factories=[create_shortened_result])
+        )
 
     @classmethod
     def get_param_aliases(cls) -> dict[str, str]:

--- a/src/serena/tools/symbol_tools.py
+++ b/src/serena/tools/symbol_tools.py
@@ -217,11 +217,8 @@ class FindSymbolTool(Tool, ToolMarkerSymbolicRead):
                 relative_path_to_name_paths[s.location.relative_path or "unknown"].append(s.get_name_path())
             return f"Shortened result:\n{self._to_json(relative_path_to_name_paths)}"
 
-        def with_coverage_note(text: str) -> str:
-            return f"{scoping.coverage_note}\n{text}" if scoping.coverage_note else text
-
         if 0 < max_matches < n_matches:
-            return with_coverage_note(f"Matched {n_matches}>{max_matches=} symbols.\n" + create_short_result_relative_path_to_name_paths())
+            return scoping.with_note(f"Matched {n_matches}>{max_matches=} symbols.\n" + create_short_result_relative_path_to_name_paths())
 
         symbol_dicts = [
             s.to_dict(
@@ -248,7 +245,7 @@ class FindSymbolTool(Tool, ToolMarkerSymbolicRead):
 
         grouped_symbol_dicts = self.symbol_dict_grouper.group(symbol_dicts)
         result = self._to_json(grouped_symbol_dicts)
-        return with_coverage_note(
+        return scoping.with_note(
             self._limit_length(result, max_answer_chars, shortened_result_factories=[create_short_result_relative_path_to_name_paths])
         )
 

--- a/src/serena/tools/symbol_tools.py
+++ b/src/serena/tools/symbol_tools.py
@@ -194,6 +194,12 @@ class FindSymbolTool(Tool, ToolMarkerSymbolicRead):
         assert max_matches != 0, "max_matches must be > 0 or equal to -1."
         parsed_include_kinds: Sequence[SymbolKind] | None = [SymbolKind(k) for k in include_kinds] if include_kinds else None
         parsed_exclude_kinds: Sequence[SymbolKind] | None = [SymbolKind(k) for k in exclude_kinds] if exclude_kinds else None
+
+        # per-language tool disabling (Behaviour 2): scope a whole-project search to the non-excluded
+        # languages. When a specific file is pinned, the refuse guard (Behaviour 1) has already run, so
+        # scoping here is a no-op for the single-file case.
+        scoping = self.get_language_scoping(relative_path=(relative_path or "").strip())
+
         symbol_retriever = self.create_language_server_symbol_retriever()
         symbols = symbol_retriever.find(
             name_path_pattern,
@@ -201,6 +207,7 @@ class FindSymbolTool(Tool, ToolMarkerSymbolicRead):
             exclude_kinds=parsed_exclude_kinds,
             substring_matching=substring_matching,
             within_relative_path=relative_path,
+            exclude_languages=scoping.excluded_languages,
         )
         n_matches = len(symbols)
 
@@ -210,8 +217,11 @@ class FindSymbolTool(Tool, ToolMarkerSymbolicRead):
                 relative_path_to_name_paths[s.location.relative_path or "unknown"].append(s.get_name_path())
             return f"Shortened result:\n{self._to_json(relative_path_to_name_paths)}"
 
+        def with_coverage_note(text: str) -> str:
+            return f"{scoping.coverage_note}\n{text}" if scoping.coverage_note else text
+
         if 0 < max_matches < n_matches:
-            return f"Matched {n_matches}>{max_matches=} symbols.\n" + create_short_result_relative_path_to_name_paths()
+            return with_coverage_note(f"Matched {n_matches}>{max_matches=} symbols.\n" + create_short_result_relative_path_to_name_paths())
 
         symbol_dicts = [
             s.to_dict(
@@ -238,7 +248,9 @@ class FindSymbolTool(Tool, ToolMarkerSymbolicRead):
 
         grouped_symbol_dicts = self.symbol_dict_grouper.group(symbol_dicts)
         result = self._to_json(grouped_symbol_dicts)
-        return self._limit_length(result, max_answer_chars, shortened_result_factories=[create_short_result_relative_path_to_name_paths])
+        return with_coverage_note(
+            self._limit_length(result, max_answer_chars, shortened_result_factories=[create_short_result_relative_path_to_name_paths])
+        )
 
     @classmethod
     def get_param_aliases(cls) -> dict[str, str]:

--- a/src/serena/tools/tools_base.py
+++ b/src/serena/tools/tools_base.py
@@ -47,6 +47,18 @@ class LanguageScoping:
     """a short, one-line note to append to the result when files of an excluded language were actually
     skipped within the search scope; ``None`` if nothing was skipped (in which case no note should be emitted)"""
 
+    @classmethod
+    def none(cls) -> "LanguageScoping":
+        """:return: a scoping that excludes nothing and carries no coverage note"""
+        return cls(excluded_languages=frozenset(), coverage_note=None)
+
+    def with_note(self, text: str) -> str:
+        """
+        :param text: a tool result
+        :return: the result with the coverage note prepended (if there is one), else unchanged
+        """
+        return f"{self.coverage_note}\n{text}" if self.coverage_note else text
+
 
 def _format_coverage_note(skipped_counts: dict[Language, int]) -> str | None:
     """
@@ -373,9 +385,9 @@ class Tool(Component):
             or language-agnostic tools). Directories are not considered pinned files.
         """
         rp = kwargs.get("relative_path")
-        if isinstance(rp, str) and rp.strip():
+        if isinstance(rp, str):
             rp = rp.strip()
-            if os.path.isfile(os.path.join(self.get_project_root(), rp)):
+            if rp and os.path.isfile(os.path.join(self.get_project_root(), rp)):
                 return [rp]
         return None
 
@@ -399,8 +411,9 @@ class Tool(Component):
         for rp in target_paths:
             hit = languages_for_path(rp, project.project_config.languages) & excluded_langs
             if hit:
-                lang_list = ", ".join(sorted(lang.value for lang in hit))
-                hit_lang = sorted(hit, key=lambda lang: lang.value)[0].value
+                hit_values = sorted(lang.value for lang in hit)
+                lang_list = ", ".join(hit_values)
+                hit_lang = hit_values[0]
                 return (
                     f"Error: Tool '{self.get_name()}' is disabled for {lang_list} in this project; "
                     f"'{rp}' is a {hit_lang} file. Inspect {hit_lang} code with text-based tools "
@@ -420,10 +433,10 @@ class Tool(Component):
         """
         project = self.agent.get_active_project()
         if project is None:
-            return LanguageScoping(excluded_languages=frozenset(), coverage_note=None)
+            return LanguageScoping.none()
         excluded_langs = project.project_config.excluded_languages_for_tool(self.get_name())
         if not excluded_langs:
-            return LanguageScoping(excluded_languages=frozenset(), coverage_note=None)
+            return LanguageScoping.none()
         skipped_counts = project.count_source_files_for_languages(excluded_langs, relative_path=relative_path)
         return LanguageScoping(excluded_languages=frozenset(excluded_langs), coverage_note=_format_coverage_note(skipped_counts))
 

--- a/src/serena/tools/tools_base.py
+++ b/src/serena/tools/tools_base.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import os
 from abc import ABC
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -13,13 +14,14 @@ from mcp.server.fastmcp.utilities.func_metadata import FuncMetadata, func_metada
 from sensai.util import logging
 from sensai.util.string import dict_string
 
-from serena.config.serena_config import LanguageBackend
+from serena.config.serena_config import LanguageBackend, languages_for_path
 from serena.memories.memory_manager import MemoryManager
 from serena.project import Project
 from serena.prompt_factory import PromptFactory
 from serena.util.class_decorators import singleton
 from serena.util.inspection import iter_subclasses
 from serena.util.ls_diagnostics import DiagnosticsDiff, EditedFilePath, PublishedDiagnosticsSnapshot
+from solidlsp.ls_config import Language
 from solidlsp.ls_exceptions import SolidLSPException
 
 if TYPE_CHECKING:
@@ -30,6 +32,35 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 T = TypeVar("T")
 SUCCESS_RESULT = "OK"
+
+
+@dataclass
+class LanguageScoping:
+    """
+    Result of resolving per-language tool disabling for a whole-project/search tool call
+    (see :meth:`Tool.get_language_scoping`).
+    """
+
+    excluded_languages: frozenset[Language]
+    """the languages for which the tool is disabled (their files are skipped in the search)"""
+    coverage_note: str | None
+    """a short, one-line note to append to the result when files of an excluded language were actually
+    skipped within the search scope; ``None`` if nothing was skipped (in which case no note should be emitted)"""
+
+
+def _format_coverage_note(skipped_counts: dict[Language, int]) -> str | None:
+    """
+    Formats the per-call coverage note for the per-language tool-disabling mechanism.
+
+    :param skipped_counts: mapping from language to the number of in-scope source files that were skipped
+    :return: a terse one-line note, or ``None`` if no files were skipped
+    """
+    parts = [(lang.value, count) for lang, count in sorted(skipped_counts.items(), key=lambda item: item[0].value) if count > 0]
+    if not parts:
+        return None
+    files_str = ", ".join(f"{count} {lang}" for lang, count in parts)
+    langs_str = ", ".join(lang for lang, _ in parts)
+    return f"⚠ Coverage: skipped {files_str} file(s) (tool disabled for {langs_str})."
 
 
 class Component(ABC):
@@ -327,6 +358,75 @@ class Tool(Component):
         """
         return {}
 
+    def get_target_relative_paths(self, kwargs: dict[str, Any]) -> list[str] | None:
+        """
+        Determines the source files a given tool call concretely targets (pins).
+
+        This is used by the per-language tool-disabling mechanism (see
+        :attr:`serena.config.serena_config.ProjectConfig.excluded_tools_by_language`):
+        if a call pins a file belonging to a language for which the tool is disabled, the
+        call is refused.
+
+        :param kwargs: the keyword arguments of the tool call
+        :return: the list of project-relative paths that the call concretely targets (pins),
+            or ``None`` if the call does not pin specific files (e.g. whole-project / search calls,
+            or language-agnostic tools). Directories are not considered pinned files.
+        """
+        rp = kwargs.get("relative_path")
+        if isinstance(rp, str) and rp.strip():
+            rp = rp.strip()
+            if os.path.isfile(os.path.join(self.get_project_root(), rp)):
+                return [rp]
+        return None
+
+    def _check_language_exclusion(self, kwargs: dict[str, Any]) -> str | None:
+        """
+        Implements Behaviour 1 of the per-language tool-disabling mechanism: refuses a call that
+        pins a file belonging to a language for which this tool is disabled.
+
+        :param kwargs: the keyword arguments of the tool call
+        :return: an explanatory error message if the call must be refused, else ``None``
+        """
+        project = self.agent.get_active_project()
+        if project is None:
+            return None
+        excluded_langs = project.project_config.excluded_languages_for_tool(self.get_name())
+        if not excluded_langs:
+            return None
+        target_paths = self.get_target_relative_paths(kwargs)
+        if not target_paths:
+            return None
+        for rp in target_paths:
+            hit = languages_for_path(rp, project.project_config.languages) & excluded_langs
+            if hit:
+                lang_list = ", ".join(sorted(lang.value for lang in hit))
+                hit_lang = sorted(hit, key=lambda lang: lang.value)[0].value
+                return (
+                    f"Error: Tool '{self.get_name()}' is disabled for {lang_list} in this project; "
+                    f"'{rp}' is a {hit_lang} file. Inspect {hit_lang} code with text-based tools "
+                    f"(e.g. search_for_pattern) or read_file instead."
+                )
+        return None
+
+    def get_language_scoping(self, relative_path: str = "") -> "LanguageScoping":
+        """
+        Implements Behaviour 2 of the per-language tool-disabling mechanism for whole-project/search
+        tools: determines the languages for which this tool is disabled and a coverage note describing
+        the files that will be skipped.
+
+        :param relative_path: the search scope (a file or directory), or an empty string for the whole project
+        :return: a :class:`LanguageScoping` carrying the excluded languages and a coverage note (the note
+            is non-``None`` only when in-scope files of an excluded language were actually present and skipped)
+        """
+        project = self.agent.get_active_project()
+        if project is None:
+            return LanguageScoping(excluded_languages=frozenset(), coverage_note=None)
+        excluded_langs = project.project_config.excluded_languages_for_tool(self.get_name())
+        if not excluded_langs:
+            return LanguageScoping(excluded_languages=frozenset(), coverage_note=None)
+        skipped_counts = project.count_source_files_for_languages(excluded_langs, relative_path=relative_path)
+        return LanguageScoping(excluded_languages=frozenset(excluded_langs), coverage_note=_format_coverage_note(skipped_counts))
+
     def apply_ex(self, log_call: bool = True, catch_exceptions: bool = True, mcp_ctx: Context | None = None, **kwargs) -> str:
         """
         Applies the tool with logging and exception handling, using the given keyword arguments.
@@ -370,6 +470,13 @@ class Tool(Component):
                             "No active project. Ask the user to provide the project path or to select a project from this list of known projects: "
                             + f"{self.agent.serena_config.project_names}"
                         )
+
+                # per-language tool disabling (Behaviour 1): refuse calls that pin a file of a
+                # language for which this tool is disabled
+                language_exclusion_error = self._check_language_exclusion(kwargs)
+                if language_exclusion_error is not None:
+                    log.info(language_exclusion_error)
+                    return language_exclusion_error
 
                 # construct apply kwargs, adding session_id if the tool is session-aware
                 apply_kwargs = dict(kwargs)

--- a/test/serena/config/test_excluded_tools_by_language.py
+++ b/test/serena/config/test_excluded_tools_by_language.py
@@ -1,0 +1,154 @@
+"""Tests for the per-language tool disabling feature (``excluded_tools_by_language``).
+
+Covers configuration parsing/validation, the path->language resolution helper, and the
+reverse lookup ``ProjectConfig.excluded_languages_for_tool``.
+"""
+
+import logging
+
+import pytest
+
+from serena.config.serena_config import ProjectConfig, languages_for_path
+from serena.constants import PROJECT_TEMPLATE_FILE
+from solidlsp.ls_config import Language
+
+
+def _template_data() -> dict:
+    data, _ = ProjectConfig._load_yaml_dict(PROJECT_TEMPLATE_FILE)
+    data["project_name"] = "test"
+    data["languages"] = ["typescript", "haxe", "python"]
+    return data
+
+
+class TestExcludedToolsByLanguageParsing:
+    def test_default_is_empty_dict(self):
+        config = ProjectConfig(project_name="test", languages=[Language.PYTHON])
+        assert config.excluded_tools_by_language == {}
+
+    def test_missing_from_dict_defaults_to_empty(self):
+        data = _template_data()
+        data.pop("excluded_tools_by_language", None)
+        config = ProjectConfig._from_dict(data, local_override_keys=[])
+        assert config.excluded_tools_by_language == {}
+
+    def test_valid_map_parses(self):
+        data = _template_data()
+        data["excluded_tools_by_language"] = {
+            "haxe": ["find_symbol", "replace_symbol_body"],
+            "python": ["replace_content"],
+        }
+        config = ProjectConfig._from_dict(data, local_override_keys=[])
+        assert config.excluded_tools_by_language == {
+            Language.HAXE: ["find_symbol", "replace_symbol_body"],
+            Language.PYTHON: ["replace_content"],
+        }
+
+    def test_none_value_treated_as_empty(self):
+        data = _template_data()
+        data["excluded_tools_by_language"] = None
+        config = ProjectConfig._from_dict(data, local_override_keys=[])
+        assert config.excluded_tools_by_language == {}
+
+    def test_language_alias_is_normalised(self):
+        """The 'javascript' alias should be normalised to typescript, consistent with the languages field."""
+        data = _template_data()
+        data["excluded_tools_by_language"] = {"javascript": ["find_symbol"]}
+        config = ProjectConfig._from_dict(data, local_override_keys=[])
+        assert config.excluded_tools_by_language == {Language.TYPESCRIPT: ["find_symbol"]}
+
+    def test_unknown_language_raises(self):
+        data = _template_data()
+        data["excluded_tools_by_language"] = {"klingon": ["find_symbol"]}
+        with pytest.raises(ValueError, match="klingon"):
+            ProjectConfig._from_dict(data, local_override_keys=[])
+
+    def test_language_not_in_project_raises(self):
+        """A valid language that is not among the project's configured languages is an error."""
+        data = _template_data()
+        data["excluded_tools_by_language"] = {"go": ["find_symbol"]}
+        with pytest.raises(ValueError, match="go"):
+            ProjectConfig._from_dict(data, local_override_keys=[])
+
+    def test_unknown_tool_raises(self):
+        data = _template_data()
+        data["excluded_tools_by_language"] = {"haxe": ["this_tool_does_not_exist"]}
+        with pytest.raises(ValueError, match="this_tool_does_not_exist"):
+            ProjectConfig._from_dict(data, local_override_keys=[])
+
+    def test_language_agnostic_tool_warns(self, caplog):
+        data = _template_data()
+        data["excluded_tools_by_language"] = {"haxe": ["read_memory"]}
+        with caplog.at_level(logging.WARNING):
+            config = ProjectConfig._from_dict(data, local_override_keys=[])
+        # the entry is still parsed (it is a valid tool name) but a warning is emitted
+        assert config.excluded_tools_by_language == {Language.HAXE: ["read_memory"]}
+        assert any("read_memory" in msg and "no effect" in msg for msg in caplog.messages)
+
+    def test_roundtrips_through_yaml(self):
+        config = ProjectConfig(
+            project_name="test",
+            languages=[Language.HAXE, Language.PYTHON],
+            excluded_tools_by_language={Language.HAXE: ["find_symbol"]},
+        )
+        d = config._to_yaml_dict()
+        assert d["excluded_tools_by_language"] == {"haxe": ["find_symbol"]}
+
+
+class TestExcludedLanguagesForTool:
+    def test_reverse_lookup(self):
+        config = ProjectConfig(
+            project_name="test",
+            languages=[Language.HAXE, Language.PYTHON],
+            excluded_tools_by_language={
+                Language.HAXE: ["find_symbol", "replace_symbol_body"],
+                Language.PYTHON: ["replace_content"],
+            },
+        )
+        assert config.excluded_languages_for_tool("find_symbol") == {Language.HAXE}
+        assert config.excluded_languages_for_tool("replace_content") == {Language.PYTHON}
+        assert config.excluded_languages_for_tool("search_for_pattern") == set()
+
+    def test_tool_excluded_for_multiple_languages(self):
+        config = ProjectConfig(
+            project_name="test",
+            languages=[Language.HAXE, Language.PYTHON],
+            excluded_tools_by_language={
+                Language.HAXE: ["find_symbol"],
+                Language.PYTHON: ["find_symbol"],
+            },
+        )
+        assert config.excluded_languages_for_tool("find_symbol") == {Language.HAXE, Language.PYTHON}
+
+    def test_empty_config(self):
+        config = ProjectConfig(project_name="test", languages=[Language.PYTHON])
+        assert config.excluded_languages_for_tool("find_symbol") == set()
+
+
+class TestLanguagesForPath:
+    def test_resolves_haxe(self):
+        configured = [Language.TYPESCRIPT, Language.HAXE, Language.PYTHON]
+        assert languages_for_path("src/Main.hx", configured) == {Language.HAXE}
+
+    def test_resolves_typescript(self):
+        configured = [Language.TYPESCRIPT, Language.HAXE, Language.PYTHON]
+        assert languages_for_path("src/main.ts", configured) == {Language.TYPESCRIPT}
+
+    def test_resolves_python(self):
+        configured = [Language.TYPESCRIPT, Language.HAXE, Language.PYTHON]
+        assert languages_for_path("src/main.py", configured) == {Language.PYTHON}
+
+    def test_unmatched_extension_returns_empty(self):
+        configured = [Language.TYPESCRIPT, Language.HAXE, Language.PYTHON]
+        assert languages_for_path("README.md", configured) == set()
+
+    def test_scoped_to_configured_languages_only(self):
+        """A .go file must not resolve to Go if Go is not configured."""
+        configured = [Language.TYPESCRIPT, Language.HAXE]
+        assert languages_for_path("main.go", configured) == set()
+
+    def test_extension_overlap_returns_all_matching(self):
+        """If two configured languages match the same extension, both are returned."""
+        # both cpp and c share the .h extension via the cpp matcher; here we use a clearer case:
+        # typescript matches .js, and so does vue. With both configured, a .js file matches both.
+        configured = [Language.TYPESCRIPT, Language.VUE]
+        assert languages_for_path("app.js", configured) == {Language.TYPESCRIPT, Language.VUE}

--- a/test/serena/test_mcp.py
+++ b/test/serena/test_mcp.py
@@ -20,6 +20,13 @@ class MockAgent:
     def get_context() -> SerenaAgentContext:
         return SerenaAgentContext.load_default()
 
+    def get_active_project(self):
+        return None
+
+    def get_tool_description_override(self, tool_name: str) -> str | None:
+        # mirror SerenaAgent.get_tool_description_override for the no-active-project case
+        return self.get_context().tool_description_overrides.get(tool_name, None)
+
 
 class BaseMockTool(Tool):
     """A mock Tool class for testing."""

--- a/test/serena/tools/test_jetbrains_per_language_scoping.py
+++ b/test/serena/tools/test_jetbrains_per_language_scoping.py
@@ -7,8 +7,6 @@ server; only the in-tool scoping/filtering logic is exercised. We disable the to
 count is > 0 and the note is emitted.
 """
 
-import pytest
-
 from serena.config.serena_config import ProjectConfig
 from serena.project import Project
 from serena.tools.jetbrains_tools import JetBrainsFindSymbolTool
@@ -101,7 +99,7 @@ def test_external_dependency_symbols_are_not_scoped(monkeypatch):
         result = tool.apply(name_path_pattern="Thing", search_deps=True)
         assert "Coverage" in result  # in-project python files were skipped
         body = result.split("\n", 1)[1]
-        assert "ExtThing" in body          # external symbol retained
-        assert "BaseModel" not in body     # in-project python symbol scoped away
+        assert "ExtThing" in body  # external symbol retained
+        assert "BaseModel" not in body  # in-project python symbol scoped away
     finally:
         tool.project.shutdown(timeout=5)

--- a/test/serena/tools/test_jetbrains_per_language_scoping.py
+++ b/test/serena/tools/test_jetbrains_per_language_scoping.py
@@ -1,0 +1,107 @@
+"""Tests for Behaviour 2 (language scoping + coverage note) of the per-language tool-disabling
+mechanism under the JetBrains backend, specifically for ``jet_brains_find_symbol``.
+
+The JetBrains plugin client is stubbed so the tests need neither a running IDE nor a language
+server; only the in-tool scoping/filtering logic is exercised. We disable the tool for *python*
+(the language that actually has files in the python test repo) so that the coverage-note file
+count is > 0 and the note is emitted.
+"""
+
+import pytest
+
+from serena.config.serena_config import ProjectConfig
+from serena.project import Project
+from serena.tools.jetbrains_tools import JetBrainsFindSymbolTool
+from solidlsp.ls_config import Language
+from test.conftest import create_default_serena_config, get_repo_path
+
+
+class _FakeAgent:
+    """Minimal agent stub exposing only what the tool + scoping helper need."""
+
+    def __init__(self, project: Project):
+        self._project = project
+        self.serena_config = project.serena_config
+
+    def get_active_project(self) -> Project | None:
+        return self._project
+
+    def get_active_project_or_raise(self) -> Project:
+        return self._project
+
+
+class _FakeClient:
+    """Stub for JetBrainsPluginClient used as a context manager."""
+
+    def __init__(self, symbols):
+        self._symbols = symbols
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def find_symbol(self, **kwargs):
+        return {"symbols": self._symbols}
+
+
+_PY_SYMBOLS = [
+    {"name_path": "BaseModel", "type": "Class", "relative_path": "test_repo/models.py"},
+    {"name_path": "Helper", "type": "Class", "relative_path": "test_repo/utils.py"},
+]
+
+
+def _make_tool(excluded, monkeypatch, symbols) -> JetBrainsFindSymbolTool:
+    project = Project(
+        project_root=str(get_repo_path(Language.PYTHON)),
+        project_config=ProjectConfig(
+            project_name="jb_scope_repo",
+            languages=[Language.PYTHON],
+            excluded_tools_by_language=excluded,
+        ),
+        serena_config=create_default_serena_config(),
+    )
+    monkeypatch.setattr(
+        "serena.tools.jetbrains_tools.JetBrainsPluginClient.from_project",
+        lambda _project: _FakeClient(symbols),
+    )
+    return JetBrainsFindSymbolTool(_FakeAgent(project))  # type: ignore[arg-type]
+
+
+def test_whole_project_search_scoped_away_with_note(monkeypatch):
+    tool = _make_tool({Language.PYTHON: ["jet_brains_find_symbol"]}, monkeypatch, _PY_SYMBOLS)
+    try:
+        result = tool.apply(name_path_pattern="BaseModel")
+        assert "Coverage" in result, f"expected coverage note, got: {result}"
+        assert "disabled for python" in result
+        # the python symbols must have been scoped away (only the note remains, not the symbol body)
+        assert "BaseModel" not in result.split("\n", 1)[1]
+    finally:
+        tool.project.shutdown(timeout=5)
+
+
+def test_no_note_when_tool_not_excluded(monkeypatch):
+    tool = _make_tool({}, monkeypatch, _PY_SYMBOLS)
+    try:
+        result = tool.apply(name_path_pattern="BaseModel")
+        assert "Coverage" not in result
+        assert "BaseModel" in result  # nothing scoped away
+    finally:
+        tool.project.shutdown(timeout=5)
+
+
+def test_external_dependency_symbols_are_not_scoped(monkeypatch):
+    symbols = [
+        {"name_path": "BaseModel", "type": "Class", "relative_path": "test_repo/models.py"},
+        {"name_path": "ExtThing", "type": "Class", "relative_path": "<ext:lib/foo.py>"},
+    ]
+    tool = _make_tool({Language.PYTHON: ["jet_brains_find_symbol"]}, monkeypatch, symbols)
+    try:
+        result = tool.apply(name_path_pattern="Thing", search_deps=True)
+        assert "Coverage" in result  # in-project python files were skipped
+        body = result.split("\n", 1)[1]
+        assert "ExtThing" in body          # external symbol retained
+        assert "BaseModel" not in body     # in-project python symbol scoped away
+    finally:
+        tool.project.shutdown(timeout=5)

--- a/test/serena/tools/test_per_language_comms.py
+++ b/test/serena/tools/test_per_language_comms.py
@@ -1,0 +1,91 @@
+"""Tests for the communication channels of the per-language tool-disabling mechanism:
+
+* Channel 2: the upfront summary injected into the project activation message
+  (``SerenaAgent._format_excluded_tools_by_language_summary``).
+* Channel 3: the per-language caveat appended to the tool description
+  (``SerenaAgent.get_tool_description_override``).
+"""
+
+import logging
+
+import pytest
+
+from serena.agent import SerenaAgent
+from serena.config.serena_config import ProjectConfig, RegisteredProject, SerenaConfig
+from serena.project import Project
+from solidlsp.ls_config import Language
+from test.conftest import get_repo_path
+
+
+class TestActivationSummary:
+    def test_none_when_empty(self):
+        config = ProjectConfig(project_name="p", languages=[Language.PYTHON])
+        assert SerenaAgent._format_excluded_tools_by_language_summary(config) is None
+
+    def test_summary_lists_languages_and_tools(self):
+        config = ProjectConfig(
+            project_name="p",
+            languages=[Language.HAXE, Language.PYTHON],
+            excluded_tools_by_language={
+                Language.HAXE: ["find_symbol", "replace_symbol_body"],
+                Language.PYTHON: ["replace_content"],
+            },
+        )
+        summary = SerenaAgent._format_excluded_tools_by_language_summary(config)
+        assert summary is not None
+        assert "haxe → find_symbol, replace_symbol_body" in summary
+        assert "python → replace_content" in summary
+        assert "search_for_pattern" in summary  # mentions the recommended fallback
+
+    def test_empty_tool_lists_yield_none(self):
+        config = ProjectConfig(
+            project_name="p",
+            languages=[Language.HAXE],
+            excluded_tools_by_language={Language.HAXE: []},
+        )
+        assert SerenaAgent._format_excluded_tools_by_language_summary(config) is None
+
+
+@pytest.mark.python
+class TestToolDescriptionCaveat:
+    def _make_agent(self, excluded: dict[Language, list[str]]) -> SerenaAgent:
+        config = SerenaConfig(gui_log_window=False, web_dashboard=False, log_level=logging.ERROR)
+        project = Project(
+            project_root=str(get_repo_path(Language.PYTHON)),
+            project_config=ProjectConfig(
+                project_name="comms_repo",
+                languages=[Language.PYTHON],
+                excluded_tools_by_language=excluded,
+            ),
+            serena_config=config,
+        )
+        config.projects = [RegisteredProject.from_project_instance(project)]
+        agent = SerenaAgent(project="comms_repo", serena_config=config)
+        agent.execute_task(lambda: None)
+        return agent
+
+    def test_caveat_added_for_excluded_tool(self):
+        agent = self._make_agent({Language.PYTHON: ["find_symbol"]})
+        try:
+            override = agent.get_tool_description_override("find_symbol")
+            assert override is not None
+            assert "disabled for python" in override
+        finally:
+            agent.on_shutdown(timeout=10)
+
+    def test_no_caveat_for_non_excluded_tool(self):
+        agent = self._make_agent({Language.PYTHON: ["find_symbol"]})
+        try:
+            # search_for_pattern is not excluded; without a context override this should be None
+            assert agent.get_tool_description_override("search_for_pattern") is None
+        finally:
+            agent.on_shutdown(timeout=10)
+
+    def test_activation_message_contains_summary(self):
+        agent = self._make_agent({Language.PYTHON: ["find_symbol"]})
+        try:
+            msg = agent.get_project_activation_message(session_id="test")
+            assert "disabled per language" in msg
+            assert "python → find_symbol" in msg
+        finally:
+            agent.on_shutdown(timeout=10)

--- a/test/serena/tools/test_per_language_scoping.py
+++ b/test/serena/tools/test_per_language_scoping.py
@@ -1,0 +1,209 @@
+"""Tests for Behaviour 2 (transparent scoping of whole-project / search calls) of the
+per-language tool-disabling mechanism, plus the supporting helpers.
+
+* ``LanguageServerManager.iter_language_servers(exclude_languages=...)`` filtering.
+* ``Project.count_source_files_for_languages`` / ``_filter_out_languages``.
+* ``_format_coverage_note`` formatting.
+* ``SearchForPatternTool`` end-to-end: excluded-language files are skipped and a coverage note is
+  emitted only when files were actually skipped.
+"""
+
+import logging
+
+import pytest
+
+from serena.config.serena_config import ProjectConfig, RegisteredProject, SerenaConfig
+from serena.ls_manager import LanguageServerManager
+from serena.project import Project, _filter_out_languages
+from serena.tools.file_tools import SearchForPatternTool
+from serena.tools.tools_base import _format_coverage_note
+from solidlsp.ls_config import Language
+from test.conftest import create_default_serena_config, get_repo_path
+
+
+class _StubLS:
+    def __init__(self, language: Language):
+        self.language = language
+
+    def is_running(self) -> bool:
+        return True
+
+
+class TestIterLanguageServersExclusion:
+    def _manager(self) -> LanguageServerManager:
+        servers = {
+            Language.PYTHON: _StubLS(Language.PYTHON),
+            Language.TYPESCRIPT: _StubLS(Language.TYPESCRIPT),
+            Language.HAXE: _StubLS(Language.HAXE),
+        }
+        return LanguageServerManager(servers)  # type: ignore[arg-type]
+
+    def test_no_exclusion_yields_all(self):
+        manager = self._manager()
+        langs = {ls.language for ls in manager.iter_language_servers()}
+        assert langs == {Language.PYTHON, Language.TYPESCRIPT, Language.HAXE}
+
+    def test_excludes_single_language(self):
+        manager = self._manager()
+        langs = {ls.language for ls in manager.iter_language_servers(exclude_languages={Language.HAXE})}
+        assert langs == {Language.PYTHON, Language.TYPESCRIPT}
+
+    def test_excludes_multiple_languages(self):
+        manager = self._manager()
+        langs = {ls.language for ls in manager.iter_language_servers(exclude_languages={Language.HAXE, Language.PYTHON})}
+        assert langs == {Language.TYPESCRIPT}
+
+
+class TestFormatCoverageNote:
+    def test_empty_returns_none(self):
+        assert _format_coverage_note({}) is None
+
+    def test_zero_counts_return_none(self):
+        assert _format_coverage_note({Language.HAXE: 0}) is None
+
+    def test_single_language(self):
+        note = _format_coverage_note({Language.HAXE: 12})
+        assert note is not None
+        assert "12 haxe" in note
+        assert "disabled for haxe" in note
+
+    def test_multiple_languages_sorted(self):
+        note = _format_coverage_note({Language.PYTHON: 3, Language.HAXE: 12})
+        assert note is not None
+        # languages reported in alphabetical order
+        assert note.index("haxe") < note.index("python")
+
+
+class TestFilterOutLanguages:
+    def test_removes_matching_extensions(self):
+        paths = ["src/Main.hx", "src/app.py", "README.md", "lib/Util.hx"]
+        assert _filter_out_languages(paths, {Language.HAXE}) == ["src/app.py", "README.md"]
+
+    def test_empty_exclusion_is_identity(self):
+        paths = ["a.py", "b.hx"]
+        assert _filter_out_languages(paths, frozenset()) == paths
+
+
+class TestCountSourceFilesForLanguages:
+    def test_counts_python_files(self):
+        project = Project(
+            project_root=str(get_repo_path(Language.PYTHON)),
+            project_config=ProjectConfig(project_name="test_repo", languages=[Language.PYTHON]),
+            serena_config=create_default_serena_config(),
+        )
+        try:
+            counts = project.count_source_files_for_languages({Language.PYTHON})
+            assert counts.get(Language.PYTHON, 0) > 0
+        finally:
+            project.shutdown(timeout=5)
+
+    def test_no_files_for_absent_language(self):
+        project = Project(
+            project_root=str(get_repo_path(Language.PYTHON)),
+            project_config=ProjectConfig(project_name="test_repo", languages=[Language.PYTHON, Language.HAXE]),
+            serena_config=create_default_serena_config(),
+        )
+        try:
+            counts = project.count_source_files_for_languages({Language.HAXE})
+            assert counts.get(Language.HAXE, 0) == 0
+        finally:
+            project.shutdown(timeout=5)
+
+
+@pytest.mark.python
+class TestSearchForPatternScoping:
+    """End-to-end test of ``search_for_pattern`` scoping through a real agent."""
+
+    def _make_agent(self, excluded: dict[Language, list[str]]):
+        from serena.agent import SerenaAgent
+
+        config = SerenaConfig(gui_log_window=False, web_dashboard=False, log_level=logging.ERROR)
+        project = Project(
+            project_root=str(get_repo_path(Language.PYTHON)),
+            project_config=ProjectConfig(
+                project_name="search_scope_repo",
+                languages=[Language.PYTHON],
+                excluded_tools_by_language=excluded,
+            ),
+            serena_config=config,
+        )
+        config.projects = [RegisteredProject.from_project_instance(project)]
+        agent = SerenaAgent(project="search_scope_repo", serena_config=config)
+        agent.execute_task(lambda: None)
+        return agent
+
+    def test_excluded_language_files_are_skipped_with_note(self):
+        agent = self._make_agent({Language.PYTHON: ["search_for_pattern"]})
+        try:
+            tool = agent.get_tool(SearchForPatternTool)
+            # search for something that certainly exists in the python sources
+            result = tool.apply(substring_pattern="class ", restrict_search_to_code_files=True)
+            assert "Coverage" in result, f"expected coverage note, got: {result}"
+            assert "disabled for python" in result
+            # no python file should appear in the (scoped-away) results
+            assert ".py" not in result.split("\n", 1)[1] if "\n" in result else True
+        finally:
+            agent.on_shutdown(timeout=10)
+
+    def test_no_note_when_tool_not_excluded(self):
+        agent = self._make_agent({})
+        try:
+            tool = agent.get_tool(SearchForPatternTool)
+            result = tool.apply(substring_pattern="class ", restrict_search_to_code_files=True)
+            assert "Coverage" not in result
+            # the python matches should be present
+            assert ".py" in result
+        finally:
+            agent.on_shutdown(timeout=10)
+
+
+@pytest.mark.python
+class TestFindSymbolScoping:
+    """End-to-end test of ``find_symbol`` whole-project scoping through a real agent."""
+
+    def _make_agent(self, excluded: dict[Language, list[str]]):
+        from serena.agent import SerenaAgent
+
+        config = SerenaConfig(gui_log_window=False, web_dashboard=False, log_level=logging.ERROR)
+        project = Project(
+            project_root=str(get_repo_path(Language.PYTHON)),
+            project_config=ProjectConfig(
+                project_name="find_symbol_scope_repo",
+                languages=[Language.PYTHON],
+                excluded_tools_by_language=excluded,
+            ),
+            serena_config=config,
+        )
+        config.projects = [RegisteredProject.from_project_instance(project)]
+        agent = SerenaAgent(project="find_symbol_scope_repo", serena_config=config)
+        agent.execute_task(lambda: None)
+        return agent
+
+    def test_whole_project_search_scoped_away_with_note(self):
+        from serena.tools.symbol_tools import FindSymbolTool
+
+        agent = self._make_agent({Language.PYTHON: ["find_symbol"]})
+        try:
+            tool = agent.get_tool(FindSymbolTool)
+            # whole-project search (no relative_path) for a symbol that exists in the python sources
+            result = tool.apply(name_path_pattern="BaseModel")
+            assert "Coverage" in result, f"expected coverage note, got: {result}"
+            assert "disabled for python" in result
+            # since python is the only language and it is excluded, no symbols are returned
+            assert "BaseModel" not in result.split("\n", 1)[1] if "\n" in result else True
+        finally:
+            agent.on_shutdown(timeout=10)
+
+    def test_pinned_file_is_refused_not_scoped(self):
+        """A find_symbol call that pins an excluded-language file is refused (Behaviour 1), not scoped."""
+        from serena.tools.symbol_tools import FindSymbolTool
+
+        agent = self._make_agent({Language.PYTHON: ["find_symbol"]})
+        try:
+            tool = agent.get_tool(FindSymbolTool)
+            rp = str(__import__("pathlib").Path("test_repo") / "models.py")
+            result = tool.apply_ex(log_call=False, name_path_pattern="BaseModel", relative_path=rp)
+            assert "disabled for python" in result
+            assert "is a python file" in result
+        finally:
+            agent.on_shutdown(timeout=10)

--- a/test/serena/tools/test_per_language_tool_disabling.py
+++ b/test/serena/tools/test_per_language_tool_disabling.py
@@ -1,0 +1,163 @@
+"""Tests for the runtime behaviour of per-language tool disabling.
+
+* Behaviour 1 (refuse): a pinned-file tool call targeting an excluded-language file is refused
+  before the tool body executes; a call targeting a non-excluded file proceeds.
+* Behaviour 3 (no-op): language-agnostic tools are never refused.
+
+The guard logic (``Tool.get_target_relative_paths`` / ``Tool._check_language_exclusion``) is exercised
+directly via a lightweight fake agent so the tests are deterministic and do not require a running
+language server. An end-to-end test through ``apply_ex`` validates the wiring.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+from serena.config.serena_config import ProjectConfig
+from serena.project import Project
+from serena.tools import Tool
+from serena.tools.memory_tools import ReadMemoryTool
+from serena.tools.symbol_tools import ReplaceSymbolBodyTool
+from solidlsp.ls_config import Language
+from test.conftest import create_default_serena_config, get_repo_path
+
+
+class _FakeAgent:
+    """Minimal agent stub exposing only what the per-language guard needs."""
+
+    def __init__(self, project: Project):
+        self._project = project
+        self.serena_config = project.serena_config
+
+    def get_active_project(self) -> Project | None:
+        return self._project
+
+    def get_active_project_or_raise(self) -> Project:
+        return self._project
+
+    def tool_is_active(self, tool_name: str) -> bool:
+        return True
+
+
+def _make_python_project(excluded: dict[Language, list[str]]) -> Project:
+    repo_path = str(get_repo_path(Language.PYTHON))
+    project_config = ProjectConfig(
+        project_name="test_repo",
+        languages=[Language.PYTHON],
+        excluded_tools_by_language=excluded,
+    )
+    return Project(
+        project_root=repo_path,
+        project_config=project_config,
+        serena_config=create_default_serena_config(),
+    )
+
+
+def _make_tool(tool_cls: type[Tool], project: Project) -> Tool:
+    return tool_cls(_FakeAgent(project))  # type: ignore[arg-type]
+
+
+class TestGetTargetRelativePaths:
+    def test_returns_pinned_existing_file(self):
+        project = _make_python_project({})
+        tool = _make_tool(ReplaceSymbolBodyTool, project)
+        rp = os.path.join("test_repo", "models.py")
+        assert tool.get_target_relative_paths({"relative_path": rp}) == [rp]
+
+    def test_returns_none_for_empty_path(self):
+        project = _make_python_project({})
+        tool = _make_tool(ReplaceSymbolBodyTool, project)
+        assert tool.get_target_relative_paths({"relative_path": ""}) is None
+        assert tool.get_target_relative_paths({}) is None
+
+    def test_returns_none_for_directory(self):
+        project = _make_python_project({})
+        tool = _make_tool(ReplaceSymbolBodyTool, project)
+        assert tool.get_target_relative_paths({"relative_path": "test_repo"}) is None
+
+    def test_returns_none_for_nonexistent_file(self):
+        project = _make_python_project({})
+        tool = _make_tool(ReplaceSymbolBodyTool, project)
+        assert tool.get_target_relative_paths({"relative_path": "does_not_exist.py"}) is None
+
+
+class TestRefuseGuard:
+    def test_refuses_pinned_excluded_language_file(self):
+        project = _make_python_project({Language.PYTHON: ["replace_symbol_body"]})
+        tool = _make_tool(ReplaceSymbolBodyTool, project)
+        rp = os.path.join("test_repo", "models.py")
+        msg = tool._check_language_exclusion({"relative_path": rp})
+        assert msg is not None
+        assert "disabled for python" in msg
+        assert rp in msg
+
+    def test_does_not_refuse_when_tool_not_excluded(self):
+        project = _make_python_project({Language.PYTHON: ["find_symbol"]})
+        tool = _make_tool(ReplaceSymbolBodyTool, project)
+        rp = os.path.join("test_repo", "models.py")
+        assert tool._check_language_exclusion({"relative_path": rp}) is None
+
+    def test_does_not_refuse_file_of_other_language(self):
+        # tool is disabled for haxe, but the pinned file is a python file -> not refused
+        project = ProjectConfig(
+            project_name="test_repo",
+            languages=[Language.PYTHON, Language.HAXE],
+            excluded_tools_by_language={Language.HAXE: ["replace_symbol_body"]},
+        )
+        proj = Project(
+            project_root=str(get_repo_path(Language.PYTHON)),
+            project_config=project,
+            serena_config=create_default_serena_config(),
+        )
+        tool = _make_tool(ReplaceSymbolBodyTool, proj)
+        rp = os.path.join("test_repo", "models.py")
+        assert tool._check_language_exclusion({"relative_path": rp}) is None
+
+    def test_no_active_project_is_noop(self):
+        project = _make_python_project({Language.PYTHON: ["replace_symbol_body"]})
+        tool = _make_tool(ReplaceSymbolBodyTool, project)
+        # simulate no active project
+        tool.agent._project = None  # type: ignore[attr-defined]
+        assert tool._check_language_exclusion({"relative_path": "test_repo/models.py"}) is None
+
+    def test_language_agnostic_tool_is_noop(self):
+        # read_memory is configured but it does not target files -> guard never fires
+        project = _make_python_project({Language.PYTHON: ["read_memory"]})
+        tool = _make_tool(ReadMemoryTool, project)
+        assert tool._check_language_exclusion({"memory_name": "anything"}) is None
+
+
+@pytest.mark.python
+class TestRefuseGuardEndToEnd:
+    """End-to-end test through ``apply_ex`` using a real agent (validates the wiring)."""
+
+    def test_apply_ex_refuses_without_executing(self):
+        from serena.agent import SerenaAgent
+        from serena.config.serena_config import RegisteredProject, SerenaConfig
+
+        config = SerenaConfig(gui_log_window=False, web_dashboard=False, log_level=logging.ERROR)
+        project = Project(
+            project_root=str(get_repo_path(Language.PYTHON)),
+            project_config=ProjectConfig(
+                project_name="excl_test_repo",
+                languages=[Language.PYTHON],
+                excluded_tools_by_language={Language.PYTHON: ["replace_symbol_body"]},
+            ),
+            serena_config=config,
+        )
+        config.projects = [RegisteredProject.from_project_instance(project)]
+        agent = SerenaAgent(project="excl_test_repo", serena_config=config)
+        try:
+            agent.execute_task(lambda: None)
+            tool = agent.get_tool(ReplaceSymbolBodyTool)
+            rp = str(Path("test_repo") / "models.py")
+            # this must be refused BEFORE the LSP-backed edit is attempted; if the edit ran,
+            # the (empty) body replacement would either error differently or mutate the file.
+            result = tool.apply_ex(log_call=False, relative_path=rp, name_path="BaseModel", body="# replaced")
+            assert "disabled for python" in result
+            # the file must be unchanged (the edit must not have executed)
+            assert "# replaced" not in project.read_file(rp)
+        finally:
+            agent.on_shutdown(timeout=10)


### PR DESCRIPTION
Hey 👋 
Here's a PR for a new config option to disable specific tools for specific languages in a project.
Please let me know what you think! Happy to address any feedback.

## Why?
Sometimes I need to use `exclude_tools` as certain language server implementations are unreliable. That particularly bothered me after using it for more Haxe code recently (after we just added support for it a few weeks back).
I have a Haxe codebase to test this with (unusually large and complex for a Haxe project), and for some tools the language server simply takes too long, so things time out (_btw, this seems to be just the Haxe LSP implementation and not something we can fix in Serena, except maybe improving how to deal with and communicate timeouts and errors, etc._).

Disabling those tools for that project completely is not ideal. It also contains a lot of Java code and our PHP backend, so I don't want to "globally" disable stuff.

## Per-level tool disabling
Therefore, here's a PR that allows you to disable specific tools only for specific languages. I hope this doesn't go against your idea of how Serena should be used. My experience is that in reality not all language server implementations are super robust and fast, so this seems like a useful addition to me. I'm excited to hear your thoughts on it. :)

Basically, there's a new config option `excluded_tools_by_language`:

```
languages: [typescript, python, haxe]

excluded_tools_by_language:
  haxe:
    - find_symbol
    - replace_symbol_body
```

The tools should also clearly communicate that information when it's used. It is exposed as a summary on project activation, mentioning all disabled language-specific tools. Additionally, it's part of the description of each tool.

And when targeting, for example, only Haxe code on a specifically disabled tool, it will return an error like:
```
Error: Tool 'find_symbol' is disabled for haxe in this project; 'src/Main.hx' is a haxe file. Inspect haxe code with text-based tools (e.g. search_for_pattern) or read_file instead.
```

Or when targeting multiple languages, it runs against the "allowed" tools and prepends a one-line note for each language that was specifically disabled:
```
⚠ Coverage: skipped 12 haxe file(s) (tool disabled for haxe).
[...]
```

`excluded_tools` should still work as before.

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.
