### PR TITLE
fix(solidlsp): cap LSP message and header size to prevent unbounded memory growth

### DIFF
--- a/src/solidlsp/ls_process.py
+++ b/src/solidlsp/ls_process.py
@@ -52,6 +52,46 @@ class LanguageServerTerminatedException(Exception):
         return f"LanguageServerTerminatedException: {self.message}" + (f"; Cause: {self.cause}" if self.cause else "")
 
 
+def _positive_int_from_env(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back to ``default`` on absence or
+    an invalid/non-positive value (so a misconfigured override can never break startup).
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        log.warning("Ignoring invalid %s=%r (not an integer); using default %d", name, raw, default)
+        return default
+    if value <= 0:
+        log.warning("Ignoring non-positive %s=%d; using default %d", name, value, default)
+        return default
+    return value
+
+
+# Upper bounds on inbound LSP wire data. A misbehaving language server (one that dies
+# mid-frame, or emits a corrupt / oversized / negative "Content-Length") can otherwise drive
+# an unbounded read allocation until the host runs out of memory. A message that exceeds the
+# limit (or declares a negative length) is treated as a fatal protocol error: the reader
+# stops and the language server is torn down (and later restarted) instead of the whole
+# process being OOM-killed. The message limit defaults to 512 MiB and can be raised via
+# SOLIDLSP_MAX_LSP_MESSAGE_SIZE for the rare server that legitimately needs larger frames.
+MAX_LSP_MESSAGE_SIZE = _positive_int_from_env("SOLIDLSP_MAX_LSP_MESSAGE_SIZE", 512 * 1024 * 1024)
+MAX_LSP_HEADER_LINE = 64 * 1024  # 64 KiB; real LSP headers are tiny, so this is pure headroom
+
+
+def _check_message_size(num_bytes: int, language: Language) -> None:
+    """Guard against unbounded/invalid allocation from a malformed LSP frame."""
+    if num_bytes < 0 or num_bytes > MAX_LSP_MESSAGE_SIZE:
+        raise LanguageServerTerminatedException(
+            f"Language server declared an invalid LSP message length ({num_bytes} bytes); "
+            f"expected 0..{MAX_LSP_MESSAGE_SIZE}. Aborting the read loop to avoid unbounded or "
+            f"invalid memory allocation",
+            language=language,
+        )
+
+
 class Request(ToStringMixin):
     @dataclass
     class Result:
@@ -555,7 +595,7 @@ class StdioLanguageServer(LanguageServerInterface):
             while self.process and self.process.stdout:
                 if self.process.poll() is not None:  # process has terminated
                     break
-                line = self.process.stdout.readline()
+                line = self.process.stdout.readline(MAX_LSP_HEADER_LINE)
                 if not line:
                     continue
                 try:
@@ -564,8 +604,9 @@ class StdioLanguageServer(LanguageServerInterface):
                     continue
                 if num_bytes is None:
                     continue
+                _check_message_size(num_bytes, self.language)
                 while line and line.strip():
-                    line = self.process.stdout.readline()
+                    line = self.process.stdout.readline(MAX_LSP_HEADER_LINE)
                 if not line:
                     continue
                 body = self._read_bytes_from_process(self.process, self.process.stdout, num_bytes)
@@ -742,7 +783,7 @@ class TCPLanguageServer(LanguageServerInterface):
                 if f is None:
                     break
                 try:
-                    line = f.readline()
+                    line = f.readline(MAX_LSP_HEADER_LINE)
                 except OSError as exc:
                     if not self._is_stopping:
                         exception = LanguageServerTerminatedException("TCP read error", self.language, cause=exc)
@@ -755,9 +796,10 @@ class TCPLanguageServer(LanguageServerInterface):
                     continue
                 if num_bytes is None:
                     continue
+                _check_message_size(num_bytes, self.language)
                 while line and line.strip():
                     try:
-                        line = f.readline()
+                        line = f.readline(MAX_LSP_HEADER_LINE)
                     except OSError:
                         line = b""
                         break
@@ -772,6 +814,8 @@ class TCPLanguageServer(LanguageServerInterface):
                 if len(body) < num_bytes:
                     break
                 self._handle_body(body)
+        except LanguageServerTerminatedException as exc:
+            exception = exc
         except Exception as exc:
             exception = LanguageServerTerminatedException("Unexpected error in TCP language server read loop", self.language, cause=exc)
         log.info("TCP language server read loop has terminated")

--- a/test/solidlsp/test_ls_process_message_size.py
+++ b/test/solidlsp/test_ls_process_message_size.py
@@ -1,0 +1,77 @@
+"""Unit tests for the LSP wire-size guards in ``solidlsp.ls_process``.
+
+Regression coverage for the unbounded-allocation memory leak (see issue #944): a language
+server that declares an oversized ``Content-Length`` must not drive an unbounded read.
+Instead the read loop aborts with a ``LanguageServerTerminatedException`` so the server is
+torn down and restarted rather than exhausting host memory.
+"""
+
+import io
+from unittest.mock import MagicMock
+
+import pytest
+
+from solidlsp.ls_config import Language
+from solidlsp.ls_process import (
+    MAX_LSP_MESSAGE_SIZE,
+    LanguageServerTerminatedException,
+    StdioLanguageServer,
+    _check_message_size,
+)
+
+
+def test_check_message_size_allows_normal_and_boundary() -> None:
+    # Values within the limit, and exactly at the limit, are accepted (no exception).
+    _check_message_size(0, Language.PYTHON)
+    _check_message_size(1024, Language.PYTHON)
+    _check_message_size(MAX_LSP_MESSAGE_SIZE, Language.PYTHON)
+
+
+def test_check_message_size_rejects_oversized() -> None:
+    with pytest.raises(LanguageServerTerminatedException) as excinfo:
+        _check_message_size(MAX_LSP_MESSAGE_SIZE + 1, Language.PYTHON)
+    assert excinfo.value.language == Language.PYTHON
+    assert str(MAX_LSP_MESSAGE_SIZE + 1) in str(excinfo.value)
+
+
+def test_check_message_size_rejects_negative() -> None:
+    # A negative Content-Length is malformed and must be rejected, not silently accepted.
+    with pytest.raises(LanguageServerTerminatedException):
+        _check_message_size(-1, Language.PYTHON)
+
+
+class _FakeProcess:
+    """Minimal stand-in for ``subprocess.Popen`` exposing only what the reader touches."""
+
+    def __init__(self, stdout: io.BytesIO) -> None:
+        self.stdout = stdout
+
+    def poll(self) -> None:
+        # Report the process as still running so the loop reads the frame rather than
+        # breaking out early on termination.
+        return None
+
+
+def test_read_loop_aborts_on_oversized_frame_without_allocating() -> None:
+    """The real stdout read loop must abort on an oversized declared frame.
+
+    Regression for the memory-exhaustion bug: a header declaring a body far larger than
+    the limit must terminate the reader (via ``_cancel_pending_requests``) *before* the
+    body read, rather than attempting the allocation.
+    """
+    oversized = MAX_LSP_MESSAGE_SIZE + 1
+    stdout = io.BytesIO(f"Content-Length: {oversized}\r\n\r\n".encode())
+
+    ls = object.__new__(StdioLanguageServer)  # bypass the heavy real __init__
+    ls.process = _FakeProcess(stdout)
+    ls.language = Language.PYTHON
+    ls._is_stopping = False
+    ls._cancel_pending_requests = MagicMock()
+
+    # Must return promptly (no hang, no multi-GB allocation).
+    ls._read_ls_process_stdout()
+
+    ls._cancel_pending_requests.assert_called_once()
+    (raised,) = ls._cancel_pending_requests.call_args.args
+    assert isinstance(raised, LanguageServerTerminatedException)
+    assert str(oversized) in str(raised)


### PR DESCRIPTION
## Problem

`solidlsp` frames LSP messages by reading a `Content-Length` header and then allocating **exactly that many bytes, with no upper bound**, and reads the header line with an unbounded `readline()`. A language server that dies mid-frame or emits a corrupt / oversized / negative `Content-Length` can drive an unbounded allocation until the host runs out of memory. In practice the reader catches the resulting error and the supervisor restarts the language server, which re-triggers it, so the `python` process climbs to the RAM ceiling and parks there. This matches the behavior in #944 (process reaching ~30 GB even in single-instance mode).

## Root cause

In `ls_process.py`, both `StdioLanguageServer._read_ls_process_stdout` (via `_read_bytes_from_process`) and `TCPLanguageServer._read_loop` do:

- `line = stream.readline()` with no maximum length (an unbounded header line), and
- read exactly `num_bytes = content_length(line)` bytes with no sanity cap on `num_bytes`.

`content_length()` parses the value with a bare `int()`, so any size the server declares is trusted.

## Fix

- Add `MAX_LSP_MESSAGE_SIZE` (default **512 MiB**, overridable via `SOLIDLSP_MAX_LSP_MESSAGE_SIZE`; a misconfigured value falls back to the default with a warning) and `MAX_LSP_HEADER_LINE` (64 KiB).
- Validate the declared message size immediately after parsing `Content-Length`. A length that is **negative or exceeds the limit** raises `LanguageServerTerminatedException`, so the reader aborts and the language server is torn down / restarted instead of the process being OOM-killed.
- Pass `MAX_LSP_HEADER_LINE` to every header `readline()` so a malformed newline-less header can't balloon memory either.
- Applied symmetrically to the stdio and TCP read paths.

Failing fast on a pathological frame is strictly better than exhausting host RAM: a clean language-server restart vs. a machine-wide OOM. With the default limit no legitimate message is rejected; the env override exists for the rare server that genuinely needs larger frames.

## Tests

`test/solidlsp/test_ls_process_message_size.py`:

- unit coverage of the size guard (accepts values up to and including the limit; rejects oversized and negative lengths), and
- an integration test that drives the real `_read_ls_process_stdout` loop with an oversized frame and asserts it aborts (via `_cancel_pending_requests`) **before** attempting the body read.

`ruff check` / `ruff format` clean.

## Scope

Intentionally focused on the unbounded-allocation issue. A separate, lesser concern in the same loop (a server that floods endless header lines could spin the header-drain loop) is a *hang* rather than an OOM and is left out to keep this change reviewable; happy to follow up separately if useful.

Addresses #944.
