### PR TITLE
fix(search): do not mark the following line as matched when a match ends at a line break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Status of the `main` branch. Changes prior to the next official version change w
     the `line_ending` setting is meant to be the single point of line-ending translation on write. The
     fallback now normalizes line endings to LF, consistently with the primary path.
 
+* Tools:
+  - Fix: `search_for_pattern` marked one line too many as matched whenever a match ended with a line
+    break, because the match's exclusive end index was mapped to a line number directly and therefore
+    resolved to the start of the following line. The line the match ends on is now determined correctly,
+    which also keeps `context_lines_after` aligned.
+
 * JetBrains:
   - Allow external files from dependencies (specified via references like "<ext:FileUtil.class|472e0a13>") to be
     - read via `ReadFileTool` 

--- a/src/serena/util/text_utils.py
+++ b/src/serena/util/text_utils.py
@@ -187,6 +187,10 @@ def search_text(
         # Find the line numbers for the start and end positions
         start_line_num = TextUtils.get_line_from_index(content, start_pos)
         end_line_num = TextUtils.get_line_from_index(content, end_pos)
+        if end_line_num > start_line_num and TextUtils.get_line_col_from_index(content, end_pos)[1] == 0:
+            # `end_pos` is exclusive, so if it is at the start of a line, the match ends with the
+            # preceding line's newline and does not extend into the line that `end_pos` points to
+            end_line_num -= 1
 
         # Calculate the range of lines to include in the context
         context_start = max(0, start_line_num - context_lines_before)

--- a/test/serena/test_text_utils.py
+++ b/test/serena/test_text_utils.py
@@ -103,6 +103,55 @@ class TestSearchText:
         assert "return a * c" in first_match.lines[1].line_content
         assert "elif b > a:" in first_match.lines[2].line_content
 
+    @pytest.mark.parametrize(
+        ("pattern", "expected_matched_lines"),
+        [
+            # matches ending with a newline: the trailing newline terminates the last matched line
+            # and must not pull in the line that follows
+            (r"alpha\n", [0]),
+            (r"alpha\nbeta\n", [0, 1]),
+            (r"gamma\n", [2]),
+            # controls: matches ending mid-line were always correct
+            (r"alpha", [0]),
+            (r"beta", [1]),
+            (r"alpha\nbeta", [0, 1]),
+        ],
+    )
+    def test_search_text_match_ending_at_line_break(self, pattern: str, expected_matched_lines: list[int]):
+        """The lines marked as matched are exactly the lines the matched text occupies."""
+        content = "alpha\nbeta\ngamma\n"
+
+        matches = search_text(pattern, content=content)
+
+        assert len(matches) == 1
+        matched_lines = [line.line_number for line in matches[0].lines if line.match_type == LineType.MATCH]
+        assert matched_lines == expected_matched_lines
+        assert matches[0].num_matched_lines == len(expected_matched_lines)
+
+    @pytest.mark.parametrize(
+        ("pattern", "expected_matched_lines"),
+        [
+            (r"alpha\r\n", [0]),
+            (r"alpha\r", [0]),
+            (r"alpha\r\nbeta\r\n", [0, 1]),
+            (r"alpha", [0]),
+        ],
+    )
+    def test_search_text_match_ending_at_line_break_crlf(self, pattern: str, expected_matched_lines: list[int]):
+        """As above for CRLF content, where the end index can fall inside the two-character line break.
+
+        The content is passed directly rather than read from a file, since the file read paths translate
+        line endings and CR would not reach this function.
+        """
+        content = "alpha\r\nbeta\r\ngamma\r\n"
+
+        matches = search_text(pattern, content=content)
+
+        assert len(matches) == 1
+        matched_lines = [line.line_number for line in matches[0].lines if line.match_type == LineType.MATCH]
+        assert matched_lines == expected_matched_lines
+        assert matches[0].num_matched_lines == len(expected_matched_lines)
+
     def test_search_text_with_multiline_match(self):
         """Test searching with multiline pattern matching."""
         content = """


### PR DESCRIPTION
## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.

## Problem

`search_text` (`text_utils.py:189`) resolves the end of a match to a line number with:

```python
end_line_num = TextUtils.get_line_from_index(content, end_pos)
```

`end_pos` is `match.end()`, which is **exclusive**, but `get_line_from_index` maps an index to the line that index *points at*. When a match ends with a line break, `end_pos` is the start of the next line, so `get_line_from_index` returns that next line.

`end_line_num` is then consumed inclusively (`:200`, `elif end_line_num < line_num <= context_end`, so anything up to and including `end_line_num` falls through to `LineType.MATCH`), and `context_end` is computed from the same inflated number (`:193`), which shifts `context_lines_after` by one as well.

Effect, on `content = "alpha\nbeta\ngamma\n"`:

| pattern | lines marked `MATCH` | matched text actually occupies |
|---|---|---|
| `alpha\n` | 0, 1 | 0 |
| `alpha\nbeta\n` | 0, 1, 2 | 0, 1 |
| `alpha` (control) | 0 | 0 |

`to_display_string()` renders the extra line with the `>` matched-line prefix, so `search_for_pattern` presents a real, unmatched line as part of the match:

```
  >   0:alpha
  >   1:beta
```

`multiline=True` is the tool default, so `re.DOTALL | re.MULTILINE` is on and patterns ending in `\n` are reachable through normal use.

This predates #1691. The previous code (`content[:end_pos].count("\n")`) had the identical off-by-one, so 97c9b8c0 preserved the behaviour rather than introducing it.

## Fix

Two lines at the call site. `TextUtils` is untouched, since the exclusive-end convention belongs to this caller and not to the shared helper.

The `col == 0` test is deliberate and is not equivalent to inspecting `end_pos - 1`: for CRLF content, `end_pos - 1` lands *inside* the `\r\n` pair, which `get_line_col_from_index` maps to the following line by design, which would reintroduce the same bug. Measured on the branch:

```
get_line_col_from_index("alpha\r\nbeta\r\n...", 5) = (0, 5)   # the \r
get_line_col_from_index("alpha\r\nbeta\r\n...", 6) = (1, 0)   # inside the \r\n pair
get_line_col_from_index("alpha\r\nbeta\r\n...", 7) = (1, 0)   # start of "beta"
```

The `end_line_num > start_line_num` guard leaves single-line and empty matches alone.

## Verification

Run in a clean `python:3.11-slim` container against HEAD `c7ee15c0`, with the imported module's sha256 checked against the repo file (provenance match confirmed: `b6e306c1927283e7` for main, `fe7e89cfe77e3401` for the branch).

```
python -m pytest test/serena/test_text_utils.py -q
```

- On this branch: `89 passed`.
- With only `src/serena/util/text_utils.py` reverted to main and the new tests kept: `6 failed, 4 passed`. The 6 failures are the newline cases (3 LF, 3 CRLF); the 4 mid-line controls pass on main by design, since they pin behaviour that was already correct and that this change must not alter.
- `ruff format --check` / `ruff check` (pinned `ruff==0.12.5`), `codespell`, and `ty check` on `src` and `test`: all exit 0.

The CRLF cases pass the content as a string rather than through a file fixture, because `FileUtils.read_file`'s primary path opens with `newline=None` and CR would never reach this function from disk. They cover the direct-string callers, which is where CR can actually arrive.

Scope of the claim: `search_text` and `search_files` are the only callers of this code (`search_files` at `text_utils.py:334`, and `project.py:417` in turn calls that), so the change reaches `search_for_pattern` and nothing else.

Not verified: I did not run the full language-server test matrix locally, only `test/serena/test_text_utils.py` and the lint, spelling and type gates above.

Related but deliberately left out of this PR: `MultiFileContentReplacer.find_occurrences` (`text_utils.py:583`) computes its line numbers with `content.count("\n", 0, match.end())` and has the same exclusive-end issue. There it only feeds a `lines X-Y` header label in `render_occurrence_diff`, and the diff slicing uses raw offsets, so the effect looks cosmetic. Happy to send that separately if you want it fixed.

Disclosure: this patch was prepared with AI assistance. The reproduction, the differential test run and the CRLF probe above were executed, not inferred.
