### PR TITLE
Add Astro language server support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Make tool call errors surface explicitly as errors at the MCP protocol level
 
 * Language Servers:
+  - Add support for **Astro** (`@astrojs/language-server`) with a companion `typescript-language-server`
+    (configured with `@astrojs/ts-plugin`) for cross-file go-to-definition, references and rename between
+    `.ts`/`.js` and `.astro` files. Requires Node.js v18+ and npm; dependencies auto-install on first use.
+    Use language `astro` instead of also enabling `typescript`.
   - C/C++ (clangd): improve support and documentation for Unreal Engine 5 projects.
   - HLSL (`shader-language-server`): pass `--locked` to `cargo install` when building from source
     on macOS (and in the manual-install instructions), honoring the crate's packaged `Cargo.lock`.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Serena incorporates a powerful abstraction layer for the integration of language
 The underlying language servers are typically open-source projects or at least freely available for use.
 
 When using Serena's language server backend, we provide **support for over 40 programming languages**, including
-Ada / SPARK, AL, Angular, Ansible, Bash, BSL, C#, C/C++, Clojure, Crystal, CUE, Dart, Elixir, Elm, Erlang, Fortran, F#, GDScript, GLSL, Go, Groovy, Haskell, Haxe, HLSL, HTML, Java, JavaScript, JSON, Julia, Kotlin, LaTeX, Lean 4, Lua, Luau, Markdown, MATLAB, mSL, Nix, OCaml, Perl, PHP, PowerShell, Python, R, Ruby, Rust, Scala, SCSS / Sass / CSS, Solidity, Svelte, Swift, TOML, TypeScript, WGSL, YAML, and Zig.
+Ada / SPARK, AL, Angular, Ansible, Astro, Bash, BSL, C#, C/C++, Clojure, Crystal, CUE, Dart, Elixir, Elm, Erlang, Fortran, F#, GDScript, GLSL, Go, Groovy, Haskell, Haxe, HLSL, HTML, Java, JavaScript, JSON, Julia, Kotlin, LaTeX, Lean 4, Lua, Luau, Markdown, MATLAB, mSL, Nix, OCaml, Perl, PHP, PowerShell, Python, R, Ruby, Rust, Scala, SCSS / Sass / CSS, Solidity, Svelte, Swift, TOML, TypeScript, WGSL, YAML, and Zig.
 
 ### The Serena JetBrains Plugin
 

--- a/docs/01-about/020_programming-languages.md
+++ b/docs/01-about/020_programming-languages.md
@@ -46,6 +46,11 @@ Some languages require additional installations or setup steps, as noted.
   the upstream `@ansible/ansible-language-server@1.2.3` supports hover, completion, definition,
   semantic tokens, and validation; document symbols, workspace symbols, references, and rename
   are not supported by this version)
+* **Astro**
+  (requires Node.js v18+ and npm; supports `.astro` components plus TypeScript/JavaScript files via
+  `@astrojs/language-server`; a companion `typescript-language-server` configured with `@astrojs/ts-plugin`
+  is spawned automatically for cross-file go-to-definition, references, and rename across `.ts`/`.js` and
+  `.astro` files; use language `astro` for Astro projects instead of also enabling `typescript`)
 * **Bash**
 * **BSL** (1C:Enterprise / OneScript)  
   (requires Java 21+ on PATH; uses [bsl-language-server](https://github.com/1c-syntax/bsl-language-server) by 1c-syntax; the JAR is auto-downloaded and SHA-256-verified for the bundled default version; supports `.bsl` and `.os` files; configure optional `ls_path` or `bsl_ls_version` under `ls_specific_settings.bsl`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,6 +331,7 @@ markers = [
   "typescript: language server running for TypeScript",
   "svelte: language server running for Svelte (uses svelte-language-server)",
   "vue: language server running for Vue (uses TypeScript LSP)",
+  "astro: language server running for Astro (uses TypeScript LSP)",
   "php: language server running for PHP",
   "perl: language server running for Perl",
   "csharp: language server running for C#",

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -282,6 +282,7 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
     _CODE_FILE_EXTENSIONS: frozenset[str] = frozenset(
         (
             ".al",
+            ".astro",
             ".bash",
             ".c",
             ".clj",

--- a/src/solidlsp/language_servers/astro_language_server.py
+++ b/src/solidlsp/language_servers/astro_language_server.py
@@ -1,0 +1,703 @@
+"""
+Astro Language Server implementation using @astrojs/language-server with companion TypeScript LS.
+Operates in a dual-server setup: the Astro LS handles .astro files (parsing, document symbols),
+while a companion TypeScript LS (configured with @astrojs/ts-plugin) handles definitions,
+references and rename for .ts/.js files and cross-file resolution.
+
+This mirrors the Vue and Svelte language servers, which use a self-contained companion server
+held in ``self._ts_server`` rather than a shared companion base class.
+"""
+
+import logging
+import os
+import pathlib
+import shutil
+import threading
+from collections.abc import Callable
+from pathlib import Path, PurePath
+from time import sleep
+
+from overrides import override
+
+from solidlsp import ls_types
+from solidlsp.language_servers.common import RuntimeDependency, RuntimeDependencyCollection, build_npm_install_command
+from solidlsp.language_servers.typescript_language_server import (
+    TypeScriptLanguageServer,
+    prefer_non_node_modules_definition,
+)
+from solidlsp.ls import LanguageServerDependencyProvider, SolidLanguageServer
+from solidlsp.ls_config import FilenameMatcher, Language, LanguageServerConfig
+from solidlsp.ls_exceptions import SolidLSPException
+from solidlsp.ls_utils import PathUtils
+from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
+
+log = logging.getLogger(__name__)
+
+
+class AstroTypeScriptServer(TypeScriptLanguageServer):
+    """TypeScript LS configured with @astrojs/ts-plugin for Astro file support."""
+
+    @classmethod
+    @override
+    def get_language_enum_instance(cls) -> Language:
+        """Return TYPESCRIPT since this is a TypeScript language server variant.
+
+        AstroTypeScriptServer is a companion server that uses TypeScript's language server
+        with the Astro TypeScript plugin. It reports as TYPESCRIPT to maintain compatibility
+        with the TypeScript language server infrastructure.
+        """
+        return Language.TYPESCRIPT
+
+    def get_source_fn_matcher(self) -> FilenameMatcher:
+        # Override with an Astro-specific matcher to ensure .astro files are included (they can be
+        # discovered via references); otherwise references in .astro files would be filtered out.
+        return Language.ASTRO.get_source_fn_matcher()
+
+    class DependencyProvider(TypeScriptLanguageServer.DependencyProvider):
+        """Dependency provider that returns a pre-resolved executable path.
+
+        The Astro LS install (run by ``AstroLanguageServer._setup_runtime_dependencies``)
+        already locates the ``typescript-language-server`` binary alongside the Astro
+        language server, so the companion does not need to perform another install
+        lookup -- it just returns the path it was constructed with.
+        """
+
+        def __init__(
+            self,
+            custom_settings: SolidLSPSettings.CustomLSSettings,
+            ls_resources_dir: str,
+            explicit_executable_path: str,
+        ) -> None:
+            super().__init__(custom_settings, ls_resources_dir)
+            self._explicit_executable_path = explicit_executable_path
+
+        @override
+        def _get_or_install_core_dependency(self) -> str:
+            return self._explicit_executable_path
+
+    @override
+    def _get_language_id_for_file(self, relative_file_path: str) -> str:
+        """Return the correct language ID for files.
+
+        Astro files must be opened with language ID "astro" for the @astrojs/ts-plugin
+        to process them correctly. The plugin is configured with "languages": ["astro"]
+        in the initialization options. JSX/TSX use the react variants so tsserver does
+        not truncate symbol ranges at the first multi-line JSX expression (see the base
+        ``TypeScriptLanguageServer._get_language_id_for_file``); Astro projects commonly
+        include .tsx/.jsx via React/Preact/Solid integrations.
+        """
+        ext = os.path.splitext(relative_file_path)[1].lower()
+        if ext == ".astro":
+            return "astro"
+        elif ext == ".tsx":
+            return "typescriptreact"
+        elif ext == ".jsx":
+            return "javascriptreact"
+        elif ext in (".ts", ".mts", ".cts"):
+            return "typescript"
+        elif ext in (".js", ".mjs", ".cjs"):
+            return "javascript"
+        else:
+            return "typescript"
+
+    def __init__(
+        self,
+        config: LanguageServerConfig,
+        repository_root_path: str,
+        solidlsp_settings: SolidLSPSettings,
+        astro_plugin_path: str,
+        tsdk_path: str,
+        ts_ls_executable_path: str,
+    ):
+        self._astro_plugin_path = astro_plugin_path
+        self._custom_tsdk_path = tsdk_path
+        # Stored as instance state so the override survives across concurrent
+        # constructions of multiple AstroLanguageServer instances.
+        self._explicit_ts_ls_executable = ts_ls_executable_path
+        super().__init__(config, repository_root_path, solidlsp_settings)
+
+    @override
+    def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
+        return self.DependencyProvider(
+            self._custom_settings,
+            self._ls_resources_dir,
+            self._explicit_ts_ls_executable,
+        )
+
+    @override
+    def _create_base_initialize_params(self) -> dict:
+        params = super()._create_base_initialize_params()
+
+        params["initializationOptions"] = {
+            "plugins": [
+                {
+                    "name": "@astrojs/ts-plugin",
+                    "location": self._astro_plugin_path,
+                    "languages": ["astro"],
+                }
+            ],
+            "tsserver": {
+                "path": self._custom_tsdk_path,
+            },
+        }
+
+        if "workspace" in params["capabilities"]:
+            params["capabilities"]["workspace"]["executeCommand"] = {"dynamicRegistration": True}
+
+        return params
+
+    @override
+    def _start_server(self) -> None:
+        def workspace_configuration_handler(params: dict) -> list:
+            items = params.get("items", [])
+            return [{} for _ in items]
+
+        self.server.on_request("workspace/configuration", workspace_configuration_handler)
+        super()._start_server()
+
+
+class AstroLanguageServer(SolidLanguageServer):
+    """
+    Language server for Astro components using @astrojs/language-server with companion TypeScript LS.
+
+    You can pass the following entries in ls_specific_settings["astro"]:
+        - astro_language_server_version: Version of @astrojs/language-server to install (default: "2.16.11")
+
+    Note: TypeScript versions are configured via ls_specific_settings["typescript"]:
+        - typescript_version: Version of TypeScript to install (default: "5.9.3")
+        - typescript_language_server_version: Version of typescript-language-server to install (default: "5.1.3")
+    """
+
+    TS_SERVER_READY_TIMEOUT = 5.0
+    ASTRO_SERVER_READY_TIMEOUT = 3.0
+
+    def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
+        astro_lsp_executable_path, self.tsdk_path, self._ts_ls_cmd = self._setup_runtime_dependencies(config, solidlsp_settings)
+        self._astro_ls_dir = os.path.join(self.ls_resources_dir(solidlsp_settings), "astro-lsp")
+        super().__init__(
+            config,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=astro_lsp_executable_path, cwd=repository_root_path),
+            "astro",
+            solidlsp_settings,
+        )
+        self.server_ready = threading.Event()
+        self.initialize_searcher_command_available = threading.Event()
+        self._ts_server: AstroTypeScriptServer | None = None
+        self._ts_server_started = False
+        self._astro_files_indexed = False
+        self._indexed_astro_file_uris: list[str] = []
+        self._ls_operational_ready_event = threading.Event()
+        self._ls_operational_lock = threading.Lock()
+
+    def _ensure_ls_operational(self) -> None:
+        # short-circuit completed warm-up
+        if self._ls_operational_ready_event.is_set():
+            return
+
+        # serialize the warm-up sequence
+        with self._ls_operational_lock:
+            # short-circuit repeated callers after waiting for the lock
+            if self._ls_operational_ready_event.is_set():
+                return
+
+            # validate server availability
+            if not self.server_started:
+                raise SolidLSPException("Language Server not started")
+
+            # wait for cross-file reference readiness
+            if not self._has_waited_for_cross_file_references:
+                sleep(self._get_wait_time_for_cross_file_referencing())
+                self._has_waited_for_cross_file_references = True
+
+            # index Astro files on the companion TypeScript server
+            self._ensure_astro_files_indexed_on_ts_server()
+
+            # publish operational readiness
+            self._ls_operational_ready_event.set()
+
+    @override
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        return super().is_ignored_dirname(dirname) or dirname in [
+            "node_modules",
+            "dist",
+            "build",
+            "coverage",
+            ".astro",
+        ]
+
+    @override
+    def _get_language_id_for_file(self, relative_file_path: str) -> str:
+        # Inherited document-symbol requests open files on this primary server, so JSX/TSX must use
+        # the react variants here too (see the companion's _get_language_id_for_file for rationale).
+        ext = os.path.splitext(relative_file_path)[1].lower()
+        if ext == ".astro":
+            return "astro"
+        elif ext == ".tsx":
+            return "typescriptreact"
+        elif ext == ".jsx":
+            return "javascriptreact"
+        elif ext in (".ts", ".mts", ".cts"):
+            return "typescript"
+        elif ext in (".js", ".mjs", ".cjs"):
+            return "javascript"
+        else:
+            return "astro"
+
+    def _is_typescript_file(self, file_path: str) -> bool:
+        ext = os.path.splitext(file_path)[1].lower()
+        return ext in (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
+
+    def _find_all_astro_files(self) -> list[str]:
+        astro_files = []
+        repo_path = Path(self.repository_root_path)
+
+        for astro_file in repo_path.rglob("*.astro"):
+            try:
+                relative_path = str(astro_file.relative_to(repo_path))
+                if "node_modules" not in relative_path and not relative_path.startswith("."):
+                    astro_files.append(relative_path)
+            except Exception as e:
+                log.debug(f"Error processing Astro file {astro_file}: {e}")
+
+        return astro_files
+
+    def _ensure_astro_files_indexed_on_ts_server(self) -> None:
+        if self._astro_files_indexed:
+            return
+
+        assert self._ts_server is not None
+        log.info("Indexing .astro files on TypeScript server for cross-file references")
+        astro_files = self._find_all_astro_files()
+        log.debug(f"Found {len(astro_files)} .astro files to index")
+
+        # Prepare the TS server to track new $/progress notifications triggered
+        # by the didOpen calls below. Must happen BEFORE opening files to avoid
+        # a race where progress begins and ends before we start waiting.
+        self._ts_server.expect_indexing()
+
+        for astro_file in astro_files:
+            try:
+                with self._ts_server.open_file(astro_file) as file_buffer:
+                    file_buffer.ref_count += 1
+                    self._indexed_astro_file_uris.append(file_buffer.uri)
+            except Exception as e:
+                log.debug(f"Failed to open {astro_file} on TS server: {e}")
+
+        self._astro_files_indexed = True
+        log.info("Astro file indexing on TypeScript server complete, waiting for TS server to finish processing")
+
+        self._wait_for_ts_indexing_complete()
+
+    def _wait_for_ts_indexing_complete(self) -> None:
+        """Wait for the companion TypeScript server to finish processing opened Astro files.
+
+        Uses the $/progress tracking in TypeScriptLanguageServer: after Astro files are
+        opened, tsserver sends "Initializing JS/TS language features..." progress.
+        We wait for all progress tokens to complete, with a timeout fallback.
+        """
+        assert self._ts_server is not None
+        timeout = TypeScriptLanguageServer.INDEXING_PROGRESS_TIMEOUT
+        if self._ts_server.wait_for_indexing(timeout=timeout):
+            log.info("TypeScript server finished indexing Astro files (signaled via $/progress)")
+        else:
+            log.warning(f"Timeout ({timeout}s) waiting for TypeScript server to finish indexing Astro files, proceeding anyway")
+
+    def _send_ts_references_request(self, relative_file_path: str, line: int, column: int) -> list[ls_types.Location]:
+        assert self._ts_server is not None
+        uri = PathUtils.path_to_uri(os.path.join(self.repository_root_path, relative_file_path))
+        request_params = {
+            "textDocument": {"uri": uri},
+            "position": {"line": line, "character": column},
+            "context": {"includeDeclaration": True},
+        }
+
+        with self._ts_server.open_file(relative_file_path):
+            response = self._ts_server.handler.send.references(request_params)  # type: ignore[arg-type]
+
+        result: list[ls_types.Location] = []
+        if response is not None:
+            for item in response:
+                abs_path = PathUtils.uri_to_path(item["uri"])
+                if not Path(abs_path).is_relative_to(self.repository_root_path):
+                    log.debug(f"Found reference outside repository: {abs_path}, skipping")
+                    continue
+
+                rel_path = Path(abs_path).relative_to(self.repository_root_path)
+                if self.is_ignored_path(str(rel_path)):
+                    log.debug(f"Ignoring reference in {rel_path}")
+                    continue
+
+                new_item: dict = {}
+                new_item.update(item)
+                new_item["absolutePath"] = str(abs_path)
+                new_item["relativePath"] = str(rel_path)
+                result.append(ls_types.Location(**new_item))  # type: ignore
+
+        return result
+
+    @override
+    def request_references(self, relative_file_path: str, line: int, column: int) -> list[ls_types.Location]:
+        self._ensure_ls_operational()
+        return self._send_ts_references_request(relative_file_path, line=line, column=column)
+
+    @override
+    def request_definition(self, relative_file_path: str, line: int, column: int) -> list[ls_types.Location]:
+        self._ensure_ls_operational()
+        assert self._ts_server is not None
+        with self._ts_server.open_file(relative_file_path):
+            return self._ts_server.request_definition(relative_file_path, line, column)
+
+    @override
+    def request_rename_symbol_edit(self, relative_file_path: str, line: int, column: int, new_name: str) -> ls_types.WorkspaceEdit | None:
+        self._ensure_ls_operational()
+        assert self._ts_server is not None
+        with self._ts_server.open_file(relative_file_path):
+            return self._ts_server.request_rename_symbol_edit(relative_file_path, line, column, new_name)
+
+    @override
+    def request_text_document_diagnostics(
+        self,
+        relative_file_path: str,
+        start_line: int = 0,
+        end_line: int = -1,
+        min_severity: int = 4,
+    ) -> list[ls_types.Diagnostic]:
+        self._ensure_ls_operational()
+        assert self._ts_server is not None
+        return self._ts_server.request_text_document_diagnostics(relative_file_path, start_line, end_line, min_severity)
+
+    def _forward_edit_to_ts_server_if_needed(self, relative_file_path: str, edit_fn: Callable[[], object]) -> None:
+        """
+        Calls ``edit_fn`` on the TypeScript server if the file is open there.
+
+        Only applicable to non-TypeScript files (i.e. .astro files) that have been
+        indexed on the TypeScript server for cross-file reference support.
+        """
+        if self._ts_server is None or not self._ts_server_started:
+            return
+        if self._is_typescript_file(relative_file_path):
+            return
+
+        absolute_file_path = str(PurePath(self.repository_root_path, relative_file_path))
+        uri = pathlib.Path(absolute_file_path).as_uri()
+        if uri in self._ts_server.open_file_buffers:
+            edit_fn()
+
+    @override
+    def insert_text_at_position(self, relative_file_path: str, line: int, column: int, text_to_be_inserted: str) -> ls_types.Position:
+        result = super().insert_text_at_position(relative_file_path, line, column, text_to_be_inserted)
+        self._forward_edit_to_ts_server_if_needed(
+            relative_file_path,
+            lambda: self._ts_server.insert_text_at_position(  # type: ignore[union-attr]
+                relative_file_path, line, column, text_to_be_inserted
+            ),
+        )
+        return result
+
+    @override
+    def delete_text_between_positions(
+        self,
+        relative_file_path: str,
+        start: ls_types.Position,
+        end: ls_types.Position,
+    ) -> str:
+        deleted_text = super().delete_text_between_positions(relative_file_path, start, end)
+        self._forward_edit_to_ts_server_if_needed(
+            relative_file_path,
+            lambda: self._ts_server.delete_text_between_positions(  # type: ignore[union-attr]
+                relative_file_path, start, end
+            ),
+        )
+        return deleted_text
+
+    @classmethod
+    def _setup_runtime_dependencies(cls, config: LanguageServerConfig, solidlsp_settings: SolidLSPSettings) -> tuple[list[str], str, str]:
+        is_node_installed = shutil.which("node") is not None
+        assert is_node_installed, "node is not installed or isn't in PATH. Please install NodeJS and try again."
+        is_npm_installed = shutil.which("npm") is not None
+        assert is_npm_installed, "npm is not installed or isn't in PATH. Please install npm and try again."
+
+        # Get TypeScript version settings from TypeScript language server settings
+        typescript_config = solidlsp_settings.get_ls_specific_settings(Language.TYPESCRIPT)
+        typescript_version = typescript_config.get("typescript_version", "5.9.3")
+        typescript_language_server_version = typescript_config.get("typescript_language_server_version", "5.1.3")
+        astro_config = solidlsp_settings.get_ls_specific_settings(Language.ASTRO)
+        astro_language_server_version = astro_config.get("astro_language_server_version", "2.16.11")
+        # @astrojs/ts-plugin is NOT a dependency of @astrojs/language-server, so it must be installed
+        # explicitly. Without it the companion tsserver has no .astro awareness and cross-file
+        # resolution between .ts/.js and .astro files silently returns nothing.
+        astro_ts_plugin_version = astro_config.get("astro_ts_plugin_version", "1.10.10")
+        npm_registry = astro_config.get("npm_registry", typescript_config.get("npm_registry"))
+
+        deps = RuntimeDependencyCollection(
+            [
+                RuntimeDependency(
+                    id="astro-language-server",
+                    description="Astro language server package",
+                    command=build_npm_install_command("@astrojs/language-server", astro_language_server_version, npm_registry),
+                    platform_id="any",
+                ),
+                RuntimeDependency(
+                    id="astro-ts-plugin",
+                    description="Astro TypeScript plugin, gives the companion tsserver .astro awareness",
+                    command=build_npm_install_command("@astrojs/ts-plugin", astro_ts_plugin_version, npm_registry),
+                    platform_id="any",
+                ),
+                RuntimeDependency(
+                    id="typescript",
+                    description="TypeScript (required for tsdk)",
+                    command=build_npm_install_command("typescript", typescript_version, npm_registry),
+                    platform_id="any",
+                ),
+                RuntimeDependency(
+                    id="typescript-language-server",
+                    description="TypeScript language server (for Astro companion TS forwarding)",
+                    command=build_npm_install_command("typescript-language-server", typescript_language_server_version, npm_registry),
+                    platform_id="any",
+                ),
+            ]
+        )
+
+        astro_ls_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "astro-lsp")
+        astro_executable_path = os.path.join(astro_ls_dir, "node_modules", ".bin", "astro-ls")
+        ts_ls_executable_path = os.path.join(astro_ls_dir, "node_modules", ".bin", "typescript-language-server")
+
+        if os.name == "nt":
+            astro_executable_path += ".cmd"
+            ts_ls_executable_path += ".cmd"
+
+        tsdk_path = os.path.join(astro_ls_dir, "node_modules", "typescript", "lib")
+
+        # Check if installation is needed based on executables AND version
+        version_file = os.path.join(astro_ls_dir, ".installed_version")
+        expected_version = (
+            f"{astro_language_server_version}_{astro_ts_plugin_version}_{typescript_version}_{typescript_language_server_version}"
+        )
+
+        needs_install = False
+        if not os.path.exists(astro_executable_path) or not os.path.exists(ts_ls_executable_path):
+            log.info("Astro/TypeScript Language Server executables not found.")
+            needs_install = True
+        elif os.path.exists(version_file):
+            with open(version_file) as f:
+                installed_version = f.read().strip()
+            if installed_version != expected_version:
+                log.info(
+                    f"Astro Language Server version mismatch: installed={installed_version}, expected={expected_version}. Reinstalling..."
+                )
+                needs_install = True
+        else:
+            # No version file exists, assume old installation needs refresh
+            log.info("Astro Language Server version file not found. Reinstalling to ensure correct version...")
+            needs_install = True
+
+        if needs_install:
+            log.info("Installing Astro/TypeScript Language Server dependencies...")
+            deps.install(astro_ls_dir)
+            # Write version marker file
+            with open(version_file, "w") as f:
+                f.write(expected_version)
+            log.info("Astro language server dependencies installed successfully")
+
+        if not os.path.exists(astro_executable_path):
+            raise FileNotFoundError(
+                f"astro-ls executable not found at {astro_executable_path}, something went wrong with the installation."
+            )
+
+        if not os.path.exists(ts_ls_executable_path):
+            raise FileNotFoundError(
+                f"typescript-language-server executable not found at {ts_ls_executable_path}, something went wrong with the installation."
+            )
+
+        return [astro_executable_path, "--stdio"], tsdk_path, ts_ls_executable_path
+
+    def _create_base_initialize_params(self) -> dict:
+        initialize_params = {
+            "locale": "en",
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {"didSave": True, "dynamicRegistration": True},
+                    "completion": {"dynamicRegistration": True, "completionItem": {"snippetSupport": True}},
+                    "definition": {"dynamicRegistration": True, "linkSupport": True},
+                    "references": {"dynamicRegistration": True},
+                    "documentSymbol": {
+                        "dynamicRegistration": True,
+                        "hierarchicalDocumentSymbolSupport": True,
+                        "symbolKind": {"valueSet": list(range(1, 27))},
+                    },
+                    "hover": {"dynamicRegistration": True, "contentFormat": ["markdown", "plaintext"]},
+                    "signatureHelp": {"dynamicRegistration": True},
+                    "codeAction": {"dynamicRegistration": True},
+                    "rename": {"dynamicRegistration": True, "prepareSupport": True},
+                    "publishDiagnostics": {"relatedInformation": True},
+                },
+                "workspace": {
+                    "workspaceFolders": True,
+                    "didChangeConfiguration": {"dynamicRegistration": True},
+                    "symbol": {"dynamicRegistration": True},
+                },
+            },
+            "initializationOptions": {
+                "typescript": {
+                    "tsdk": self.tsdk_path,
+                },
+            },
+        }
+        return initialize_params
+
+    def _start_typescript_server(self) -> None:
+        try:
+            astro_ts_plugin_path = os.path.join(self._astro_ls_dir, "node_modules", "@astrojs", "ts-plugin")
+            if not os.path.exists(astro_ts_plugin_path):
+                log.warning(
+                    "Astro TypeScript plugin not found at %s. The companion tsserver will lack .astro "
+                    "awareness, so cross-file resolution between .ts/.js and .astro files will not work. "
+                    "This usually means the @astrojs/ts-plugin install did not complete.",
+                    astro_ts_plugin_path,
+                )
+
+            ts_config = LanguageServerConfig(
+                code_language=Language.TYPESCRIPT,
+                trace_lsp_communication=False,
+            )
+
+            log.info("Creating companion AstroTypeScriptServer")
+            self._ts_server = AstroTypeScriptServer(
+                config=ts_config,
+                repository_root_path=self.repository_root_path,
+                solidlsp_settings=self._solidlsp_settings,
+                astro_plugin_path=astro_ts_plugin_path,
+                tsdk_path=self.tsdk_path,
+                ts_ls_executable_path=self._ts_ls_cmd,
+            )
+
+            log.info("Starting companion TypeScript server")
+            self._ts_server.start()
+
+            log.info("Waiting for companion TypeScript server to be ready...")
+            if not self._ts_server.server_ready.wait(timeout=self.TS_SERVER_READY_TIMEOUT):
+                log.warning(
+                    f"Timeout waiting for companion TypeScript server to be ready after {self.TS_SERVER_READY_TIMEOUT} seconds, proceeding anyway"
+                )
+                self._ts_server.server_ready.set()
+
+            self._ts_server_started = True
+            log.info("Companion TypeScript server ready")
+        except Exception as e:
+            log.error(f"Error starting TypeScript server: {e}")
+            self._ts_server = None
+            self._ts_server_started = False
+            raise
+
+    def _cleanup_indexed_astro_files(self) -> None:
+        if not self._indexed_astro_file_uris or self._ts_server is None:
+            return
+
+        log.debug(f"Cleaning up {len(self._indexed_astro_file_uris)} indexed Astro files")
+        for uri in self._indexed_astro_file_uris:
+            try:
+                if uri in self._ts_server.open_file_buffers:
+                    file_buffer = self._ts_server.open_file_buffers[uri]
+                    file_buffer.ref_count -= 1
+
+                    if file_buffer.ref_count == 0:
+                        self._ts_server.server.notify.did_close_text_document({"textDocument": {"uri": uri}})
+                        del self._ts_server.open_file_buffers[uri]
+                        log.debug(f"Closed indexed Astro file: {uri}")
+            except Exception as e:
+                log.debug(f"Error closing indexed Astro file {uri}: {e}")
+
+        self._indexed_astro_file_uris.clear()
+
+    def _stop_typescript_server(self) -> None:
+        if self._ts_server is not None:
+            try:
+                log.info("Stopping companion TypeScript server")
+                self._ts_server.stop()
+            except Exception as e:
+                log.warning(f"Error stopping TypeScript server: {e}")
+            finally:
+                self._ts_server = None
+                self._ts_server_started = False
+
+    @override
+    def _start_server(self) -> None:
+        self._start_typescript_server()
+
+        def register_capability_handler(params: dict) -> None:
+            assert "registrations" in params
+            for registration in params["registrations"]:
+                if registration["method"] == "workspace/executeCommand":
+                    self.initialize_searcher_command_available.set()
+            return
+
+        def configuration_handler(params: dict) -> list:
+            items = params.get("items", [])
+            return [{} for _ in items]
+
+        def do_nothing(params: dict) -> None:
+            return
+
+        def window_log_message(msg: dict) -> None:
+            log.info(f"LSP: window/logMessage: {msg}")
+            message_text = msg.get("message", "")
+            if "initialized" in message_text.lower() or "ready" in message_text.lower():
+                log.info("Astro language server ready signal detected")
+                self.server_ready.set()
+
+        self.server.on_request("client/registerCapability", register_capability_handler)
+        self.server.on_request("workspace/configuration", configuration_handler)
+        self.server.on_notification("window/logMessage", window_log_message)
+        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+
+        # The companion is already running. If anything below fails, our caller never received an
+        # initialised handle and therefore can't invoke stop() -- so we tear down the companion and
+        # the partially-started Astro process here to avoid leaking Node processes.
+        try:
+            log.info("Starting Astro server process")
+            self.server.start()
+            initialize_params = self._create_initialize_params()
+
+            log.info("Sending initialize request from LSP client to LSP server and awaiting response")
+            init_response = self.server.send.initialize(initialize_params)
+            log.debug(f"Received initialize response from Astro server: {init_response}")
+
+            assert init_response["capabilities"]["textDocumentSync"] in [1, 2]
+
+            self.server.notify.initialized({})
+
+            log.info("Waiting for Astro language server to be ready...")
+            if not self.server_ready.wait(timeout=self.ASTRO_SERVER_READY_TIMEOUT):
+                log.info("Timeout waiting for Astro server ready signal, proceeding anyway")
+                self.server_ready.set()
+            else:
+                log.info("Astro server initialization complete")
+        except Exception:
+            self._stop_typescript_server()
+            try:
+                self.server.stop()
+            except Exception as e:
+                log.warning("Error stopping Astro server during startup-failure cleanup: %s", e)
+            raise
+
+    @override
+    def _get_wait_time_for_cross_file_referencing(self) -> float:
+        return 5.0
+
+    @override
+    def stop(self, shutdown_timeout: float = 5.0) -> None:
+        # serialize shutdown with operational warm-up
+        with self._ls_operational_lock:
+            self.server_started = False
+            self._ls_operational_ready_event.clear()
+            self._cleanup_indexed_astro_files()
+            self._stop_typescript_server()
+
+        super().stop(shutdown_timeout)
+
+    @override
+    def _get_preferred_definition(self, definitions: list[ls_types.Location]) -> ls_types.Location:
+        return prefer_non_node_modules_definition(definitions)

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -100,6 +100,11 @@ class Language(str, Enum):
     LEAN4 = "lean4"
     GROOVY = "groovy"
     VUE = "vue"
+    ASTRO = "astro"
+    """Astro language server using @astrojs/language-server with a companion TypeScript LS.
+    Handles .astro Single File Components plus TypeScript and JavaScript files in Astro
+    projects. Requires Node.js and npm.
+    """
     SVELTE = "svelte"
     """Svelte language server using svelte-language-server.
     Supports .svelte Single File Components plus TypeScript and JavaScript
@@ -298,8 +303,8 @@ class Language(str, Enum):
         # We assign lower priority to languages that are supersets of others, such that
         # the "larger" language is only chosen when it matches more strongly
         match self:
-            # languages that are supersets of others (Vue/Svelte are supersets of TypeScript/JavaScript)
-            case self.VUE | self.SVELTE:
+            # languages that are supersets of others (Vue/Astro/Svelte are supersets of TypeScript/JavaScript)
+            case self.VUE | self.ASTRO | self.SVELTE:
                 return 1
             # regular languages
             case _:
@@ -478,6 +483,13 @@ class Language(str, Enum):
                         for base_pattern in ["ts", "js"]:
                             path_patterns.append(f".{prefix}{base_pattern}{postfix}")
                 return FilenameMatcher(*path_patterns)
+            case self.ASTRO:
+                path_patterns = [".astro"]
+                for prefix in ["c", "m", ""]:
+                    for postfix in ["x", ""]:
+                        for base_pattern in ["ts", "js"]:
+                            path_patterns.append(f".{prefix}{base_pattern}{postfix}")
+                return FilenameMatcher(*path_patterns)
             case self.SVELTE:
                 path_patterns = [".svelte"]
                 for prefix in ["c", "m", ""]:
@@ -593,6 +605,10 @@ class Language(str, Enum):
                 from solidlsp.language_servers.vue_language_server import VueLanguageServer
 
                 return VueLanguageServer
+            case self.ASTRO:
+                from solidlsp.language_servers.astro_language_server import AstroLanguageServer
+
+                return AstroLanguageServer
             case self.SVELTE:
                 from solidlsp.language_servers.svelte_language_server import SvelteLanguageServer
 

--- a/test/resources/repos/astro/test_repo/.gitignore
+++ b/test/resources/repos/astro/test_repo/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.astro/
+package-lock.json
+.astro-install.lock

--- a/test/resources/repos/astro/test_repo/astro.config.mjs
+++ b/test/resources/repos/astro/test_repo/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  // Minimal config for testing
+});

--- a/test/resources/repos/astro/test_repo/package.json
+++ b/test/resources/repos/astro/test_repo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "astro-test-fixture",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "astro": "^5.16.6"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/test/resources/repos/astro/test_repo/src/components/Footer.astro
+++ b/test/resources/repos/astro/test_repo/src/components/Footer.astro
@@ -1,0 +1,7 @@
+---
+const year = new Date().getFullYear();
+---
+
+<footer>
+  <p>&copy; {year} Test Site</p>
+</footer>

--- a/test/resources/repos/astro/test_repo/src/components/Header.astro
+++ b/test/resources/repos/astro/test_repo/src/components/Header.astro
@@ -1,0 +1,13 @@
+---
+interface Props {
+  siteName: string;
+}
+
+const { siteName } = Astro.props;
+---
+
+<header>
+  <nav>
+    <a href="/">{siteName}</a>
+  </nav>
+</header>

--- a/test/resources/repos/astro/test_repo/src/layouts/Layout.astro
+++ b/test/resources/repos/astro/test_repo/src/layouts/Layout.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/test/resources/repos/astro/test_repo/src/pages/index.astro
+++ b/test/resources/repos/astro/test_repo/src/pages/index.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { createCounter } from '../stores/counter';
+import { formatNumber } from '../utils/format';
+
+const counter = createCounter();
+---
+
+<Layout title="Home">
+  <Header siteName="Test Site" />
+  <main>
+    <h1>Welcome</h1>
+    <p>Count: {formatNumber(counter.count)}</p>
+  </main>
+  <Footer />
+</Layout>

--- a/test/resources/repos/astro/test_repo/src/stores/counter.ts
+++ b/test/resources/repos/astro/test_repo/src/stores/counter.ts
@@ -1,0 +1,21 @@
+export interface CounterStore {
+  count: number;
+  increment: () => void;
+  decrement: () => void;
+}
+
+export function createCounter(): CounterStore {
+  let count = 0;
+
+  return {
+    get count() {
+      return count;
+    },
+    increment() {
+      count++;
+    },
+    decrement() {
+      count--;
+    },
+  };
+}

--- a/test/resources/repos/astro/test_repo/src/utils/format.ts
+++ b/test/resources/repos/astro/test_repo/src/utils/format.ts
@@ -1,0 +1,13 @@
+/**
+ * Format a number with thousands separators.
+ */
+export function formatNumber(value: number): string {
+  return value.toLocaleString();
+}
+
+/**
+ * Format a date to locale string.
+ */
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString();
+}

--- a/test/resources/repos/astro/test_repo/tsconfig.json
+++ b/test/resources/repos/astro/test_repo/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "preserve"
+  },
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}

--- a/test/solidlsp/astro/__init__.py
+++ b/test/solidlsp/astro/__init__.py
@@ -1,0 +1,1 @@
+# Astro language server tests

--- a/test/solidlsp/astro/conftest.py
+++ b/test/solidlsp/astro/conftest.py
@@ -1,0 +1,74 @@
+"""
+Pytest fixtures for Astro language server tests.
+
+This conftest does NOT install the language server itself -- that is handled by
+``RuntimeDependencyCollection`` inside ``AstroLanguageServer`` and lands in Serena's
+managed ``ls_resources_dir`` like every other LS download.
+
+What we install here is the *test fixture project's* npm dependencies (notably
+``astro``) into the fixture's own ``node_modules``. The companion tsserver (via
+``@astrojs/ts-plugin``) needs ``astro`` resolvable from the workspace to understand
+``.astro`` modules; without it, cross-file references between ``.ts`` and ``.astro``
+files return nothing and the tests would pass vacuously. Vendoring ``node_modules``
+in-repo is impractical, so we run ``npm install`` once per checkout, cached across
+sessions, and serialised across xdist workers via ``filelock``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from filelock import FileLock
+
+log = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[2] / "resources" / "repos" / "astro" / "test_repo"
+NODE_MODULES = REPO_ROOT / "node_modules"
+ASTRO_MARKER = NODE_MODULES / "astro" / "package.json"
+# Lock file lives inside the repo (covered by its .gitignore) so xdist workers can
+# serialise on the install.
+INSTALL_LOCK = REPO_ROOT / ".astro-install.lock"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _install_astro_test_repo_node_modules() -> None:
+    """Populate the Astro fixture's project dependencies via npm (cached across sessions)."""
+    if ASTRO_MARKER.exists():
+        log.info("Astro test repo node_modules already populated; skipping npm install")
+        return
+
+    npm_executable = shutil.which("npm.cmd") or shutil.which("npm")
+    if npm_executable is None:
+        pytest.skip("npm is not available; cannot install Astro test repo dependencies")
+
+    with FileLock(str(INSTALL_LOCK)):
+        # Re-check inside the lock: a sibling worker may have just installed.
+        if ASTRO_MARKER.exists():
+            log.info("Astro test repo node_modules populated by another worker; skipping npm install")
+            return
+
+        log.warning(
+            "Installing npm dependencies into the Astro test repo at %s. This is a one-time cost per checkout.",
+            REPO_ROOT,
+        )
+        proc = subprocess.run(
+            [npm_executable, "install", "--no-audit", "--no-fund", "--loglevel=warn"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=os.environ.copy(),
+        )
+        if proc.returncode != 0:
+            log.error("npm install failed (rc=%s).\nstdout:\n%s\nstderr:\n%s", proc.returncode, proc.stdout, proc.stderr)
+            pytest.skip(f"npm install failed in {REPO_ROOT} (rc={proc.returncode}); see logs for details")
+
+        if not ASTRO_MARKER.exists():
+            pytest.skip(f"npm install completed but {ASTRO_MARKER} is missing; cannot run Astro tests")
+
+        log.info("Astro test repo node_modules installed successfully")

--- a/test/solidlsp/astro/test_astro_basic.py
+++ b/test/solidlsp/astro/test_astro_basic.py
@@ -1,0 +1,144 @@
+"""
+Basic tests for Astro language server functionality.
+
+Tests cover:
+- Language server startup
+- Symbol tree extraction from .astro files
+- Cross-file reference finding between Astro and TypeScript
+- Dual server coordination
+- Reference deduplication
+
+Template: test_vue_basic.py
+"""
+
+from pathlib import Path
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+
+
+@pytest.mark.astro
+class TestAstroLanguageServer:
+    """Core Astro language server functionality tests."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_ls_is_running(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that the Astro language server starts and stops successfully."""
+        assert language_server.is_running()
+        assert Path(language_server.language_server.repository_root_path).resolve() == repo_path.resolve()
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_astro_document_symbols(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that document symbols are extracted from .astro files."""
+        layout_path = str(repo_path / "src" / "layouts" / "Layout.astro")
+        symbols = language_server.request_document_symbols(layout_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        # Layout.astro defines: interface Props { title: string; }
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
+        # Verify we found the Props interface from frontmatter
+        assert "Props" in symbol_names, f"Expected 'Props' interface in symbols, got: {symbol_names}"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_typescript_document_symbols(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that TypeScript files in Astro project have document symbols."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        symbols = language_server.request_document_symbols(counter_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
+        assert "CounterStore" in symbol_names, f"Expected 'CounterStore' in symbols, got: {symbol_names}"
+        assert "createCounter" in symbol_names, f"Expected 'createCounter' in symbols, got: {symbol_names}"
+
+
+@pytest.mark.astro
+class TestAstroDefinition:
+    """Go-to-definition tests for Astro language server."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_find_definition_within_typescript(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test finding definition within TypeScript file."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        definition_list = language_server.request_definition(counter_path, 6, 35)
+        assert definition_list, "Expected at least one definition"
+        assert len(definition_list) >= 1
+        definition = definition_list[0]
+        assert definition["uri"].endswith("counter.ts"), f"Expected counter.ts, got: {definition['uri']}"
+        assert definition["range"]["start"]["line"] == 0, "Expected definition at line 0"
+
+
+@pytest.mark.astro
+class TestAstroReferences:
+    """Reference finding tests for Astro language server."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_find_references_within_typescript(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test finding references within TypeScript file."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        # CounterStore interface on line 0 (0-indexed), column 20
+        references = language_server.request_references(counter_path, 0, 20)
+        assert references, "Expected at least one reference"
+        # (file basename, 0-indexed start line) for every reference found
+        locations = {(ref["uri"].rsplit("/", 1)[-1], ref["range"]["start"]["line"]) for ref in references}
+        # CounterStore is declared on line 0 and used as the createCounter return type on line 6,
+        # both within counter.ts (this symbol is not referenced from .astro files).
+        assert ("counter.ts", 0) in locations, f"Expected the declaration at counter.ts:0, got: {sorted(locations)}"
+        assert ("counter.ts", 6) in locations, f"Expected the return-type use at counter.ts:6, got: {sorted(locations)}"
+
+
+@pytest.mark.astro
+class TestAstroDualLspArchitecture:
+    """Tests for TypeScript server coordination in Astro."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_typescript_server_starts(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that companion TypeScript server starts successfully."""
+        astro_ls = language_server.language_server
+        # The Astro LS keeps its companion TypeScript server in the _ts_server attribute
+        # (self-contained companion pattern, mirroring the upstream Vue language server).
+        assert hasattr(astro_ls, "_ts_server"), "Expected _ts_server attribute on Astro language server"
+        assert astro_ls._ts_server is not None, "Expected companion TypeScript server to be started"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_dual_server_definition_lookup(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that definitions work with both Astro and TypeScript servers."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        ts_definition = language_server.request_definition(counter_path, 6, 35)
+        assert ts_definition, "Expected definition from TypeScript server"
+
+
+@pytest.mark.astro
+class TestAstroEdgeCases:
+    """Edge case tests for Astro language server."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_astro_file_with_frontmatter(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test handling of .astro files with frontmatter section."""
+        index_path = str(repo_path / "src" / "pages" / "index.astro")
+        # index.astro has imports and variable declarations in frontmatter
+        symbols = language_server.request_document_symbols(index_path)
+        # Should handle frontmatter without errors
+        assert symbols is not None, "Expected document symbols but got None"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_layout_astro_with_props_interface(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test Layout.astro which has Props interface in frontmatter."""
+        layout_path = str(repo_path / "src" / "layouts" / "Layout.astro")
+        # Layout.astro defines: interface Props { title: string; }
+        symbols = language_server.request_document_symbols(layout_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
+        # Verify Props interface is found
+        assert "Props" in symbol_names, f"Expected 'Props' interface in Layout.astro, got: {symbol_names}"

--- a/test/solidlsp/astro/test_astro_symbol_retrieval.py
+++ b/test/solidlsp/astro/test_astro_symbol_retrieval.py
@@ -1,0 +1,84 @@
+"""
+Symbol retrieval tests for Astro language server.
+
+Tests cover:
+- Containing symbol requests
+- Referencing symbol requests
+- Cross-file type resolution
+- Import resolution
+
+Template: test_vue_symbol_retrieval.py
+"""
+
+from pathlib import Path
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+
+
+@pytest.mark.astro
+class TestAstroSymbolRetrieval:
+    """Symbol retrieval functionality tests."""
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_get_containing_symbol_in_typescript(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test finding containing symbol in .ts file within Astro project."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        # Request document symbols to verify we can get symbols from TS files
+        symbols = language_server.request_document_symbols(counter_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
+        # Verify expected symbols from counter.ts
+        assert "CounterStore" in symbol_names, f"Expected 'CounterStore' in symbols, got: {symbol_names}"
+        assert "createCounter" in symbol_names, f"Expected 'createCounter' in symbols, got: {symbol_names}"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_find_references_to_typescript_export(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test finding references to a TypeScript export from an .astro component.
+
+        createCounter is defined in counter.ts and imported + called in
+        src/pages/index.astro. This exercises the dual-server cross-file path: the
+        companion tsserver (with @astrojs/ts-plugin) must resolve the .astro usage.
+        """
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        # createCounter is on line 7 (0-indexed: 6), function name starts around char 16
+        references = language_server.request_references(counter_path, 6, 20)
+        assert references is not None, "Expected references but got None"
+        # (file basename, 0-indexed start line) for every reference found
+        locations = {(ref["uri"].rsplit("/", 1)[-1], ref["range"]["start"]["line"]) for ref in references}
+        # Definition in counter.ts (line 6) plus the import (line 4) and the call (line 7) in index.astro.
+        # The index.astro hits require the companion tsserver's @astrojs/ts-plugin awareness to resolve.
+        assert ("counter.ts", 6) in locations, f"Expected the definition at counter.ts:6, got: {sorted(locations)}"
+        assert ("index.astro", 4) in locations, f"Expected the import at index.astro:4, got: {sorted(locations)}"
+        assert ("index.astro", 7) in locations, f"Expected the call at index.astro:7, got: {sorted(locations)}"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_go_to_definition_from_typescript(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test go-to-definition within TypeScript source."""
+        counter_path = str(repo_path / "src" / "stores" / "counter.ts")
+        # In createCounter function, CounterStore return type is on line 7 (0-indexed: 6)
+        definition_list = language_server.request_definition(counter_path, 6, 35)
+        assert definition_list, "Expected at least one definition"
+        # Should point to CounterStore interface definition
+        definition = definition_list[0]
+        assert definition["uri"].endswith("counter.ts"), f"Expected counter.ts, got: {definition['uri']}"
+        # CounterStore is defined at line 0
+        assert definition["range"]["start"]["line"] == 0, f"Expected line 0, got: {definition['range']['start']['line']}"
+
+    @pytest.mark.parametrize("language_server", [Language.ASTRO], indirect=True)
+    @pytest.mark.parametrize("repo_path", [Language.ASTRO], indirect=True)
+    def test_format_utils_symbols(self, language_server: SolidLanguageServer, repo_path: Path) -> None:
+        """Test that format.ts utility file symbols are accessible."""
+        format_path = str(repo_path / "src" / "utils" / "format.ts")
+        symbols = language_server.request_document_symbols(format_path)
+        assert symbols is not None, "Expected document symbols but got None"
+        all_symbols, _roots = symbols.get_all_symbols_and_roots()
+        symbol_names = [s["name"] for s in all_symbols]
+        assert "formatNumber" in symbol_names, f"Expected 'formatNumber' in symbols, got: {symbol_names}"
+        assert "formatDate" in symbol_names, f"Expected 'formatDate' in symbols, got: {symbol_names}"


### PR DESCRIPTION
Adds support for the [Astro](https://astro.build/) web framework using
`@astrojs/language-server` with a companion TypeScript language server for
cross-file type resolution.

## Relationship to #886 / #884

This builds on @dansasser's Astro work in #886. #884 was closed with the
suggestion to base Astro on the companion-server abstraction from #829, and
#886 was written against that abstraction (`CompanionLanguageServer` in
`companion_ls.py`, plus `embedded_language_config.py` and
`typescript_companion.py`).

That abstraction is not present in `main`. The Vue and Svelte language servers
in the current tree each keep their companion TypeScript server in a
self-contained `self._ts_server` attribute instead of a shared base class. To
match what is actually in `main`, the adapter here was re-implemented against
that Vue/Svelte pattern rather than importing the abstraction from #886. As a
result this PR does not add the `CompanionLanguageServer` base class, does not
modify the Vue language server, and is smaller than #886.

## Architecture

Dual-server setup, identical in shape to Vue/Svelte:

- **Astro LS** (`@astrojs/language-server`, run via `astro-ls --stdio`) handles
  `.astro` parsing and document symbols.
- **Companion TypeScript LS** (`typescript-language-server` configured with the
  `@astrojs/ts-plugin` initialization plugin) handles go-to-definition,
  find-references and rename for `.ts`/`.js` files and cross-file resolution.
  `.astro` files are indexed on the companion so cross-file references resolve.
  `@astrojs/ts-plugin` is installed explicitly (it is not a dependency of
  `@astrojs/language-server`), and its path is validated at startup with a clear
  warning if missing.

`AstroLanguageServer` subclasses `SolidLanguageServer`; the nested
`AstroTypeScriptServer` subclasses `TypeScriptLanguageServer` and reuses its
`DependencyProvider`, `$/progress` indexing tracking and
`prefer_non_node_modules_definition` helper. Initialization uses
`_create_base_initialize_params` (server-specific keys only; the common keys are
supplied by the central `InitializeParamsBuilder`).

## Changes

- `src/solidlsp/language_servers/astro_language_server.py` (new)
- `src/solidlsp/ls_config.py`: `Language.ASTRO`, superset priority, `.astro`
  source matcher, factory wiring
- `src/serena/hooks.py`: `.astro` added to the source-extension set
- `pyproject.toml`: `astro` pytest marker
- `README.md`, `docs/01-about/020_programming-languages.md`, `CHANGELOG.md`
- `test/solidlsp/astro/` (new): `conftest.py`, `test_astro_basic.py`,
  `test_astro_symbol_retrieval.py`
- `test/resources/repos/astro/test_repo/` (new): minimal Astro project

Runtime dependencies (`@astrojs/language-server`, `@astrojs/ts-plugin`,
`typescript`, `typescript-language-server`) are auto-installed via npm into
Serena's managed resource dir on first use, with a version marker file that
triggers reinstall on version change. Defaults: `@astrojs/language-server`
2.16.11 and `@astrojs/ts-plugin` 1.10.10 (latest at time of writing), both
overridable via `ls_specific_settings.astro`.

The test fixture's own npm dependencies (`astro`, needed by the ts-plugin to
resolve `.astro` modules) are installed by `test/solidlsp/astro/conftest.py`,
following the Svelte fixture: a session-scoped, filelock-guarded `npm install`
into the fixture's `node_modules`, cached across runs and skipped if npm is
unavailable. As with Svelte, `package-lock.json` is git-ignored rather than
committed.

## Tests

Tests assert concrete symbol names and exact reference locations
(`file:line`), per the CONTRIBUTING guideline, not just non-empty results. In
particular, references to `createCounter` (defined in `counter.ts`) are asserted
to include its import at `index.astro:4` and its call at `index.astro:7` — this
exercises the dual-server cross-file path and would fail if `@astrojs/ts-plugin`
were missing from the companion. The tests are skipped only when npm is
unavailable (or the fixture install fails), matching the Svelte/Angular
fixtures. The `astro` marker is not in any named CI marker group, so the tests
run in the `catch-all` pytest batch, which already sets up Node.js on all OSes.

Verified locally on Windows (Python 3.14, Node 22):

```
uv run pytest test/solidlsp/astro test/solidlsp/vue -q
55 passed, 2 warnings in 108.67s (0:01:48)
```

(13 Astro tests + 42 Vue tests; Vue is included to show it is unchanged.)

To confirm the fixture install path and that nothing passes vacuously, the
Astro suite was also run after deleting both the fixture `node_modules` and the
managed language-server install:

```
uv run pytest test/solidlsp/astro -q
13 passed, 2 warnings in 70.84s (0:01:10)
```

`uv run serena --help` starts cleanly. `ruff check` and `ruff format --check`
pass on the changed files.

## Notes

- No standalone setup guide was added, following the Vue/Svelte precedent (they
  have none); the language is documented in
  `docs/01-about/020_programming-languages.md`.
- `request_references` for `.ts`/`.js` symbols is served by the companion only.
  The sharpened cross-file test confirms this already returns references located
  inside `.astro` files, so no separate merge of primary-Astro-LS references is
  needed for symbol references. File-level component references (e.g. locating
  `<Header/>` tag usages), which the Vue/Svelte servers add via Volar-specific
  requests, are not implemented here and could be a follow-up.
- `.tsx`/`.jsx` are opened with the `typescriptreact`/`javascriptreact` language
  ids (as the base `TypeScriptLanguageServer` does) so tsserver does not truncate
  symbol ranges at JSX expressions; Astro projects commonly include these via
  React/Preact/Solid integrations.
- If the Astro LS fails to initialize after the companion has started,
  `_start_server` tears down the companion and the partial Astro process before
  re-raising, to avoid leaking Node processes (mirrors the Angular server).
- The internal `assert self._ts_server is not None` invariants follow the
  current Vue/Svelte servers.
