### PR TITLE
TypeScript/VTS: event-based indexing wait and no automatic typing acquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ Status of the `main` branch. Changes prior to the next official version change w
   - C/C++ (clangd): improve support and documentation for Unreal Engine 5 projects.
   - `typescript_vts`: Add `initialization_options` setting in `ls_specific_settings.typescript_vts`. 
     Enables Yarn PnP setups with `typescript.tsdk` pointing at the Yarn-generated SDK.
+  - TypeScript/VTS: disable automatic typing acquisition during initialization (no network
+    downloads at startup) and replace the fixed 2-second cross-file reference wait with
+    event-based `$/progress` indexing tracking (configurable `indexing_timeout`, default 30s)
   - C#: minor fixes in Omnisharp and Roslyn that prevented startup on some systems #1617
   - `SvelteLanguageServer`: Fix diagnostics requests for TypeScript/JavaScript files incorrectly being
     processed by the Svelte LS instead of the TypeScript LS.

--- a/docs/02-usage/050_configuration.md
+++ b/docs/02-usage/050_configuration.md
@@ -992,6 +992,7 @@ Supported settings:
 | `typescript_version` | `5.9.3` | Override the bundled `typescript` npm package version Serena installs when `ls_path` is not set. |
 | `typescript_language_server_version` | `5.1.3` | Override the bundled `typescript-language-server` npm package version Serena installs when `ls_path` is not set. |
 | `npm_registry` | `null` | Override the npm registry Serena uses for the managed install. |
+| `indexing_timeout` | `30.0` | Timeout in seconds for waiting on tsserver's `$/progress` project-indexing signal (both at startup and before the first cross-file reference query). If indexing does not complete within this window, Serena logs a warning and proceeds anyway. Increase it for very large projects. |
 
 TypeScript supports [additional workspace folders](additional-workspace-folders) for cross-package
 reference discovery. Configure `additional_workspace_folders` in `project.yml` to enable this feature.

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import shutil
 import threading
+import time
 from typing import Any, cast
 
 from overrides import override
@@ -73,6 +74,7 @@ class TypeScriptLanguageServer(SolidLanguageServer):
     You can pass the following entries in ls_specific_settings["typescript"]:
         - typescript_version: Version of TypeScript to install (default: "5.9.3")
         - typescript_language_server_version: Version of typescript-language-server to install (default: "5.1.3")
+        - indexing_timeout: float, timeout in seconds for project indexing (default: 30.0)
     """
 
     @classmethod
@@ -81,7 +83,7 @@ class TypeScriptLanguageServer(SolidLanguageServer):
 
     # Safety timeout for $/progress-based indexing wait. Normally the event fires
     # well within this window; the timeout is only hit if the server never sends progress.
-    INDEXING_PROGRESS_TIMEOUT = 15.0 if os.name == "nt" else 10.0
+    INDEXING_PROGRESS_TIMEOUT = 30.0
 
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
         """
@@ -231,6 +233,11 @@ class TypeScriptLanguageServer(SolidLanguageServer):
         root_uri = pathlib.Path(repository_absolute_path).as_uri()
         initialize_params = {
             "locale": "en",
+            "initializationOptions": {
+                "preferences": {
+                    "disableAutomaticTypingAcquisition": True,
+                },
+            },
             "capabilities": {
                 "textDocument": {
                     "synchronization": {"didSave": True, "dynamicRegistration": True},
@@ -393,13 +400,14 @@ class TypeScriptLanguageServer(SolidLanguageServer):
         # typescript-language-server may send $/progress for "Initializing JS/TS
         # language features…" after initialized. If no progress is sent,
         # _indexing_complete stays SET and wait() returns immediately.
+        indexing_timeout = self._custom_settings.get("indexing_timeout", self.INDEXING_PROGRESS_TIMEOUT)
         log.info("Waiting for TypeScript project indexing to complete (if async)...")
-        if self.wait_for_indexing(timeout=self.INDEXING_PROGRESS_TIMEOUT):
+        if self.wait_for_indexing(timeout=indexing_timeout):
             log.info("TypeScript project indexing complete")
         else:
             log.warning(
                 "TypeScript project indexing did not complete within %.0fs; proceeding anyway",
-                self.INDEXING_PROGRESS_TIMEOUT,
+                indexing_timeout,
             )
 
         self._activate_additional_workspaces()
@@ -456,8 +464,32 @@ class TypeScriptLanguageServer(SolidLanguageServer):
         return self._published_diagnostics_timeout
 
     @override
-    def _get_wait_time_for_cross_file_referencing(self) -> float:
-        return 2
+    def _pre_open_for_cross_file_references(self) -> None:
+        if not self._has_waited_for_cross_file_references:
+            self.expect_indexing()
+
+    #: how long to wait for tsserver to *start* reporting indexing progress after didOpen;
+    #: matches the fixed wait the base implementation previously used
+    _INDEXING_START_GRACE_S = 2.0
+
+    @override
+    def _wait_for_cross_file_references_if_needed(self) -> None:
+        if self._has_waited_for_cross_file_references:
+            return
+        # Give tsserver a short grace period to start reporting $/progress after the file
+        # was opened. If progress starts, wait until it drains (bounded by indexing_timeout);
+        # if it never starts, tsserver considers the project loaded and we proceed after the
+        # grace period — which is no worse than the previous fixed 2-second wait.
+        grace_deadline = time.monotonic() + self._INDEXING_START_GRACE_S
+        while time.monotonic() < grace_deadline and not self._indexing_complete.is_set() and not self._active_progress_tokens:
+            time.sleep(0.05)
+        if self._active_progress_tokens:
+            timeout = self._custom_settings.get("indexing_timeout", self.INDEXING_PROGRESS_TIMEOUT)
+            if self.wait_for_indexing(timeout=timeout):
+                log.info("TypeScript cross-file indexing complete")
+            else:
+                log.warning("TypeScript cross-file indexing did not complete within %.0fs; proceeding", timeout)
+        self._has_waited_for_cross_file_references = True
 
     @override
     def _get_preferred_definition(self, definitions: list[ls_types.Location]) -> ls_types.Location:

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -233,6 +233,10 @@ class TypeScriptLanguageServer(SolidLanguageServer):
         root_uri = pathlib.Path(repository_absolute_path).as_uri()
         initialize_params = {
             "locale": "en",
+            # Disable Automatic Type Acquisition (ATA): with ATA enabled, tsserver fetches
+            # @types/* packages from npm in the background during indexing, which makes startup
+            # slow, network-dependent, and nondeterministic (and can hang on offline/locked-down
+            # machines). Serena relies on the types already installed in the project instead.
             "initializationOptions": {
                 "preferences": {
                     "disableAutomaticTypingAcquisition": True,

--- a/src/solidlsp/language_servers/vts_language_server.py
+++ b/src/solidlsp/language_servers/vts_language_server.py
@@ -151,6 +151,11 @@ class VtsLanguageServer(SolidLanguageServer):
         root_uri = pathlib.Path(repository_absolute_path).as_uri()
         initialize_params: dict = {
             "locale": "en",
+            "initializationOptions": {
+                "preferences": {
+                    "disableAutomaticTypingAcquisition": True,
+                },
+            },
             "capabilities": {
                 "textDocument": {
                     "synchronization": {"didSave": True, "dynamicRegistration": True},

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -1457,6 +1457,9 @@ class SolidLanguageServer(ABC):
             self._ensure_server_started()
 
             t0 = perf_counter() if _debug_enabled else None
+            # arm indexing tracking before didOpen so that the subsequent wait can
+            # observe the indexing progress triggered by opening the file
+            self.language_server._pre_open_for_cross_file_references()
             with self.language_server.open_file(self.relative_file_path):
                 self.language_server._wait_for_cross_file_references_if_needed()
                 try:
@@ -1607,6 +1610,14 @@ class SolidLanguageServer(ABC):
                 },
             },
         )
+
+    def _pre_open_for_cross_file_references(self) -> None:
+        """Called just before open_file() for requests that may need cross-file indexing.
+
+        Override to pre-arm async indexing tracking before sending didOpen (e.g. clear
+        a threading.Event so a subsequent wait for indexing blocks correctly).
+        The base implementation is a no-op.
+        """
 
     def _wait_for_cross_file_references_if_needed(self) -> None:
         if not self._has_waited_for_cross_file_references:


### PR DESCRIPTION
## Problem

1. Before answering cross-file reference requests, the TypeScript language server integration waits a **fixed 2 seconds** (`_get_wait_time_for_cross_file_referencing`). On large projects 2 seconds is often not enough — `find_referencing_symbols` returns incomplete results; on small projects the fixed sleep just wastes time on the first request.
2. During initialization, tsserver's automatic typing acquisition may **download type packages from the network**, slowing startup and introducing a network dependency where none is expected.

## Fix

- Replace the fixed sleep with event-based indexing tracking via the `$/progress` machinery that the codebase already uses (`expect_indexing` / `wait_for_indexing`): before the first cross-file reference request, wait until active indexing progress tokens drain, with a configurable `indexing_timeout` (`ls_specific_settings`, default 30s) as a backstop. This extends the existing progress-tracking mechanism along existing lines rather than introducing new machinery.
- Set `disableAutomaticTypingAcquisition: true` in `initializationOptions` for both TypeScript and VTS servers.

## Tests

- `test/solidlsp/typescript` passes (10 passed).
- `ruff check` clean; CHANGELOG entry added under *Language Servers*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
