### PR TITLE
Svelte test fixture: remove unused demo dependencies

### DIFF
--- a/test/resources/repos/svelte/test_repo/package-lock.json
+++ b/test/resources/repos/svelte/test_repo/package-lock.json
@@ -8,16 +8,12 @@
 			"name": "test-repo",
 			"version": "0.0.1",
 			"devDependencies": {
-				"@fontsource/fira-mono": "^5.2.7",
-				"@neoconfetti/svelte": "^2.2.2",
 				"@sveltejs/adapter-auto": "^7.0.1",
 				"@sveltejs/kit": "^2.57.0",
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
-				"@tailwindcss/vite": "^4.2.2",
 				"@types/node": "^25.6.1",
 				"svelte": "^5.55.2",
 				"svelte-check": "^4.4.6",
-				"tailwindcss": "^4.2.2",
 				"typescript": "^6.0.2",
 				"vite": "^8.0.7"
 			}
@@ -54,16 +50,6 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@fontsource/fira-mono": {
-			"version": "5.2.7",
-			"resolved": "https://registry.npmjs.org/@fontsource/fira-mono/-/fira-mono-5.2.7.tgz",
-			"integrity": "sha512-wYrAn6i3nH6luqQBZxtWUpl4UTUvs9AEbEeZxksPMwIqyjRRaxHTNW3c2VfM50gabS2IS7pT8lVWS2USB4ukYA==",
-			"dev": true,
-			"license": "OFL-1.1",
-			"funding": {
-				"url": "https://github.com/sponsors/ayuhito"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -135,20 +121,10 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
-		"node_modules/@neoconfetti/svelte": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@neoconfetti/svelte/-/svelte-2.2.2.tgz",
-			"integrity": "sha512-E7xCFVEEm5Ctnj2udTJy1b9oaTvjz1zi1mYdEtE8rB5BVwq6kHisosDS+zdWN5PMfEMjtbsOV9Cl6tsNSAD1sA==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"svelte": "^3.0.0 || ^4.0.0 || ^5.0.0"
-			}
-		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.138.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-			"integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+			"integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -163,9 +139,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-			"integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+			"integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -180,9 +156,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-			"integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+			"integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
 			"cpu": [
 				"arm64"
 			],
@@ -197,9 +173,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-			"integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+			"integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
 			"cpu": [
 				"x64"
 			],
@@ -214,9 +190,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-			"integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+			"integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
 			"cpu": [
 				"x64"
 			],
@@ -231,9 +207,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-			"integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+			"integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
 			"cpu": [
 				"arm"
 			],
@@ -248,16 +224,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-			"integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+			"integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -268,16 +241,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-			"integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+			"integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -288,16 +258,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-			"integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+			"integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -308,16 +275,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-			"integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+			"integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -328,16 +292,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-			"integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+			"integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -348,16 +309,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-			"integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+			"integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -368,9 +326,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-			"integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+			"integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
 			"cpu": [
 				"arm64"
 			],
@@ -385,9 +343,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-			"integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+			"integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
 			"cpu": [
 				"wasm32"
 			],
@@ -404,9 +362,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-			"integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+			"integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
 			"cpu": [
 				"arm64"
 			],
@@ -421,9 +379,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-			"integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+			"integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
 			"cpu": [
 				"x64"
 			],
@@ -452,9 +410,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
-			"integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+			"integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -472,9 +430,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.69.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.1.tgz",
-			"integrity": "sha512-+nz8Fx/cElzb2ZPHC+6Ll3y3NEVIe4Na75PeplLlyTmd1dBXAjz2KR14y1ZgNjb2ThfAYzulu+PFy1UE3RCUzA==",
+			"version": "2.69.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.3.tgz",
+			"integrity": "sha512-cphwqMRcE19/9VkrIPr5qZhQ0SptSSDfDzRUpYHu9OJDFGuYBFyJzK+KQA27wB4YG32O/yF2QjBkDmTyo0vtCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -524,9 +482,9 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.2.tgz",
-			"integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.2.0.tgz",
+			"integrity": "sha512-1SpkuMSRLfugrVX+IrKfE1RUegzo8AQzKQ6qQPfVzbcWi5IhuTPaKb5ZrLpucleFznkc4/RTeSPoRnGWFxX+EQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -541,356 +499,6 @@
 			"peerDependencies": {
 				"svelte": "^5.46.4",
 				"vite": "^8.0.0-beta.7 || ^8.0.0"
-			}
-		},
-		"node_modules/@tailwindcss/node": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-			"integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/remapping": "^2.3.5",
-				"enhanced-resolve": "5.21.6",
-				"jiti": "^2.7.0",
-				"lightningcss": "1.32.0",
-				"magic-string": "^0.30.21",
-				"source-map-js": "^1.2.1",
-				"tailwindcss": "4.3.2"
-			}
-		},
-		"node_modules/@tailwindcss/oxide": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-			"integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20"
-			},
-			"optionalDependencies": {
-				"@tailwindcss/oxide-android-arm64": "4.3.2",
-				"@tailwindcss/oxide-darwin-arm64": "4.3.2",
-				"@tailwindcss/oxide-darwin-x64": "4.3.2",
-				"@tailwindcss/oxide-freebsd-x64": "4.3.2",
-				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-				"@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-				"@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-				"@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-				"@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-				"@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-android-arm64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-			"integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-darwin-arm64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-			"integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-darwin-x64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-			"integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-freebsd-x64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-			"integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-			"integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-			"integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-			"integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-			"integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-linux-x64-musl": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-			"integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-			"integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
-			"bundleDependencies": [
-				"@napi-rs/wasm-runtime",
-				"@emnapi/core",
-				"@emnapi/runtime",
-				"@tybys/wasm-util",
-				"@emnapi/wasi-threads",
-				"tslib"
-			],
-			"cpu": [
-				"wasm32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/core": "^1.11.1",
-				"@emnapi/runtime": "^1.11.1",
-				"@emnapi/wasi-threads": "^1.2.2",
-				"@napi-rs/wasm-runtime": "^1.1.4",
-				"@tybys/wasm-util": "^0.10.2",
-				"tslib": "^2.8.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-			"version": "1.11.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.2",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-			"version": "1.11.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Brooooooklyn"
-			},
-			"peerDependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-			"version": "0.10.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "0BSD",
-			"optional": true
-		},
-		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-			"integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-			"integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@tailwindcss/vite": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
-			"integrity": "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tailwindcss/node": "4.3.2",
-				"@tailwindcss/oxide": "4.3.2",
-				"tailwindcss": "4.3.2"
-			},
-			"peerDependencies": {
-				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
 		"node_modules/@tybys/wasm-util": {
@@ -919,9 +527,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.9.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-			"integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+			"version": "25.9.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+			"integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1031,20 +639,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/enhanced-resolve": {
-			"version": "5.21.6",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-			"integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.4",
-				"tapable": "^2.3.3"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -1103,13 +697,6 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -1118,16 +705,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
-			}
-		},
-		"node_modules/jiti": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
 		"node_modules/kleur": {
@@ -1283,9 +860,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -1307,9 +881,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -1331,9 +902,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -1355,9 +923,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -1451,9 +1016,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.15",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -1470,9 +1035,9 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
@@ -1504,9 +1069,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+			"version": "8.5.19",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+			"integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -1547,13 +1112,13 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-			"integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.138.0",
+				"@oxc-project/types": "=0.139.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -1563,21 +1128,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.1.4",
-				"@rolldown/binding-darwin-arm64": "1.1.4",
-				"@rolldown/binding-darwin-x64": "1.1.4",
-				"@rolldown/binding-freebsd-x64": "1.1.4",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-				"@rolldown/binding-linux-arm64-gnu": "1.1.4",
-				"@rolldown/binding-linux-arm64-musl": "1.1.4",
-				"@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-				"@rolldown/binding-linux-s390x-gnu": "1.1.4",
-				"@rolldown/binding-linux-x64-gnu": "1.1.4",
-				"@rolldown/binding-linux-x64-musl": "1.1.4",
-				"@rolldown/binding-openharmony-arm64": "1.1.4",
-				"@rolldown/binding-wasm32-wasi": "1.1.4",
-				"@rolldown/binding-win32-arm64-msvc": "1.1.4",
-				"@rolldown/binding-win32-x64-msvc": "1.1.4"
+				"@rolldown/binding-android-arm64": "1.1.5",
+				"@rolldown/binding-darwin-arm64": "1.1.5",
+				"@rolldown/binding-darwin-x64": "1.1.5",
+				"@rolldown/binding-freebsd-x64": "1.1.5",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.5",
+				"@rolldown/binding-linux-arm64-musl": "1.1.5",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-musl": "1.1.5",
+				"@rolldown/binding-openharmony-arm64": "1.1.5",
+				"@rolldown/binding-wasm32-wasi": "1.1.5",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.5",
+				"@rolldown/binding-win32-x64-msvc": "1.1.5"
 			}
 		},
 		"node_modules/sade": {
@@ -1594,9 +1159,9 @@
 			}
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
-			"integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+			"integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1626,9 +1191,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.56.4",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
-			"integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+			"version": "5.56.6",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.6.tgz",
+			"integrity": "sha512-p4HDLDogGHKRKCrgckQHNs5PEfXkju6JI5jTywueaKJI5hAdjPohEhRtQ0M1SWC/+TA73SPln+r7srr+7e4nZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1654,9 +1219,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
-			"integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.3.tgz",
+			"integrity": "sha512-DHdTCGX62R0fCxBEaT+USdASAnoaRBaaNczkRJl0K7o3WyoCeVUbVxo6fKqpOll/B+WMWCsiFK0eFrJSNBKZIg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1676,27 +1241,6 @@
 			"peerDependencies": {
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
 				"typescript": ">=5.0.0"
-			}
-		},
-		"node_modules/tailwindcss": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-			"integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/tapable": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/tinyglobby": {
@@ -1756,16 +1300,16 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-			"integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+			"integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
-				"picomatch": "^4.0.4",
-				"postcss": "^8.5.16",
-				"rolldown": "~1.1.3",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.17",
+				"rolldown": "~1.1.5",
 				"tinyglobby": "^0.2.17"
 			},
 			"bin": {

--- a/test/resources/repos/svelte/test_repo/package.json
+++ b/test/resources/repos/svelte/test_repo/package.json
@@ -12,16 +12,12 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@fontsource/fira-mono": "^5.2.7",
-		"@neoconfetti/svelte": "^2.2.2",
 		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/kit": "^2.57.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
-		"@tailwindcss/vite": "^4.2.2",
 		"@types/node": "^25.6.1",
 		"svelte": "^5.55.2",
 		"svelte-check": "^4.4.6",
-		"tailwindcss": "^4.2.2",
 		"typescript": "^6.0.2",
 		"vite": "^8.0.7"
 	}

--- a/test/resources/repos/svelte/test_repo/src/routes/(sverdle)/+page.svelte
+++ b/test/resources/repos/svelte/test_repo/src/routes/(sverdle)/+page.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import { resolve } from '$app/paths';
-	import { confetti } from '@neoconfetti/svelte';
-	import { MediaQuery } from 'svelte/reactivity';
 	import { words } from '$lib/components/Words.svelte';
 	import { GAME_VERSION } from '$lib/game';
 
 	let { data } = $props();
-
-	const reducedMotion = new MediaQuery('(prefers-reduced-motion: reduce)');
 
 	let shake = $state(false);
 
@@ -165,19 +161,6 @@
 		{/if}
 	</div>
 </form>
-
-{#if won}
-	<div
-		style="position: absolute; left: 50%; top: 30%"
-		use:confetti={{
-			particleCount: reducedMotion.current ? 0 : undefined,
-			force: 0.7,
-			stageWidth: window.innerWidth,
-			stageHeight: window.innerHeight,
-			colors: ['#ff3e00', '#40b3ff', '#676778']
-		}}
-	></div>
-{/if}
 
 <style>
 	form {

--- a/test/resources/repos/svelte/test_repo/src/routes/layout.css
+++ b/test/resources/repos/svelte/test_repo/src/routes/layout.css
@@ -1,6 +1,3 @@
-@import 'tailwindcss';
-@import '@fontsource/fira-mono';
-
 :root {
 	--font-body: Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
 		'Open Sans', 'Helvetica Neue', sans-serif;

--- a/test/resources/repos/svelte/test_repo/vite.config.ts
+++ b/test/resources/repos/svelte/test_repo/vite.config.ts
@@ -1,5 +1,4 @@
-import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
-export default defineConfig({ plugins: [tailwindcss(), sveltekit()] });
+export default defineConfig({ plugins: [sveltekit()] });


### PR DESCRIPTION
Removes SvelteKit demo-template dependencies that no test exercises: `@fontsource/fira-mono`, `@neoconfetti/svelte`, `@tailwindcss/vite`, and `tailwindcss`, along with their only usages (the `layout.css` imports, the sverdle page's confetti effect, and the tailwind vite plugin).

## Why

- Smaller, more maintainable fixture: a regenerated lockfile drops from 119 to 91 package entries (−24%).
- Less dependency surface for the fixture bootstrap — fewer packages that can break `npm install` / `svelte-kit sync`.
- `rolldown` / `lightningcss` remain: they are vite's own dependencies, not tailwind's.

## Test safety

- Tests reference the sverdle page only as an expected member of reference/rename result sets (no position queries into that file), and its `$lib` imports (`game.ts`, `Words.svelte`) — which put it in those result sets — are untouched.
- Verified locally: clean `npm install` + `svelte-kit sync` + full svelte suite (16/16) against the trimmed fixture.

## Sequencing (why this is a draft)

#1648 commits a fixture `package-lock.json` generated from the previous dependency set; whichever change lands second must regenerate it. This PR stays a draft until #1648 merges — then it will be rebased, the regenerated (trimmed) lockfile committed here, and marked ready for review.

## Checklist

- [ ] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [ ] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change. *(Not applicable: test-fixture-only change with no user-facing behavior — no entry added.)*
