### PR TITLE
fix(hooks): emit valid Codex cleanup output

### DIFF
--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -591,7 +591,15 @@ class HookCommands(AutoRegisteringGroup):
     @click.command("cleanup", help="Set this as hook at session end all hook data for the current session")
     @_client_option
     def cleanup(client: str) -> None:
-        SessionEndCleanupHook(HookClient(client)).execute()
+        hook_client = HookClient(client)
+        try:
+            SessionEndCleanupHook(hook_client).execute()
+        except Exception as exc:
+            if hook_client != HookClient.CODEX:
+                raise
+            click.echo(f"Serena cleanup failed: {exc}", err=True)
+        if hook_client == HookClient.CODEX:
+            click.echo(json.dumps({"continue": True}))
 
     @staticmethod
     @click.command(

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -693,6 +693,27 @@ class TestHookCli:
         assert result.exit_code == 0
         assert not session_dir.exists()
 
+    def test_codex_cleanup_emits_valid_stop_hook_json(self, tmp_path: Path):
+        runner = CliRunner()
+        stdin_json = json.dumps({"session_id": "codex-cleanup"})
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            result = runner.invoke(hook_commands, ["cleanup", "--client", "codex"], input=stdin_json)
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {"continue": True}
+
+    def test_codex_cleanup_without_session_id_still_emits_valid_json(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            hook_commands,
+            ["cleanup", "--client", "codex"],
+            input=json.dumps({"stop_hook_active": False}),
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {"continue": True}
+        assert "Session ID is required" in result.stderr
+
     def test_remind_command(self, tmp_path: Path):
         """Invoke the remind command enough times to trigger a deny."""
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- emit the Codex Stop-hook success object after cleanup
- keep cleanup diagnostics on stderr so stdout remains parseable JSON
- return valid JSON even when Codex input lacks a session ID
- preserve existing behavior for all other hook clients

Closes #1533

## Verification
- uv run pytest test/serena/test_hooks.py::TestHookCli::test_cleanup_command test/serena/test_hooks.py::TestHookCli::test_codex_cleanup_emits_valid_stop_hook_json test/serena/test_hooks.py::TestHookCli::test_codex_cleanup_without_session_id_still_emits_valid_json -q (3 passed)
- uv run ruff check src/serena/hooks.py test/serena/test_hooks.py
- uv run ruff format --check src/serena/hooks.py test/serena/test_hooks.py
- uv run ty check src/serena/hooks.py
- git diff --check