### PR TITLE
fix(file_system): handle PermissionError on scandir in gitignore walker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Update prompts/instructions: Serena instructions manual, modes (editing, interactive) 
   - Allow structured tool output to be configured on a per-context basis, disabling it for Claude Code
     (which does not correctly unpack structured output) #1042
+  - Fix: File system permission errors during gitignore scanning were not caught #1624 
 
 * CLI:
   - Fix `--project-from-cwd` hijacking git worktrees nested under a Serena project. `find_project_root`

--- a/src/serena/util/file_system.py
+++ b/src/serena/util/file_system.py
@@ -164,7 +164,12 @@ class GitignoreParser:
         queue: list[str] = [self.repo_root]
 
         def scan(abs_path: str | None) -> Iterator[str]:
-            for entry in os.scandir(abs_path):
+            try:
+                entries = os.scandir(abs_path)
+            except PermissionError as ex:
+                log.debug(f"Skipping unreadable directory {abs_path}: {ex}")
+                return
+            for entry in entries:
                 try:
                     if entry.is_dir(follow_symlinks=follow_symlinks):
                         queue.append(entry.path)

--- a/test/serena/util/test_file_system.py
+++ b/test/serena/util/test_file_system.py
@@ -3,7 +3,6 @@ import shutil
 import tempfile
 from pathlib import Path
 
-# Assuming the gitignore parser code is in a module named 'gitignore_parser'
 from pathspec import PathSpec
 
 from serena.util.file_system import GitignoreParser, GitignoreSpec, match_path
@@ -715,3 +714,42 @@ src/*.o
 
         # foo.txt in other/ should NOT be ignored (outside foo/ subtree)
         assert not parser.should_ignore("other/foo.txt"), "other/foo.txt should NOT be ignored by foo/.gitignore"
+
+
+class TestGitignoreParserPermissionError:
+    """Test PermissionError handling in GitignoreParser."""
+
+    def setup_method(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.repo_path = Path(self.test_dir)
+
+    def teardown_method(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_scandir_permission_error_on_subdirectory(self):
+        """
+        Test that GitignoreParser does not crash when a subdirectory
+        is not readable (PermissionError on os.scandir).
+
+        Regression test for https://github.com/oraios/serena/issues/1624
+        """
+        # Create a root .gitignore
+        gitignore = self.repo_path / ".gitignore"
+        gitignore.write_text("*.log\n")
+
+        # Create an unreadable subdirectory
+        unreadable = self.repo_path / "unreadable_dir"
+        unreadable.mkdir()
+
+        # Remove read permissions (Unix only; on Windows this is a no-op)
+        old_mode = os.stat(unreadable).st_mode
+        os.chmod(unreadable, 0o000)
+
+        try:
+            # This should not raise PermissionError
+            parser = GitignoreParser(str(self.repo_path))
+            # Parser should still function
+            assert parser.should_ignore("test.log")
+        finally:
+            # Restore permissions so teardown can clean up
+            os.chmod(unreadable, old_mode)


### PR DESCRIPTION
### Issue for this PR

Closes #1624

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### What does this PR do?

**Problem:** `serena project index` crashes with `PermissionError` when the project tree contains a subdirectory the current user can't read (e.g., a Docker-container-created dir owned by `root:root` mode `0700`), even when that path is explicitly listed in `.serena/project.yml` under `ignored_paths`.

**Root cause:** `_iter_gitignore_files()` in `file_system.py` contains an inner `scan()` function that calls `os.scandir(abs_path)` without guarding against `PermissionError` on the directory itself. While the inner loop already handles `PermissionError` on individual entries (added by #1435 for `FileNotFoundError` on broken symlinks), the `os.scandir()` call itself crashes if the entire directory is unreadable.

**Fix:** Wrap the `os.scandir()` call in a `try/except PermissionError` block. If the directory can't be read, skip it with a debug log message.

### How did you verify your code works?

- Added regression test `test_scandir_permission_error_on_subdirectory` that creates an unreadable subdirectory (`chmod 000`) and verifies `GitignoreParser` initializes without crashing and still functions correctly
- All 24 existing tests in `test_file_system.py` continue to pass
- Fix does not affect non-Linux platforms (where `os.chmod 000` is a no-op, the test still passes)

### Checklist

- [x] I have tested my changes locally
- [x] I have included no unrelated changes
