### PR TITLE
Fix: serialize memory writes to prevent corruption under concurrent access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Memories:
   - Make memory iteration follow symbolic links 
+  - Fix: serialize memory write operations (save/delete/rename) with a thread lock and an advisory
+    file lock, preventing torn or interleaved memory files when the same project is used from
+    multiple threads or Serena processes concurrently
 
 * Dependencies:
   - Add dependency `oslex`

--- a/src/serena/memories/memory_manager.py
+++ b/src/serena/memories/memory_manager.py
@@ -2,9 +2,13 @@ import logging
 import os
 import re
 import shutil
+import threading
 from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Literal
+
+from filelock import BaseFileLock, FileLock
 
 from serena.config.serena_config import (
     SerenaPaths,
@@ -48,6 +52,9 @@ class MemoryManager:
         self._read_only_memory_patterns = [re.compile(pattern) for pattern in set(read_only_memory_patterns)]
         self._ignored_memory_patterns = [re.compile(pattern) for pattern in set(ignored_memory_patterns)]
 
+        self._thread_lock = threading.Lock()
+        self._file_lock: BaseFileLock | None = None
+
     def _is_read_only_memory(self, name: str) -> bool:
         for pattern in self._read_only_memory_patterns:
             if pattern.fullmatch(name):
@@ -59,6 +66,23 @@ class MemoryManager:
             if pattern.fullmatch(name):
                 return True
         return False
+
+    @contextmanager
+    def _write_locked(self) -> Iterator[None]:
+        """Serializes memory write operations across threads and processes.
+
+        The thread lock guards against concurrent writes from within one process; the advisory
+        file lock guards against a second Serena process operating on the same data folder
+        (e.g. the same project opened in two MCP clients). The file lock is created lazily so
+        that constructing a MemoryManager has no filesystem side effects.
+        """
+        with self._thread_lock:
+            if self._file_lock is None:
+                lock_dir = self._project_memory_dir.parent if self._project_memory_dir is not None else self._global_memory_dir.parent
+                lock_dir.mkdir(parents=True, exist_ok=True)
+                self._file_lock = FileLock(str(lock_dir / ".memory_write.lock"), timeout=10)
+            with self._file_lock:
+                yield
 
     def _check_not_ignored(self, name: str) -> None:
         if self._is_ignored_memory(name):
@@ -200,8 +224,9 @@ class MemoryManager:
         self._check_not_ignored(name)
         self._check_write_access(name, is_tool_context)
         memory_file_path = self.get_memory_file_path(name)
-        with open(memory_file_path, "w", encoding=self._encoding) as f:
-            f.write(content)
+        with self._write_locked():
+            with open(memory_file_path, "w", encoding=self._encoding) as f:
+                f.write(content)
         return f"Memory {name} written."
 
     class MemoriesList:
@@ -299,9 +324,10 @@ class MemoryManager:
         self._check_not_ignored(name)
         self._check_write_access(name, is_tool_context)
         memory_file_path = self.get_memory_file_path(name)
-        if not memory_file_path.exists():
-            return f"Memory {name} not found."
-        memory_file_path.unlink()
+        with self._write_locked():
+            if not memory_file_path.exists():
+                return f"Memory {name} not found."
+            memory_file_path.unlink()
         return f"Memory {name} deleted."
 
     def move_memory(self, old_name: str, new_name: str, is_tool_context: bool) -> str:
@@ -318,13 +344,14 @@ class MemoryManager:
         old_path = self.get_memory_file_path(old_name)
         new_path = self.get_memory_file_path(new_name)
 
-        if not old_path.exists():
-            raise FileNotFoundError(f"Memory {old_name} not found.")
-        if new_path.exists():
-            raise FileExistsError(f"Memory {new_name} already exists.")
+        with self._write_locked():
+            if not old_path.exists():
+                raise FileNotFoundError(f"Memory {old_name} not found.")
+            if new_path.exists():
+                raise FileExistsError(f"Memory {new_name} already exists.")
 
-        new_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(old_path, new_path)
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(old_path, new_path)
 
         return f"Memory renamed from {old_name} to {new_name}."
 
@@ -378,14 +405,15 @@ class MemoryManager:
         self._check_not_ignored(name)
         self._check_write_access(name, is_tool_context)
         memory_file_path = self.get_memory_file_path(name)
-        if not memory_file_path.exists():
-            raise FileNotFoundError(f"Memory {name} not found.")
-        with open(memory_file_path, encoding=self._encoding) as f:
-            original_content = f.read()
-        replacer = ContentReplacer(mode=mode, allow_multiple_occurrences=allow_multiple_occurrences, regex_multiline=regex_multiline)
-        updated_content = replacer.replace(original_content, needle, repl)
-        with open(memory_file_path, "w", encoding=self._encoding) as f:
-            f.write(updated_content)
+        with self._write_locked():
+            if not memory_file_path.exists():
+                raise FileNotFoundError(f"Memory {name} not found.")
+            with open(memory_file_path, encoding=self._encoding) as f:
+                original_content = f.read()
+            replacer = ContentReplacer(mode=mode, allow_multiple_occurrences=allow_multiple_occurrences, regex_multiline=regex_multiline)
+            updated_content = replacer.replace(original_content, needle, repl)
+            with open(memory_file_path, "w", encoding=self._encoding) as f:
+                f.write(updated_content)
         return f"Memory {name} edited successfully."
 
     def validate_referential_integrity(

--- a/test/serena/test_memories_manager.py
+++ b/test/serena/test_memories_manager.py
@@ -718,3 +718,60 @@ class TestAutoPrefixBareReferences:
         # idempotent: the second run should not touch anything
         assert second.total_replacements == 0
         assert fs_manager.load_memory("docs") == "the mem:auth/login process"
+
+
+class TestConcurrentWrites:
+    """Memory writes must be serialized: concurrent writers on the same data folder
+    (multiple threads here, standing in for multiple agent sessions) must never
+    produce torn/interleaved memory files or spurious errors.
+    """
+
+    def test_parallel_saves_to_same_memory_are_atomic(self, fs_manager: MemoryManager) -> None:
+        import threading
+
+        payloads = [f"# writer {i}\n" + (f"line-{i} " * 200) for i in range(8)]
+        errors: list[Exception] = []
+
+        def writer(payload: str) -> None:
+            try:
+                for _ in range(20):
+                    fs_manager.save_memory("shared", payload, is_tool_context=False)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer, args=(p,)) for p in payloads]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        # the final content must be exactly one writer's payload, never a mix of two
+        assert fs_manager.load_memory("shared") in payloads
+
+    def test_parallel_save_and_delete_do_not_error(self, fs_manager: MemoryManager) -> None:
+        import threading
+
+        errors: list[Exception] = []
+
+        def saver() -> None:
+            try:
+                for i in range(30):
+                    fs_manager.save_memory("contended", f"content {i}", is_tool_context=False)
+            except Exception as e:
+                errors.append(e)
+
+        def deleter() -> None:
+            try:
+                for _ in range(30):
+                    fs_manager.delete_memory("contended", is_tool_context=False)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=saver), threading.Thread(target=deleter)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors


### PR DESCRIPTION
## Problem

Memory write operations (`save_memory` / `delete_memory` / `move_memory`) perform unguarded filesystem writes. When the same project is operated on concurrently — several threads in one process, or two Serena processes at once (e.g. the same project opened in two MCP clients, cf. #1235) — writes can interleave and leave torn or inconsistent memory files.

## Fix

- Serialize all memory writes behind a `threading.Lock` (in-process) plus an advisory `filelock.FileLock` (cross-process), stored next to the memory directories as `.memory_write.lock`.
- The file lock is created lazily, so constructing a `MemoryManager` has no filesystem side effects — `MemoryManager(serena_data_folder=None)` stays FS-free, as the existing unit tests rely on.
- `filelock` is already a project dependency; no new dependencies.

## Tests

- New `TestConcurrentWrites`: 8 threads × 20 writes to the same memory → the final file is exactly one writer's payload (never a mix); a parallel save/delete loop completes without errors.
- Full `test/serena/test_memories_manager.py` passes (105 passed).
- `ruff check` / `ruff format` clean; CHANGELOG entry added under *Memories*.

Related: #1235 (multi-client concurrent usage), #1251 (memory safety hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
