### PR TITLE
fix: normalize line endings in read_file's charset_normalizer fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Status of the `main` branch. Changes prior to the next official version change will appear here.
 
+* General:
+  - Fix: `FileUtils.read_file`'s `charset_normalizer` fallback (used when a file cannot be decoded with
+    the project's configured `encoding`) decoded the raw bytes directly and therefore skipped the
+    universal-newline translation that the primary read path applies. CR characters from disk thus
+    reached Serena's in-memory file contents, where the rest of the code assumes LF-normalized text and
+    the `line_ending` setting is meant to be the single point of line-ending translation on write. The
+    fallback now normalizes line endings to LF, consistently with the primary path.
+
 # v1.6.0 (2026-07-16)
 
 * General:

--- a/src/solidlsp/ls_utils.py
+++ b/src/solidlsp/ls_utils.py
@@ -380,6 +380,9 @@ class FileUtils:
         Reads the file at the given path using the given encoding and returns the contents as a string.
         If decoding fails, tries to detect the encoding using charset_normalizer.
 
+        Line endings are normalized to LF (universal newlines), irrespective of the encoding
+        used to decode the file.
+
         Raises FileNotFoundError if the file does not exist.
         """
         if not os.path.exists(file_path):
@@ -396,7 +399,10 @@ class FileUtils:
                     log.warning(
                         f"Could not decode {file_path} with encoding='{encoding}'; using best match '{match.encoding}' instead",
                     )
-                    return match.raw.decode(match.encoding)
+                    # Decoding the raw bytes bypasses the universal-newline translation that the
+                    # open() call above applies, so normalize explicitly to keep both paths equivalent.
+                    decoded = match.raw.decode(match.encoding)
+                    return decoded.replace("\r\n", "\n").replace("\r", "\n")
                 raise ude
         except Exception as exc:
             log.error(f"Failed to read '{file_path}' with encoding '{encoding}': {exc}")

--- a/test/solidlsp/util/test_ls_utils.py
+++ b/test/solidlsp/util/test_ls_utils.py
@@ -49,8 +49,8 @@ def test_download_file_verified_writes_decoded_response_body(tmp_path: Path) -> 
 # and the content is long enough for encoding detection to be reliable.
 _CP1252_LINES = [
     "# -*- coding: cp1252 -*-",
-    "# Autor: José Fernández",
-    "# Copyright (c) 2019 Müller & Söhne GmbH. Alle Rechte vorbehalten.",
+    "# Author: José Fernández",
+    "# Copyright (c) 2019 Müller & Söhne GmbH.",
     "",
     "import os",
     "",

--- a/test/solidlsp/util/test_ls_utils.py
+++ b/test/solidlsp/util/test_ls_utils.py
@@ -4,6 +4,8 @@ import hashlib
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from solidlsp.ls_utils import FileUtils
 
 
@@ -40,3 +42,65 @@ def test_download_file_verified_writes_decoded_response_body(tmp_path: Path) -> 
         )
 
     assert target_path.read_bytes() == payload
+
+
+# A file that cannot be decoded with the project encoding, forcing read_file's
+# charset_normalizer fallback. The accented characters make the bytes invalid UTF-8,
+# and the content is long enough for encoding detection to be reliable.
+_CP1252_LINES = [
+    "# -*- coding: cp1252 -*-",
+    "# Autor: José Fernández",
+    "# Copyright (c) 2019 Müller & Söhne GmbH. Alle Rechte vorbehalten.",
+    "",
+    "import os",
+    "",
+    "",
+    "class ConfiguracionBasica:",
+    '    """Clase de configuración para el módulo de facturación."""',
+    "",
+    "    def __init__(self, nombre, valor=None):",
+    "        self.nombre = nombre",
+    "        self.valor = valor",
+    "",
+    "    def describir(self):",
+    '        return f"{self.nombre}: {self.valor}"',
+]
+
+
+def test_read_file_fallback_normalizes_crlf(tmp_path: Path) -> None:
+    """The charset_normalizer fallback should apply universal newlines, just like the primary path."""
+    file_path = tmp_path / "config_cp1252.py"
+    file_path.write_bytes(("\r\n".join(_CP1252_LINES) + "\r\n").encode("cp1252"))
+
+    # guard against a vacuous test: the fixture must actually force the fallback
+    with pytest.raises(UnicodeDecodeError):
+        file_path.read_text(encoding="utf-8")
+
+    content = FileUtils.read_file(str(file_path), "utf-8")
+
+    assert "José Fernández" in content, "fallback should decode the file as cp1252"
+    assert "\r" not in content
+    assert content.splitlines() == _CP1252_LINES
+
+
+def test_read_file_fallback_normalizes_lone_cr(tmp_path: Path) -> None:
+    """Old-style lone CR separators should be normalized by the fallback as well."""
+    file_path = tmp_path / "lone_cr_cp1252.py"
+    file_path.write_bytes(("\r".join(_CP1252_LINES) + "\r").encode("cp1252"))
+
+    content = FileUtils.read_file(str(file_path), "utf-8")
+
+    assert "\r" not in content
+    assert content.splitlines() == _CP1252_LINES
+
+
+def test_read_file_primary_path_normalizes_crlf(tmp_path: Path) -> None:
+    """Control: the primary open() path already normalizes; both paths must agree."""
+    lines = ["import os", "", "def f():", "    return 1"]
+    file_path = tmp_path / "config_utf8.py"
+    file_path.write_bytes(("\r\n".join(lines) + "\r\n").encode("utf-8"))
+
+    content = FileUtils.read_file(str(file_path), "utf-8")
+
+    assert "\r" not in content
+    assert content.splitlines() == lines


### PR DESCRIPTION
## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.

## Problem

`FileUtils.read_file` has two return paths with different newline semantics:

- **Primary** (`ls_utils.py:390`): `open(file_path, encoding=encoding).read()` uses the default `newline=None`, so universal newlines apply and CR never reaches callers.
- **Fallback** (`ls_utils.py:399`, added in #682): `match.raw.decode(match.encoding)` decodes raw bytes, which performs no newline translation.

So a file that fails to decode with the project's configured `encoding` re-enters Serena carrying its CR characters, while an otherwise identical file that decodes cleanly does not. The rest of the code assumes in-memory content is LF-normalized and that the `line_ending` setting (#1139) is the single point of line-ending translation on write. Both writers depend on that: `code_editor.py:89` (`open(..., newline=self.newline)`) and `file_tools.py:87` (`write_text(..., newline=...)`).

The path is reachable through normal editing: `ls.py:164` fills `LSPFileBuffer._contents` from `read_file`, `code_editor.py:265` returns that buffer as the edited file's contents, and `_save_edited_file` writes it back with `newline=self.newline`. Editing a symbol in a non-UTF-8 file therefore rewrites the whole file through a second translation. The affected population (legacy Windows/cp1252 codebases with mixed encodings) is the one that motivated both #682 and #1139.

## Fix

Normalize to LF at the fallback's return, so both paths agree. One line at one return path, no new helper and no change to encoding detection or to the write side.

## Verification

Run in a clean `python:3.11-slim` container against HEAD `063f872a`, with the imported module's sha256 checked against the repo file (provenance match confirmed):

```
python -m pytest test/solidlsp/util/test_ls_utils.py -q
```

- On this branch: `4 passed`.
- With only `src/solidlsp/ls_utils.py` reverted to main and the new tests kept: `2 failed, 2 passed`. The two failures are the new fallback tests; `test_read_file_primary_path_normalizes_crlf` passes on main by design, since it pins the primary path's existing behaviour that the fallback is being aligned to.
- `ruff check` and `ruff format --check` clean on both changed files.
- The fixture is deliberately a realistic cp1252 file rather than a few bytes, because encoding detection is unreliable on very short inputs, and the test asserts the fixture is undecodable as UTF-8 so it cannot silently stop exercising the fallback.

Measured in the same container before the fix, composing the fallback's output with the real writer call shape and the actual `LineEnding.*.newline_str` values: with `line_ending: lf` the 22 CRLF pairs survived unchanged (the setting had no effect), and with `line_ending: crlf` they became `\r\r\n`. Those two outcomes are what the fix prevents, but they are not pinned by a shipped test: the tests here pin the read-side normalization only.

Not verified: behaviour on Windows. `line_ending: native` resolves to `os.linesep`, so on Windows it should double identically to the `crlf` case, but this box is Linux (`os.linesep == '\n'`) and I did not test that.

Disclosure: this patch was prepared with AI assistance. The reproduction, the differential test run and the reachability trace above were executed, not inferred.
