### PR TITLE
search_for_pattern: add a snippet stage to the overflow shortening chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Status of the `main` branch. Changes prior to the next official version change w
     resolved to the start of the following line. The line the match ends on is now determined correctly,
     which also keeps `context_lines_after` aligned.
   - `safe_delete`: Add heuristic to delete superfluous empty lines after a deletion
+  - `search_for_pattern`: on overflow, the shortening chain now emits each match's first line (full when
+    it fits, otherwise truncated with a trailing '...' and a note) before falling back to bare line
+    numbers, so agents can pick the right match without re-reading files. #1640
 
 * JetBrains:
   - Allow external files from dependencies (specified via references like "<ext:FileUtil.class|472e0a13>") to be
@@ -92,9 +95,6 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Add tool parameter alias support, adding `name_path` as an alias for `name_path_pattern` in `find_symbol` tools
   - Allow `query_project` tool to access read-only tools that are not enabled in the current configuration
   - Make tool call errors surface explicitly as errors at the MCP protocol level
-  - `search_for_pattern`: on overflow, the shortening chain now emits each match's first line (full when
-    it fits, otherwise truncated with a trailing '...' and a note) before falling back to bare line
-    numbers, so agents can pick the right match without re-reading files. #1640
 
 * Language Servers:
   - Fix: `SolidLanguageServer.is_ignored_path` raised `FileNotFoundError` for paths that are not present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,9 +92,9 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Add tool parameter alias support, adding `name_path` as an alias for `name_path_pattern` in `find_symbol` tools
   - Allow `query_project` tool to access read-only tools that are not enabled in the current configuration
   - Make tool call errors surface explicitly as errors at the MCP protocol level
-  - `search_for_pattern`: on overflow, the shortening chain now emits an intermediate stage with each
-    match's line number plus its matched text (truncated) before falling back to bare line numbers,
-    so agents can pick the right match without re-reading files. #1640
+  - `search_for_pattern`: on overflow, the shortening chain now emits each match's first line (full when
+    it fits, otherwise truncated with a trailing '...' and a note) before falling back to bare line
+    numbers, so agents can pick the right match without re-reading files. #1640
 
 * Language Servers:
   - Fix: `SolidLanguageServer.is_ignored_path` raised `FileNotFoundError` for paths that are not present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Add tool parameter alias support, adding `name_path` as an alias for `name_path_pattern` in `find_symbol` tools
   - Allow `query_project` tool to access read-only tools that are not enabled in the current configuration
   - Make tool call errors surface explicitly as errors at the MCP protocol level
+  - `search_for_pattern`: on overflow, the shortening chain now emits an intermediate stage with each
+    match's line number plus its matched text (truncated) before falling back to bare line numbers,
+    so agents can pick the right match without re-reading files. #1640
 
 * Language Servers:
   - Fix: `SolidLanguageServer.is_ignored_path` raised `FileNotFoundError` for paths that are not present

--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -611,15 +611,27 @@ class SearchForPatternTool(Tool):
             file_to_matches[match.source_file_path].append(match.to_display_string())
 
         # capture lightweight match data for shortening before serialization
-        match_lines_by_file: dict[str, list[int]] = defaultdict(list)
+        match_lines_by_file: dict[str, list[dict[str, int | str]]] = defaultdict(list)
         for match in matches:
             assert match.source_file_path is not None
-            match_lines_by_file[match.source_file_path].append(match.matched_lines[0].line_number)
+            first = match.matched_lines[0]
+            match_lines_by_file[match.source_file_path].append({"line": first.line_number, "text": first.line_content.strip()})
 
         # shortened result closures, from least to most aggressive shortening
+        _TEXT_TRUNCATE = 60
+
         def make_lines_only() -> str:
-            """Match locations without surrounding context"""
-            return f"Match lines per file:\n{self._to_json(match_lines_by_file)}"
+            """Match locations with line number and truncated matched text."""
+            compact = {
+                path: [{"line": m["line"], "text": str(m["text"])[:_TEXT_TRUNCATE]} for m in lines]
+                for path, lines in match_lines_by_file.items()
+            }
+            return f"Result too long. Use read_file with line ranges below:\n{self._to_json(compact)}"
+
+        def make_line_numbers_only() -> str:
+            """Match locations as bare line numbers (no text)."""
+            numbers = {path: [m["line"] for m in lines] for path, lines in match_lines_by_file.items()}
+            return f"Match lines per file:\n{self._to_json(numbers)}"
 
         def make_per_file_counts() -> str:
             counts = {path: len(lines) for path, lines in match_lines_by_file.items()}
@@ -630,5 +642,7 @@ class SearchForPatternTool(Tool):
 
         result = self._to_json(file_to_matches)
         return self._limit_length(
-            result, max_answer_chars, shortened_result_factories=[make_lines_only, make_per_file_counts, make_summary]
+            result,
+            max_answer_chars,
+            shortened_result_factories=[make_lines_only, make_line_numbers_only, make_per_file_counts, make_summary],
         )

--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -626,7 +626,7 @@ class SearchForPatternTool(Tool):
                 path: [{"line": m["line"], "text": str(m["text"])[:_TEXT_TRUNCATE]} for m in lines]
                 for path, lines in match_lines_by_file.items()
             }
-            return f"Result too long. Use read_file with line ranges below:\n{self._to_json(compact)}"
+            return f"Match locations per file (line + matched text):\n{self._to_json(compact)}"
 
         def make_line_numbers_only() -> str:
             """Match locations as bare line numbers (no text)."""

--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -620,13 +620,34 @@ class SearchForPatternTool(Tool):
         # shortened result closures, from least to most aggressive shortening
         _TEXT_TRUNCATE = 60
 
-        def make_lines_only() -> str:
-            """Match locations with line number and truncated matched text."""
+        def render_first_lines(truncate: bool) -> str:
+            """Render each match's first line, either in full or truncated to a fixed length."""
+
+            def entry_text(text: str) -> str:
+                if truncate and len(text) > _TEXT_TRUNCATE:
+                    return text[:_TEXT_TRUNCATE] + "..."
+                return text
+
             compact = {
-                path: [{"line": m["line"], "text": str(m["text"])[:_TEXT_TRUNCATE]} for m in lines]
+                path: [{"line": m["line"], "text": entry_text(str(m["text"]))} for m in lines]
                 for path, lines in match_lines_by_file.items()
             }
-            return f"Match locations per file (line + matched text):\n{self._to_json(compact)}"
+            if truncate:
+                header = (
+                    f"Matched lines (text over {_TEXT_TRUNCATE} chars is truncated, marked with a trailing '...'); "
+                    "use read_file with the line numbers for full content:"
+                )
+            else:
+                header = "Matched lines per file; use read_file with the line numbers for surrounding context:"
+            return f"{header}\n{self._to_json(compact)}"
+
+        def make_first_lines_full() -> str:
+            """Match locations with each match's full first line."""
+            return render_first_lines(truncate=False)
+
+        def make_first_lines_truncated() -> str:
+            """Match locations with each match's first line truncated to a fixed length."""
+            return render_first_lines(truncate=True)
 
         def make_line_numbers_only() -> str:
             """Match locations as bare line numbers (no text)."""
@@ -644,5 +665,11 @@ class SearchForPatternTool(Tool):
         return self._limit_length(
             result,
             max_answer_chars,
-            shortened_result_factories=[make_lines_only, make_line_numbers_only, make_per_file_counts, make_summary],
+            shortened_result_factories=[
+                make_first_lines_full,
+                make_first_lines_truncated,
+                make_line_numbers_only,
+                make_per_file_counts,
+                make_summary,
+            ],
         )

--- a/test/serena/test_search_for_pattern.py
+++ b/test/serena/test_search_for_pattern.py
@@ -1,0 +1,48 @@
+"""Tests for the ``SearchForPatternTool`` overflow shortening chain.
+
+The snippet stage and, in particular, its position in the shortening chain were
+previously untested. Test contributed by @AmirF194 in review of PR #1667.
+"""
+
+from unittest.mock import MagicMock
+
+from serena.config.serena_config import SerenaConfig
+from serena.project import Project
+from serena.tools.file_tools import SearchForPatternTool
+
+
+def test_search_for_pattern_snippet_stage(tmp_path):
+    lines: list[str] = []
+    for i in range(60):
+        lines += [
+            "filler above",
+            "filler above",
+            f"MATCHME item number {i:04d} " + "payload " * 6,
+            "filler below",
+            "filler below",
+        ]
+    (tmp_path / "data.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    project = Project.load(str(tmp_path), serena_config=SerenaConfig(gui_log_window=False, web_dashboard=False))
+    agent = MagicMock()
+    agent.get_active_project_or_raise.return_value = project
+    tool = SearchForPatternTool(agent)
+
+    def run(cap: int) -> str:
+        return tool.apply(
+            substring_pattern="MATCHME",
+            context_lines_before=2,
+            context_lines_after=2,
+            restrict_search_to_code_files=False,
+            max_answer_chars=cap,
+        )
+
+    # wide but overflowing cap: the snippet stage (line + matched text) is returned
+    snippet = run(7000)
+    assert "The answer is too long" in snippet
+    assert '"text":' in snippet and "MATCHME item number 0000" in snippet
+    assert "Match lines per file" not in snippet  # not the bare-line-numbers stage
+
+    # tighter cap: the chain degrades past the snippet stage to bare line numbers
+    bare = run(1000)
+    assert "Match lines per file" in bare and '"text":' not in bare


### PR DESCRIPTION
Resolves #1640 (direction approved by @opcode81 in the issue).

## Summary

When a `search_for_pattern` result exceeds `max_answer_chars`, the shortening chain
previously fell back from full match content **directly to bare line numbers**, so the
agent learned *where* the matches were but not *what* matched — and had to re-read files
to recover that. This adds one intermediate stage to the chain:

```
full matches → {"line": N, "text": "<matched text, truncated to 60 chars>"} → bare line numbers → per-file counts → summary
```

The snippet stage fits within the limit precisely when the matched lines are long (which
is exactly the case that makes full results overflow), and it degrades gracefully: if even
the snippets exceed the limit, the chain continues on to bare line numbers, per-file counts
and finally a summary, as before.

## What the agent actually receives (deterministic)

Reproducible tool-level demonstration — a search with ~1,300 matches whose full result is
196,274 chars, against the default `max_answer_chars` of 150,000. The task is to find the one
match belonging to a specific class (`Message777`). This is the first fallback returned in
each case (the `The answer is too long (…)` banner is added by the framework in both):

**Before** — bare line numbers:
```
Match lines per file:
{"generated/pb_models.py": [23, 46, 69, …, 17848, 17871, 17894, 17917, 17940, … (~1300 numbers)]}
```
Line `17894` is indistinguishable from the other ~1,300 — to tell which match is `Message777`,
the agent has to open the file.

**After** — line number + matched text:
```
Match locations per file (line + matched text):
{"generated/pb_models.py": [ …,
  {"line": 17894, "text": "return cls(field_id=data.get('field_id', 777), field_name=da"}, … ]}
```
The distinguishing text (`777`) is inline, so the agent can pick the right match and issue a
targeted `read_file` — without re-reading the file just to discover what matched.

## Changes

- `src/serena/tools/file_tools.py` — snippet stage in `SearchForPatternTool` (adds a
  `{line, text}` intermediate and keeps a dedicated bare-line-numbers stage after it).
- `CHANGELOG.md` — entry under *Tools*.

The motivating agent-level A/B measurement is described in #1640.
