### PR TITLE
Java (eclipse_jdtls): don't hard-ignore packages named dist/lib/classes/out (#1645)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ Status of the `main` branch. Changes prior to the next official version change w
   - `Java`: invalidate JDTLS workspace cache when Java import settings change #1576
   - `Java`: use `JAVA_HOME` for Gradle import when `use_system_java_home` is enabled and `gradle_java_home`
     is unset. #1657
+  - `Java`: stop hard-ignoring directories named `target`/`build`/`bin`/`out`/`classes`/`dist`/`lib` in
+    `EclipseJDTLS`. These are all valid Java package identifiers, so ignoring them by name hid legitimate
+    source from the symbol tools even when they were not gitignored. Removed the hardcoded override; real
+    build output is already excluded via `.gitignore`. #1645
   - Improve quoting of arguments in shell executions
   - Add **LaTeX** support (experimental) via [texlab](https://github.com/latex-lsp/texlab).
   - PHP: add support for PHPantom as alternative to the already supported PHP LS #1554.

--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -254,24 +254,6 @@ class EclipseJDTLS(SolidLanguageServer):
         ls_resources_dir = self.ls_resources_dir(self._solidlsp_settings)
         return self.DependencyProvider(self._custom_settings, ls_resources_dir, self._solidlsp_settings, self.repository_root_path)
 
-    @override
-    def is_ignored_dirname(self, dirname: str) -> bool:
-        # Ignore common Java build directories from different build tools:
-        # - Maven: target
-        # - Gradle: build, .gradle
-        # - Eclipse: bin, .settings
-        # - IntelliJ IDEA: out, .idea
-        # - General: classes, dist, lib
-        return super().is_ignored_dirname(dirname) or dirname in [
-            "target",  # Maven
-            "build",  # Gradle
-            "bin",  # Eclipse
-            "out",  # IntelliJ IDEA
-            "classes",  # General
-            "dist",  # General
-            "lib",  # General
-        ]
-
     class DependencyProvider(LanguageServerDependencyProvider):
         def __init__(
             self,

--- a/test/solidlsp/java/test_jdtls_path_resolution.py
+++ b/test/solidlsp/java/test_jdtls_path_resolution.py
@@ -615,3 +615,32 @@ class TestComputeWorkspaceHash:
         configured_hash = EclipseJDTLS.DependencyProvider._compute_workspace_hash(self.REPO, self.DEFAULT_LAUNCHER, settings)
 
         assert configured_hash != legacy_hash
+
+
+# ----------------------------------------------------------------------------
+# is_ignored_dirname (directory-traversal filter)
+# ----------------------------------------------------------------------------
+
+
+class TestIsIgnoredDirname:
+    """Regression for #1645: the Java language server must not hard-ignore directories whose names
+    collide with build-tool output (``lib``, ``dist``, ``classes``, ``out``, ...). Those are all
+    valid Java package identifiers, so ignoring them by name hid legitimate source from the symbol
+    tools even when ``git check-ignore`` reported nothing. Real build output is already filtered via
+    ``.gitignore``, so directory traversal should only skip the language-agnostic
+    ``_ALWAYS_IGNORED_DIRS`` (VCS/venv/cache/IDE internals) inherited from the base language server.
+    """
+
+    @pytest.fixture
+    def jdtls(self) -> EclipseJDTLS:
+        # is_ignored_dirname only reads the class-level _ALWAYS_IGNORED_DIRS, so an uninitialized
+        # instance is sufficient here (no Java or JDTLS process required).
+        return object.__new__(EclipseJDTLS)
+
+    @pytest.mark.parametrize("dirname", ["lib", "dist", "classes", "out", "target", "build", "bin"])
+    def test_valid_package_dirnames_are_not_ignored(self, jdtls: EclipseJDTLS, dirname: str) -> None:
+        assert jdtls.is_ignored_dirname(dirname) is False
+
+    @pytest.mark.parametrize("dirname", [".git", ".venv", ".idea", ".serena", ".mypy_cache"])
+    def test_always_ignored_dirs_are_still_ignored(self, jdtls: EclipseJDTLS, dirname: str) -> None:
+        assert jdtls.is_ignored_dirname(dirname) is True


### PR DESCRIPTION
## Root cause

`EclipseJDTLS.is_ignored_dirname` hard-ignored directories named `target`/`build`/`bin`/`out`/`classes`/`dist`/`lib`. Four of these (`dist`, `lib`, `classes`, `out`) are valid Java package identifiers, and Java packages map directly to directories, so a source file whose package path contained one of those segments (e.g. `com.example.app.lib.Foo`) was pruned during traversal (`ls.py`, `if self.is_ignored_dirname(part)`) and became invisible to `find_symbol`, `get_symbols_overview`, and `find_referencing_symbols`, despite `git check-ignore` reporting nothing.

## Fix

Remove the override entirely, per your call in #1645. The base `is_ignored_dirname` already skips `_ALWAYS_IGNORED_DIRS` (VCS/venv/cache/IDE internals), and real build output is already excluded via `.gitignore`, so the hardcoded list was redundant and harmful. Java now uses the base behavior.

## Verification

Added `TestIsIgnoredDirname` (offline, no Java/JDTLS process, matching the file's existing unit tests): it fails on `main` and passes with this change.

```
without the fix: 7 failed, 5 passed   (lib/dist/classes/out/target/build/bin wrongly ignored)
with the fix:    12 passed
```

Whole file: `pytest test/solidlsp/java/test_jdtls_path_resolution.py` gives 55 passed. `ruff check`, `ruff format --check`, and `ty check` are clean. CHANGELOG updated under Language Servers.

## Notes

- @canweed you found and diagnosed this, and opcode81 offered to take your PR. If you already have one in progress, I'm glad to close this in favour of it, just say so.
- Out of scope here, but the same `... or dirname in [<build dirs>]` pattern appears in about a dozen other language servers (gopls, typescript, svelte, sourcekit, and others list `dist`/`build`). I kept this PR to the Java case you flagged; happy to open a follow-up if you'd like the pattern reviewed more broadly.

Fixes #1645
