### PR TITLE
fix(rust-analyzer): prevent indefinite startup hang and harden init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,13 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Allow `query_project` tool to access read-only tools that are not enabled in the current configuration
   - Make tool call errors surface explicitly as errors at the MCP protocol level
 
-* Language Servers:
-  - C/C++ (clangd): improve support and documentation for Unreal Engine 5 projects.
+ * Language Servers:
+   - Rust (`rust-analyzer`): prevent an indefinite startup hang by adding a timeout to the readiness
+     wait (proceeds with a warning if the server never signals `quiescent`); harden the
+     `language/status` and `experimental/serverStatus` notification handlers against missing keys; and
+     relax the over-strict `completionProvider` capability check (an exact-equality assertion) to a
+     non-fatal warning, so upstream capability changes no longer crash initialization.
+   - C/C++ (clangd): improve support and documentation for Unreal Engine 5 projects.
   - HLSL (`shader-language-server`): pass `--locked` to `cargo install` when building from source
     on macOS (and in the manual-install instructions), honoring the crate's packaged `Cargo.lock`.
     Without it, fresh dependency resolution pulled in shader-sense 1.4.0, which no longer compiles

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -676,9 +676,8 @@ class RustAnalyzer(SolidLanguageServer):
         """
 
         def register_capability_handler(params: dict) -> None:
-            assert "registrations" in params
-            for registration in params["registrations"]:
-                if registration["method"] == "workspace/executeCommand":
+            for registration in params.get("registrations", []):
+                if registration.get("method") == "workspace/executeCommand":
                     self.initialize_searcher_command_available.set()
                     self.resolve_main_method_available.set()
             return
@@ -687,7 +686,7 @@ class RustAnalyzer(SolidLanguageServer):
             # TODO: Should we wait for
             # server -> client: {'jsonrpc': '2.0', 'method': 'language/status', 'params': {'type': 'ProjectStatus', 'message': 'OK'}}
             # Before proceeding?
-            if params["type"] == "ServiceReady" and params["message"] == "ServiceReady":
+            if params.get("type") == "ServiceReady" and params.get("message") == "ServiceReady":
                 self.service_ready_event.set()
 
         def execute_client_command_handler(params: dict) -> list:
@@ -697,7 +696,7 @@ class RustAnalyzer(SolidLanguageServer):
             return
 
         def check_experimental_status(params: dict) -> None:
-            if params["quiescent"] == True:
+            if params.get("quiescent") is True:
                 self.server_ready.set()
 
         def window_log_message(msg: dict) -> None:
@@ -718,13 +717,25 @@ class RustAnalyzer(SolidLanguageServer):
 
         log.info("Sending initialize request from LSP client to LSP server and awaiting response")
         init_response = self.server.send.initialize(initialize_params)
-        assert init_response["capabilities"]["textDocumentSync"]["change"] == 2  # type: ignore
-        assert "completionProvider" in init_response["capabilities"]
-        assert init_response["capabilities"]["completionProvider"] == {
-            "resolveProvider": True,
-            "triggerCharacters": [":", ".", "'", "("],
-            "completionItem": {"labelDetailsSupport": True},
-        }
+        # Validate key server capabilities. These are sanity checks, not hard requirements:
+        # rust-analyzer may evolve its advertised capabilities across versions, so a mismatch is
+        # logged rather than asserted. (An over-strict equality check on completionProvider here
+        # previously crashed startup whenever upstream added or changed a completionProvider field.)
+        capabilities = init_response.get("capabilities", {}) if isinstance(init_response, dict) else {}
+        text_document_sync = capabilities.get("textDocumentSync")
+        change_kind = text_document_sync.get("change") if isinstance(text_document_sync, dict) else text_document_sync
+        if change_kind != 2:
+            log.warning("rust-analyzer: unexpected textDocumentSync.change=%r (expected 2 = incremental)", change_kind)
+        if "completionProvider" not in capabilities:
+            log.warning("rust-analyzer: server did not advertise a completionProvider capability")
         self.server.notify.initialized({})
 
-        self.server_ready.wait()
+        # Wait for rust-analyzer to finish initial indexing (it emits experimental/serverStatus with
+        # quiescent=true when ready). Use a timeout so a server that crashes or never signals
+        # readiness cannot hang startup indefinitely (previously this waited with no timeout).
+        _SERVER_READY_TIMEOUT = 120.0
+        log.info("Waiting for rust-analyzer to signal readiness (quiescent)...")
+        if self.server_ready.wait(timeout=_SERVER_READY_TIMEOUT):
+            log.info("rust-analyzer ready")
+        else:
+            log.warning("rust-analyzer did not signal readiness within %.0fs; proceeding anyway", _SERVER_READY_TIMEOUT)


### PR DESCRIPTION
## What

Harden rust-analyzer startup against an indefinite hang and brittle initialization checks. All three
changes are confined to `_start_server`.

- **Indefinite hang:** `server_ready.wait()` had **no timeout**. If rust-analyzer crashes or never
  emits `experimental/serverStatus {quiescent: true}`, Serena startup hangs forever. Every other
  server that waits for readiness (kotlin, matlab, powershell, bash, …) uses a timeout and proceeds
  with a warning — rust-analyzer and clangd were the only two without one. Now waits 120s and proceeds
  with a warning on expiry.
- **Unguarded notification payloads:** the `language/status` and `experimental/serverStatus` handlers
  indexed `params[...]` directly, raising `KeyError` on an unexpected payload — and a `KeyError` in the
  `quiescent` handler could itself prevent `server_ready` from ever being set, feeding the hang above.
  Now use `params.get(...)`, matching the pyright server.
- **Over-strict capability assertion:** an exact-dict-equality assertion on `completionProvider`
  crashed initialization whenever rust-analyzer changed/added a field. These values are not used
  downstream, so a mismatch is now logged as a warning instead (same spirit as #1543).

Orthogonal to the memory/indexing work in #1556 / #1557, which tune `_get_initialize_params` options;
this only touches the readiness path in `_start_server`.

## Testing

All 34 Rust integration tests pass against real rust-analyzer (`poe test -m rust`); full CI matrix
(ubuntu/windows/macOS × all batches) green on my fork.

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs (bug fix).
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`.
