### PR TITLE
fix(search): glob '?' matches one character, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Status of the `main` branch. Changes prior to the next official version change will appear here.
 
 * General:
+  - Fix: in `glob_to_regex` / `search_text(is_glob=True)`, a `?` wildcard matched two characters instead
+    of one (it emitted `..` rather than `.`); it now matches a single character, consistent with the
+    `?` semantics documented for `glob_match` and the `test_??.py` example in `search_text`'s docstring.
   - Add notion of trusted projects via new global configuration setting `trusted_project_path_patterns`.
     Current effects:
     - `ls_specific_settings` defined in project configurations will only be applied for trusted projects

--- a/src/serena/util/text_utils.py
+++ b/src/serena/util/text_utils.py
@@ -124,7 +124,7 @@ def glob_to_regex(glob_pat: str) -> str:
         if ch == "*":
             regex_parts.append(".*")
         elif ch == "?":
-            regex_parts.append("..")
+            regex_parts.append(".")
         elif ch == "\\":
             i += 1
             if i < len(glob_pat):

--- a/test/serena/test_text_utils.py
+++ b/test/serena/test_text_utils.py
@@ -1,9 +1,10 @@
+import re
 from collections.abc import Callable
 
 import pytest
 
 from serena.util.file_proxy import FileCollection, FileProxy
-from serena.util.text_utils import LineType, MultiFileContentReplacer, search_files, search_text
+from serena.util.text_utils import LineType, MultiFileContentReplacer, glob_to_regex, search_files, search_text
 
 
 class TestSearchText:
@@ -200,6 +201,20 @@ class TestSearchText:
         matches_curly = search_text("*{bar}*", content=content, is_glob=True, multiline=False)
         assert len(matches_curly) == 1
         assert "{bar}" in matches_curly[0].lines[0].line_content
+
+    def test_glob_to_regex_question_matches_single_char(self):
+        """A glob '?' matches exactly one character, matching glob_match's documented semantics."""
+        rx = glob_to_regex("a?c")
+        assert re.fullmatch(rx, "abc") is not None
+        assert re.fullmatch(rx, "ac") is None
+        assert re.fullmatch(rx, "abbc") is None
+
+    def test_search_text_glob_question_single_char(self):
+        """search_text('c?t', is_glob=True) must match 'cat' (one char), not 'coat' (two chars)."""
+        content = "\n".join(["value_cat_end", "value_coat_end"])
+        matches = search_text("c?t", content=content, is_glob=True, multiline=False)
+        assert len(matches) == 1
+        assert "value_cat_end" in matches[0].lines[0].line_content
 
     def test_search_text_no_matches(self):
         """Test searching with a pattern that doesn't match anything."""

--- a/test/serena/test_text_utils.py
+++ b/test/serena/test_text_utils.py
@@ -211,7 +211,7 @@ class TestSearchText:
 
     def test_search_text_glob_question_single_char(self):
         """search_text('c?t', is_glob=True) must match 'cat' (one char), not 'coat' (two chars)."""
-        content = "\n".join(["value_cat_end", "value_coat_end"])
+        content = "value_cat_end\nvalue_coat_end"
         matches = search_text("c?t", content=content, is_glob=True, multiline=False)
         assert len(matches) == 1
         assert "value_cat_end" in matches[0].lines[0].line_content


### PR DESCRIPTION
## What

`glob_to_regex` (`src/serena/util/text_utils.py`) translated a glob `?` to `..`, i.e. two "any" characters, instead of a single `.`. As a result `search_text(..., is_glob=True)` treated `?` as "exactly two characters". The pattern `test_??.py` from `search_text`'s own docstring, for example, required four characters where two were intended.

Invariant: a glob `?` matches exactly one character. That is the behavior already documented for the sibling `glob_match` in the same file ("? matches a single character except /") and implied by the `test_??.py` docstring example.

## Fix

Emit `.` for `?` instead of `..` (one line). No other behavior changes; `*`, escapes and literal characters are untouched.

## Verification

Reproduced in a clean Docker container (uv, Python 3.11) against current `main` (`6018bf4`):

- On this branch, `test/serena/test_text_utils.py` passes (76 tests), including two added regression tests.
- Reverting only the one-character source change back to `..` makes both new tests fail:
  - `glob_to_regex("a?c")` returns `a..c`, so `re.fullmatch("a..c", "abc")` is `None`;
  - `search_text("c?t", is_glob=True)` matches `value_coat_end` (two characters) instead of `value_cat_end`.

Command:

    uv sync --extra dev
    uv run --no-sync pytest test/serena/test_text_utils.py -o addopts="" -k question

Scope note: this corrects the public `glob_to_regex` / `search_text(is_glob=True)` behavior. I did not find a first-party tool that currently passes `is_glob=True` with a `?` pattern, so this is not a user-facing tool regression; it fixes the glob utility and its documented `test_??.py` example.

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs (small bug fix, single logical change).
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.

Done with AI assistance.
