### PR TITLE
HLSL: build shader_language_server with cargo --locked to fix macOS CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Language Servers:
   - C/C++ (clangd): improve support and documentation for Unreal Engine 5 projects.
+  - HLSL (`shader-language-server`): pass `--locked` to `cargo install` when building from source
+    on macOS (and in the manual-install instructions), honoring the crate's packaged `Cargo.lock`.
+    Without it, fresh dependency resolution pulled in shader-sense 1.4.0, which no longer compiles
+    against the pinned shader_language_server 1.3.1, breaking the macOS CI job.
   - `typescript_vts`: Add `initialization_options` setting in `ls_specific_settings.typescript_vts`. 
     Enables Yarn PnP setups with `typescript.tsdk` pointing at the Yarn-generated SDK.
   - TypeScript/VTS: disable automatic typing acquisition during initialization (no network

--- a/src/solidlsp/language_servers/hlsl_language_server.py
+++ b/src/solidlsp/language_servers/hlsl_language_server.py
@@ -81,7 +81,7 @@ class HlslLanguageServer(SolidLanguageServer):
             base_url = f"{_GITHUB_RELEASE_BASE}/{tag}"
 
             # macOS has no pre-built binaries; build from source via cargo install
-            cargo_install_cmd = ["cargo", "install", "shader_language_server", "--version", version, "--root", "."]
+            cargo_install_cmd = ["cargo", "install", "shader_language_server", "--version", version, "--locked", "--root", "."]
 
             deps = RuntimeDependencyCollection(
                 [
@@ -141,7 +141,7 @@ class HlslLanguageServer(SolidLanguageServer):
                 raise FileNotFoundError(
                     "shader-language-server is not installed and no auto-install is available for your platform.\n"
                     "Please install it using one of the following methods:\n"
-                    "  cargo:   cargo install shader_language_server\n"
+                    "  cargo:   cargo install shader_language_server --locked\n"
                     "  GitHub:  Download from https://github.com/antaalt/shader-sense/releases\n"
                     "On macOS, install the Rust toolchain (https://rustup.rs) and Serena will build from source automatically.\n"
                     "See https://github.com/antaalt/shader-sense for more details."


### PR DESCRIPTION
Without --locked, cargo install freshly resolves shader-sense ^1.3.1, which since 2026-07-04 picks shader-sense 1.4.0. That release removed the public field GlslCompilationParams.preamble (split into preamble_path/preamble_content), which shader_language_server 1.3.1's server_config.rs still constructs, so the from-source build fails with E0560 and cargo exits 101. macOS is the only platform that builds the server from source (Linux/Windows download prebuilt release binaries), so only the macOS CI jobs fail: all 15 test/solidlsp/hlsl fixtures error at setup (run 28726267725, job 85184119276).

--locked makes cargo honor the Cargo.lock packaged with the published crate, which pins shader-sense 1.3.1 - the dependency set the 1.3.1 release was built and tested from - and immunizes the build against future lockstep releases of the two crates. Verified locally: the unlocked build reproduces the exact E0560/exit-101 failure; the locked build compiles cleanly and yields a working binary reporting v1.3.1.

Also adds --locked to the manual-install help text, matching the existing convention in taplo_server.py.

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.
