### PR TITLE
Add optional persisted log trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - During project creation, language composition percentages are now computed relative to the total number 
     of recognised source files instead of all files, i.e. unrecognised files are ignored in the percentage 
     computation.
+  - Add optional persisted log trimming by retention days and maximum number of log files.
 
 * CLI:
   - Fix `--project-from-cwd` hijacking git worktrees nested under a Serena project. `find_project_root`

--- a/docs/02-usage/065_logs.md
+++ b/docs/02-usage/065_logs.md
@@ -12,3 +12,7 @@ Additionally, logs are persisted in the Serena home directory, which, by default
 
 You can adjust the log level via the [global configuration](global-config).
 You additionally have the option of enabling full tracing of language server communication (mostly for development purposes).
+
+Persisted logs can be trimmed automatically on startup by setting `persisted_log_retention_days` in the global configuration.
+Persisted logs can also be limited by count by setting `persisted_log_max_files`.
+Both defaults are `null`, which disables persisted log trimming.

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -9,7 +9,7 @@ import shutil
 from collections.abc import Iterator, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
@@ -131,6 +131,61 @@ class SerenaPaths:
         os.makedirs(log_dir, exist_ok=True)
         self.last_returned_log_file_path = os.path.join(log_dir, prefix + "_" + datetime_tag() + f"_{os.getpid()}" + ".txt")
         return self.last_returned_log_file_path
+
+    def trim_logs(self, retention_days: int | None, max_log_files: int | None = None) -> None:
+        """
+        Remove persisted logs according to the configured retention limits.
+
+        :param retention_days: number of days of persisted logs to retain; None disables trimming.
+        :param max_log_files: maximum number of persisted log files to retain; None disables trimming by count.
+        """
+        if retention_days is None and max_log_files is None:
+            return
+        if retention_days is not None:
+            if isinstance(retention_days, bool) or not isinstance(retention_days, int):
+                raise ValueError(f"persisted_log_retention_days must be an integer or null, got: {retention_days!r}")
+            if retention_days < 0:
+                raise ValueError(f"persisted_log_retention_days cannot be negative, got: {retention_days}")
+        if max_log_files is not None:
+            if isinstance(max_log_files, bool) or not isinstance(max_log_files, int):
+                raise ValueError(f"persisted_log_max_files must be an integer or null, got: {max_log_files!r}")
+            if max_log_files < 0:
+                raise ValueError(f"persisted_log_max_files cannot be negative, got: {max_log_files}")
+
+        logs_dir = Path(self.serena_user_home_dir) / "logs"
+        if not logs_dir.exists():
+            return
+
+        if retention_days is not None:
+            cutoff_date = datetime.now().date() - timedelta(days=retention_days)
+            for entry in logs_dir.iterdir():
+                if not entry.is_dir():
+                    continue
+                try:
+                    log_date = date.fromisoformat(entry.name)
+                except ValueError:
+                    continue
+                if log_date < cutoff_date:
+                    shutil.rmtree(entry)
+
+        if max_log_files is not None:
+            active_log_file = Path(self.last_returned_log_file_path).resolve() if self.last_returned_log_file_path is not None else None
+            log_files = [entry for entry in logs_dir.glob("*/*") if entry.is_file()]
+            if active_log_file is not None:
+                log_files = [entry for entry in log_files if entry.resolve() != active_log_file]
+            log_files.sort(key=lambda path: (path.stat().st_mtime, str(path)), reverse=True)
+            for log_file in log_files[max_log_files:]:
+                log_file.unlink()
+
+        for entry in logs_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            try:
+                date.fromisoformat(entry.name)
+            except ValueError:
+                continue
+            if not any(entry.iterdir()):
+                entry.rmdir()
 
     def get_resource_path(self, *path_elems: str) -> Path:
         return Path(os.path.join(self.resources_dir, *path_elems))
@@ -767,6 +822,8 @@ class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
     projects: list[RegisteredProject] = field(default_factory=list)
     gui_log_window: bool = False
     log_level: int = logging.INFO
+    persisted_log_retention_days: int | None = None
+    persisted_log_max_files: int | None = None
     trace_lsp_communication: bool = False
     web_dashboard: bool = True
     web_dashboard_open_on_launch: bool = True
@@ -1020,6 +1077,8 @@ class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
         if num_migrations > 0:
             log.info("Legacy configuration was migrated; re-saving configuration file")
             instance._save()
+
+        SerenaPaths().trim_logs(instance.persisted_log_retention_days, instance.persisted_log_max_files)
 
         return instance
 

--- a/src/serena/resources/serena_config.template.yml
+++ b/src/serena/resources/serena_config.template.yml
@@ -90,6 +90,14 @@ jetbrains_launch_command:
 # the minimum log level for the GUI log window and the dashboard (10 = debug, 20 = info, 30 = warning, 40 = error)
 log_level: 20
 
+# number of days to keep persisted logs under the Serena home directory.
+# Set to null to disable persisted log trimming.
+persisted_log_retention_days: null
+
+# maximum number of persisted log files to keep under the Serena home directory.
+# Set to null to disable persisted log trimming by file count.
+persisted_log_max_files: null
+
 # whether to trace the communication between Serena and the language servers.
 # This is useful for debugging language server issues.
 trace_lsp_communication: False

--- a/src/solidlsp/language_servers/hlsl_language_server.py
+++ b/src/solidlsp/language_servers/hlsl_language_server.py
@@ -81,7 +81,7 @@ class HlslLanguageServer(SolidLanguageServer):
             base_url = f"{_GITHUB_RELEASE_BASE}/{tag}"
 
             # macOS has no pre-built binaries; build from source via cargo install
-            cargo_install_cmd = ["cargo", "install", "shader_language_server", "--version", version, "--root", "."]
+            cargo_install_cmd = ["cargo", "install", "--locked", "shader_language_server", "--version", version, "--root", "."]
 
             deps = RuntimeDependencyCollection(
                 [

--- a/test/serena/config/test_serena_config.py
+++ b/test/serena/config/test_serena_config.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shutil
 import tempfile
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ from serena.config.serena_config import (
     RegisteredProject,
     SerenaConfig,
     SerenaConfigError,
+    SerenaPaths,
 )
 from serena.constants import PROJECT_TEMPLATE_FILE, SERENA_MANAGED_DIR_NAME
 from serena.project import MemoryManager, Project
@@ -199,6 +201,100 @@ class TestProjectConfigLanguageBackend:
         data.pop("language_backend", None)
         config = ProjectConfig._from_dict(data, local_override_keys=[])
         assert config.language_backend is None
+
+
+class TestSerenaPathsLogTrimming:
+    def test_trim_logs_disabled_leaves_logs_untouched(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        paths = SerenaPaths()
+        monkeypatch.setattr(paths, "serena_user_home_dir", str(tmp_path))
+        old_log_dir = tmp_path / "logs" / "2000-01-01"
+        old_log_dir.mkdir(parents=True)
+        (old_log_dir / "mcp_old.txt").write_text("old log")
+
+        paths.trim_logs(None)
+
+        assert old_log_dir.exists()
+
+    def test_trim_logs_removes_date_directories_older_than_retention(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        paths = SerenaPaths()
+        monkeypatch.setattr(paths, "serena_user_home_dir", str(tmp_path))
+        today = datetime.now().date()
+        old_log_dir = tmp_path / "logs" / (today - timedelta(days=10)).isoformat()
+        kept_log_dir = tmp_path / "logs" / (today - timedelta(days=2)).isoformat()
+        unrelated_dir = tmp_path / "logs" / "not-a-date"
+        for log_dir in [old_log_dir, kept_log_dir, unrelated_dir]:
+            log_dir.mkdir(parents=True)
+            (log_dir / "mcp.txt").write_text("log")
+
+        paths.trim_logs(7)
+
+        assert not old_log_dir.exists()
+        assert kept_log_dir.exists()
+        assert unrelated_dir.exists()
+
+    def test_trim_logs_keeps_newest_log_files_by_count(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        paths = SerenaPaths()
+        monkeypatch.setattr(paths, "serena_user_home_dir", str(tmp_path))
+        log_dir = tmp_path / "logs" / "2026-01-01"
+        log_dir.mkdir(parents=True)
+        log_files = []
+        for i in range(5):
+            log_file = log_dir / f"mcp_{i}.txt"
+            log_file.write_text("log")
+            os.utime(log_file, (i, i))
+            log_files.append(log_file)
+
+        paths.trim_logs(None, max_log_files=3)
+
+        assert [log_file.exists() for log_file in log_files] == [False, False, True, True, True]
+
+    def test_trim_logs_removes_empty_date_directories_after_count_trimming(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        paths = SerenaPaths()
+        monkeypatch.setattr(paths, "serena_user_home_dir", str(tmp_path))
+        old_log_dir = tmp_path / "logs" / "2026-01-01"
+        kept_log_dir = tmp_path / "logs" / "2026-01-02"
+        old_log_dir.mkdir(parents=True)
+        kept_log_dir.mkdir(parents=True)
+        old_log_file = old_log_dir / "mcp_old.txt"
+        kept_log_file = kept_log_dir / "mcp_new.txt"
+        old_log_file.write_text("old")
+        kept_log_file.write_text("new")
+        os.utime(old_log_file, (1, 1))
+        os.utime(kept_log_file, (2, 2))
+
+        paths.trim_logs(None, max_log_files=1)
+
+        assert not old_log_dir.exists()
+        assert kept_log_dir.exists()
+        assert kept_log_file.exists()
+
+    def test_trim_logs_keeps_current_log_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        paths = SerenaPaths()
+        monkeypatch.setattr(paths, "serena_user_home_dir", str(tmp_path))
+        log_dir = tmp_path / "logs" / "2026-01-01"
+        log_dir.mkdir(parents=True)
+        old_log_file = log_dir / "mcp_old.txt"
+        current_log_file = log_dir / "mcp_current.txt"
+        old_log_file.write_text("old")
+        current_log_file.write_text("current")
+        os.utime(old_log_file, (1, 1))
+        os.utime(current_log_file, (2, 2))
+        monkeypatch.setattr(paths, "last_returned_log_file_path", str(current_log_file))
+
+        paths.trim_logs(None, max_log_files=0)
+
+        assert not old_log_file.exists()
+        assert current_log_file.exists()
+
+    @pytest.mark.parametrize("retention_days", [-1, 1.5, True])
+    def test_trim_logs_rejects_invalid_retention_days(self, retention_days):
+        with pytest.raises(ValueError, match="persisted_log_retention_days"):
+            SerenaPaths().trim_logs(retention_days)
+
+    @pytest.mark.parametrize("max_log_files", [-1, 1.5, True])
+    def test_trim_logs_rejects_invalid_max_log_files(self, max_log_files):
+        with pytest.raises(ValueError, match="persisted_log_max_files"):
+            SerenaPaths().trim_logs(None, max_log_files=max_log_files)
 
 
 def _make_config_with_project(
@@ -504,6 +600,36 @@ class TestSerenaConfigFromConfigFileRobustness:
         config = SerenaConfig.from_config_file(generate_if_missing=False)
 
         assert config.projects == []
+
+    def test_persisted_log_retention_is_applied_on_load(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        self.master_config_path.write_text("projects:\npersisted_log_retention_days: 7\npersisted_log_max_files: 1\n")
+        paths = SerenaPaths()
+        monkeypatch.setattr(paths, "serena_user_home_dir", str(tmp_path))
+        old_log_dir = tmp_path / "logs" / (datetime.now().date() - timedelta(days=10)).isoformat()
+        kept_log_dir = tmp_path / "logs" / datetime.now().date().isoformat()
+        old_log_dir.mkdir(parents=True)
+        kept_log_dir.mkdir(parents=True)
+        (old_log_dir / "mcp.txt").write_text("old log")
+        older_kept_log = kept_log_dir / "mcp_older.txt"
+        newest_kept_log = kept_log_dir / "mcp_newer.txt"
+        older_kept_log.write_text("older log")
+        newest_kept_log.write_text("newer log")
+        os.utime(older_kept_log, (1, 1))
+        os.utime(newest_kept_log, (2, 2))
+
+        monkeypatch.setattr(
+            SerenaConfig,
+            "_determine_config_file_path",
+            classmethod(lambda cls: str(self.master_config_path)),
+        )
+
+        config = SerenaConfig.from_config_file(generate_if_missing=False)
+
+        assert config.persisted_log_retention_days == 7
+        assert config.persisted_log_max_files == 1
+        assert not old_log_dir.exists()
+        assert not older_kept_log.exists()
+        assert newest_kept_log.exists()
 
     def test_malformed_project_is_skipped_with_warning(self, caplog, monkeypatch):
         """A malformed project.yml must not abort loading of the others."""


### PR DESCRIPTION
## Summary

Adds optional cleanup for persisted Serena logs under the Serena home directory.

New global config options:

- `persisted_log_retention_days`: delete dated persisted log folders older than the configured number of days
- `persisted_log_max_files`: keep only the newest persisted log files

Both default to `null`, preserving current behavior.

The trimming logic is centralized in `SerenaPaths`, where persisted log paths are already owned. Startup config loading invokes trimming after configuration is read. Count-based trimming excludes the currently active log file so startup cannot delete or unlink the log file that Serena is already writing to.

Also makes the macOS `shader_language_server` cargo install use `--locked`. The first CI run failed in `other-langs (macos-latest)` because `cargo install shader_language_server --version 1.3.1` was resolving dependencies without the crate's published lockfile after a newer `shader-sense` release. Using `--locked` keeps that install reproducible.

## Testing

- `uv run python -m pytest test\serena\config\test_serena_config.py -q`
- `uv run poe lint`
- `uv run poe type-check`
- Manual docs build equivalent to `poe doc-build` on Windows
- `uv run --with codespell codespell CHANGELOG.md docs\02-usage\065_logs.md src\serena\config\serena_config.py src\serena\resources\serena_config.template.yml test\serena\config\test_serena_config.py`
- `git diff --check`
- `uv run ruff format --check src\solidlsp\language_servers\hlsl_language_server.py src\serena\config\serena_config.py test\serena\config\test_serena_config.py`
- `uv run ruff check src\solidlsp\language_servers\hlsl_language_server.py src\serena\config\serena_config.py test\serena\config\test_serena_config.py`