### PR TITLE
fix(pyright): avoid premature analysis readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Make tool call errors surface explicitly as errors at the MCP protocol level
 
 * Language Servers:
+  - Pyright: wait up to 60 seconds for initial workspace analysis and keep readiness pending after a timeout, avoiding premature empty results on large workspaces.
   - Fix: `SolidLanguageServer.is_ignored_path` raised `FileNotFoundError` for paths that are not present
     on disk, crashing symbol tools when a language server reported locations of generated files
     (e.g. JDTLS reporting Lombok-generated classes under `target/classes`). Missing paths are now

--- a/src/solidlsp/language_servers/pyright_server.py
+++ b/src/solidlsp/language_servers/pyright_server.py
@@ -16,6 +16,7 @@ from solidlsp.settings import SolidLSPSettings
 log = logging.getLogger(__name__)
 
 PYRIGHT_VERSION = "1.1.403"
+PYRIGHT_INITIAL_ANALYSIS_TIMEOUT = 60.0
 
 
 class PyrightServer(SolidLanguageServer):
@@ -102,6 +103,12 @@ class PyrightServer(SolidLanguageServer):
             },
         }
         return initialize_params
+
+    def _wait_for_initial_analysis(self, timeout: float = PYRIGHT_INITIAL_ANALYSIS_TIMEOUT) -> None:
+        if self.analysis_complete.wait(timeout=timeout):
+            log.info("Pyright initial analysis complete, server ready")
+        else:
+            log.warning("Timeout waiting for Pyright analysis completion, proceeding anyway")
 
     def _start_server(self) -> None:
         """
@@ -232,9 +239,4 @@ class PyrightServer(SolidLanguageServer):
         # Wait for Pyright to complete its initial workspace analysis
         # This prevents zombie processes by ensuring background tasks finish
         log.info("Waiting for Pyright to complete initial workspace analysis...")
-        if self.analysis_complete.wait(timeout=5.0):
-            log.info("Pyright initial analysis complete, server ready")
-        else:
-            log.warning("Timeout waiting for Pyright analysis completion, proceeding anyway")
-            # Fallback: assume analysis is complete after timeout
-            self.analysis_complete.set()
+        self._wait_for_initial_analysis()

--- a/test/solidlsp/python/test_pyright_readiness.py
+++ b/test/solidlsp/python/test_pyright_readiness.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+from solidlsp.language_servers.pyright_server import PyrightServer
+
+
+def test_analysis_timeout_does_not_mark_analysis_complete() -> None:
+    server = object.__new__(PyrightServer)
+    server.analysis_complete = Mock()
+    server.analysis_complete.wait.return_value = False
+
+    server._wait_for_initial_analysis(timeout=0)
+
+    server.analysis_complete.wait.assert_called_once_with(timeout=0)
+    server.analysis_complete.set.assert_not_called()


### PR DESCRIPTION
## Summary

- increase Pyright's initial-analysis wait from 5 to 60 seconds for large workspaces
- stop permanently marking analysis complete when the safety timeout expires
- retain later progress and quiescent notifications as truthful readiness signals
- add a regression test and changelog entry

Closes #1681.

## Validation

- `uv run pytest test/solidlsp/python/test_pyright_readiness.py -q`
- `uv run ruff check src/solidlsp/language_servers/pyright_server.py test/solidlsp/python/test_pyright_readiness.py`
- `uv run ruff format --check src/solidlsp/language_servers/pyright_server.py test/solidlsp/python/test_pyright_readiness.py`
- `uv run poe type-check`