### PR TITLE
PHP: expose file_filter via ls_specific_settings (#1710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Status of the `main` branch. Changes prior to the next official version change w
     numbers, so agents can pick the right match without re-reading files. #1640
 
 * Language Servers:
+  - PHP: treat `.phtml` files as PHP sources by default (all PHP language servers) #1710
   - PHP/Intelephense: expose `file_filter` via `ls_specific_settings["php"]`, so that additional
     extensions containing PHP sources (e.g. Drupal's `.module` / `.install` / `.inc` / `.theme`)
     become visible to the symbol tools and are indexed by the language server #1710

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Status of the `main` branch. Changes prior to the next official version change w
     it fits, otherwise truncated with a trailing '...' and a note) before falling back to bare line
     numbers, so agents can pick the right match without re-reading files. #1640
 
+* Language Servers:
+  - PHP/Intelephense: expose `file_filter` via `ls_specific_settings["php"]`, so that additional
+    extensions containing PHP sources (e.g. Drupal's `.module` / `.install` / `.inc` / `.theme`)
+    become visible to the symbol tools and are indexed by the language server #1710
+
 * JetBrains:
   - Allow external files from dependencies (specified via references like "<ext:FileUtil.class|472e0a13>") to be
     - read via `ReadFileTool` 

--- a/docs/02-usage/050_configuration.md
+++ b/docs/02-usage/050_configuration.md
@@ -913,6 +913,19 @@ Supported settings:
 | `ignore_vendor` | `true` | Ignore directories named `vendor` while indexing the project. |
 | `maxFileSize` | unset | Forwarded as `intelephense.files.maxSize` in `initializationOptions`. |
 | `maxMemory` | unset | Forwarded as `intelephense.maxMemory` in `initializationOptions`. |
+| `file_filter` | `[".php"]` | File extensions (with leading dot) to treat as PHP sources, e.g. `[".php", ".phtml", ".module"]` (#1710). |
+
+Example configuration making Drupal source files visible to the symbol tools:
+
+```yaml
+ls_specific_settings:
+  php:
+    file_filter: [".php", ".phtml", ".module", ".install", ".inc", ".theme", ".profile", ".engine"]
+```
+
+Notes:
+- Extensions added via `file_filter` are also synced into Serena's PHP source-file matcher, so `find_symbol` and symbol indexing treat the same files as the language server. A custom list is additionally pushed to Intelephense as `intelephense.files.associations` globs and fully defines what the server indexes, so keep `.php` (and `.phtml` if you use it) in the list. Defaults are unchanged when the key is omitted.
+- The matcher is reset on every language server activation, so one project's `file_filter` does not leak into another.
 
 #### PHP (`Phpactor`)
 

--- a/docs/02-usage/050_configuration.md
+++ b/docs/02-usage/050_configuration.md
@@ -913,18 +913,18 @@ Supported settings:
 | `ignore_vendor` | `true` | Ignore directories named `vendor` while indexing the project. |
 | `maxFileSize` | unset | Forwarded as `intelephense.files.maxSize` in `initializationOptions`. |
 | `maxMemory` | unset | Forwarded as `intelephense.maxMemory` in `initializationOptions`. |
-| `file_filter` | `[".php"]` | File extensions (with leading dot) to treat as PHP sources, e.g. `[".php", ".phtml", ".module"]` (#1710). |
+| `file_filter` | unset | Additional file extensions (with leading dot) to treat as PHP sources, e.g. `[".module", ".install"]`; added to the defaults `.php` / `.phtml` (#1710). |
 
 Example configuration making Drupal source files visible to the symbol tools:
 
 ```yaml
 ls_specific_settings:
   php:
-    file_filter: [".php", ".phtml", ".module", ".install", ".inc", ".theme", ".profile", ".engine"]
+    file_filter: [".module", ".install", ".inc", ".theme", ".profile", ".engine"]
 ```
 
 Notes:
-- Extensions added via `file_filter` are also synced into Serena's PHP source-file matcher, so `find_symbol` and symbol indexing treat the same files as the language server. A custom list is additionally pushed to Intelephense as `intelephense.files.associations` globs and fully defines what the server indexes, so keep `.php` (and `.phtml` if you use it) in the list. Defaults are unchanged when the key is omitted.
+- Extensions added via `file_filter` are synced into Serena's PHP source-file matcher and pushed to Intelephense as `intelephense.files.associations` globs at startup, so `find_symbol` and the language server treat the same files as PHP sources.
 - The matcher is reset on every language server activation, so one project's `file_filter` does not leak into another.
 
 #### PHP (`Phpactor`)

--- a/src/solidlsp/language_servers/intelephense.py
+++ b/src/solidlsp/language_servers/intelephense.py
@@ -10,7 +10,7 @@ from time import sleep
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import Language, LanguageServerConfig
+from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_utils import PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import Definition, DefinitionParams, DidChangeConfigurationParams, LocationLink
 from solidlsp.settings import SolidLSPSettings
@@ -26,13 +26,6 @@ log = logging.getLogger(__name__)
 INITIAL_INTELEPHENSE_VERSION = "1.14.4"
 DEFAULT_INTELEPHENSE_VERSION = "1.14.4"
 
-# Default file extensions treated as PHP sources. Exposed for override via
-# `ls_specific_settings["php"]` (key `file_filter`). Extensions added via `file_filter` are also
-# synced into Language.PHP.get_source_fn_matcher() (a cached singleton) and, when customized,
-# pushed to Intelephense as `intelephense.files.associations` globs, so Serena's symbol index and
-# the language server agree on which files are PHP sources (#1710).
-_DEFAULT_FILE_FILTER: list[str] = [".php"]
-
 
 class Intelephense(SolidLanguageServer):
     """
@@ -42,11 +35,11 @@ class Intelephense(SolidLanguageServer):
         - maxMemory: sets intelephense.maxMemory
         - maxFileSize: sets intelephense.files.maxSize
         - ignore_vendor: whether or ignore directories named "vendor" (default: true)
-        - file_filter: list of file extensions (with leading dot) to treat as PHP sources,
-          e.g. [".php", ".phtml", ".module"]. Defaults to [".php"]. The extensions are added to
-          Serena's PHP source-file matcher and a custom list is pushed to Intelephense as
-          intelephense.files.associations globs, so find_symbol and the language server treat
-          the same files as PHP sources (see #1710).
+        - file_filter: list of additional file extensions (with leading dot) to treat as PHP
+          sources, e.g. [".module", ".inc"]. The extensions are added to the defaults (".php",
+          ".phtml") of Serena's PHP source-file matcher and are pushed to Intelephense via
+          files.associations, such that the symbol tools and the language server treat the
+          same files as PHP sources (see #1710).
     """
 
     @override
@@ -105,42 +98,6 @@ class Intelephense(SolidLanguageServer):
         def _create_launch_command(self, core_path: str) -> list[str]:
             return [core_path, "--stdio"]
 
-    @staticmethod
-    def _resolve_file_filter(solidlsp_settings: SolidLSPSettings) -> list[str]:
-        """Resolve the file extensions to treat as PHP sources.
-
-        Reads an optional override from ``ls_specific_settings["php"]`` (key ``file_filter``);
-        falls back to the default otherwise. Extracted as a pure function so the configuration
-        plumbing can be unit-tested without starting the language server.
-        """
-        php_settings = solidlsp_settings.get_ls_specific_settings(Language.PHP)
-        return php_settings.get("file_filter", list(_DEFAULT_FILE_FILTER))
-
-    @staticmethod
-    def _sync_source_fn_matcher(file_filter: list[str]) -> None:
-        """Keep Serena's PHP source-file matcher in sync with the configured ``file_filter``.
-
-        ``Language.PHP.get_source_fn_matcher()`` is a ``@cache``d per-language singleton, so adding
-        the configured extensions here propagates to every consumer of the matcher - symbol index
-        traversal, ignore checks, and language composition detection. Without this, ``find_symbol``
-        would not surface symbols in files whose extensions were added to ``file_filter`` (#1710).
-        """
-        Language.PHP.get_source_fn_matcher().add_extensions(*file_filter)
-
-    @staticmethod
-    def _resolve_files_associations(file_filter: list[str]) -> list[str] | None:
-        """The ``intelephense.files.associations`` globs to push for ``file_filter``, or ``None``.
-
-        Returns ``None`` for the default filter: the pushed list replaces Intelephense's built-in
-        associations (``["*.php", "*.phtml"]``), so pushing globs derived from ``[".php"]`` would
-        silently drop ``*.phtml`` indexing and change default behavior (unlike Perl::LanguageServer,
-        whose defaults match Serena's and allow an unconditional push). A customized filter is
-        pushed and fully defines what the server indexes (#1710).
-        """
-        if file_filter == _DEFAULT_FILE_FILTER:
-            return None
-        return [f"*{ext}" for ext in file_filter]
-
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
         super().__init__(config, repository_root_path, None, "php", solidlsp_settings)
         self.request_id = 0
@@ -154,10 +111,11 @@ class Intelephense(SolidLanguageServer):
             self._ignored_dirnames.add("vendor")
         log.info(f"Ignoring the following directories for PHP projects: {', '.join(sorted(self._ignored_dirnames))}")
 
-        self._file_filter = self._resolve_file_filter(solidlsp_settings)
-        # Sync Serena's source-file matcher with the configured extensions so find_symbol and the
-        # language server agree on which files are PHP sources (see #1710).
-        self._sync_source_fn_matcher(self._file_filter)
+        # extend the source-file matcher with any additional extensions configured via `file_filter`,
+        # such that Serena's symbol tools treat the added extensions as PHP sources as well (#1710)
+        file_filter = self._custom_settings.get("file_filter")
+        if file_filter:
+            self.language.get_source_fn_matcher().add_extensions(*file_filter)
 
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
         return self.DependencyProvider(self._custom_settings, self._ls_resources_dir)
@@ -237,24 +195,16 @@ class Intelephense(SolidLanguageServer):
 
         self.server.notify.initialized({})
 
-        associations = self._resolve_files_associations(self._file_filter)
-        if associations is not None:
-            # Intelephense only indexes files matching its `files.associations` globs, so a custom
-            # file_filter must also be pushed to the server; otherwise cross-file features
-            # (references, definitions) would skip the extra files even though Serena's matcher
-            # accepts them (#1710). User-configured size/memory settings are carried along so the
-            # pushed section stays self-consistent regardless of the server's merge semantics.
-            files_settings: dict = {"associations": associations}
-            max_file_size = self._custom_settings.get("maxFileSize")
-            if max_file_size is not None:
-                files_settings["maxSize"] = max_file_size
-            intelephense_settings: dict = {"files": files_settings}
-            max_memory = self._custom_settings.get("maxMemory")
-            if max_memory is not None:
-                intelephense_settings["maxMemory"] = max_memory
-            intelephense_config: DidChangeConfigurationParams = {"settings": {"intelephense": intelephense_settings}}
-            log.info(f"Sending workspace/didChangeConfiguration with file associations: {associations}")
-            self.server.notify.workspace_did_change_configuration(intelephense_config)
+        # push the file associations derived from the source-file matcher (the default extensions
+        # plus any configured via `file_filter`), such that Intelephense indexes the same set of
+        # files that Serena's symbol tools treat as PHP sources (#1710). This cannot be passed in
+        # the initialize request: Intelephense reads configuration exclusively from
+        # workspace/didChangeConfiguration (its initializationOptions only cover storagePath,
+        # globalStoragePath, clearCache and licenceKey).
+        associations = [f"*{ext}" for ext in self.language.get_source_fn_matcher().file_extensions]
+        intelephense_config: DidChangeConfigurationParams = {"settings": {"intelephense": {"files": {"associations": associations}}}}
+        log.info(f"Sending workspace/didChangeConfiguration with file associations: {associations}")
+        self.server.notify.workspace_did_change_configuration(intelephense_config)
 
         # Intelephense server is typically ready immediately after initialization
         # TODO: This is probably incorrect; the server does send an initialized notification, which we could wait for!

--- a/src/solidlsp/language_servers/intelephense.py
+++ b/src/solidlsp/language_servers/intelephense.py
@@ -10,9 +10,9 @@ from time import sleep
 from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
-from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.ls_config import Language, LanguageServerConfig
 from solidlsp.ls_utils import PlatformId, PlatformUtils
-from solidlsp.lsp_protocol_handler.lsp_types import Definition, DefinitionParams, LocationLink
+from solidlsp.lsp_protocol_handler.lsp_types import Definition, DefinitionParams, DidChangeConfigurationParams, LocationLink
 from solidlsp.settings import SolidLSPSettings
 
 from ..lsp_protocol_handler import lsp_types
@@ -26,6 +26,13 @@ log = logging.getLogger(__name__)
 INITIAL_INTELEPHENSE_VERSION = "1.14.4"
 DEFAULT_INTELEPHENSE_VERSION = "1.14.4"
 
+# Default file extensions treated as PHP sources. Exposed for override via
+# `ls_specific_settings["php"]` (key `file_filter`). Extensions added via `file_filter` are also
+# synced into Language.PHP.get_source_fn_matcher() (a cached singleton) and, when customized,
+# pushed to Intelephense as `intelephense.files.associations` globs, so Serena's symbol index and
+# the language server agree on which files are PHP sources (#1710).
+_DEFAULT_FILE_FILTER: list[str] = [".php"]
+
 
 class Intelephense(SolidLanguageServer):
     """
@@ -35,6 +42,11 @@ class Intelephense(SolidLanguageServer):
         - maxMemory: sets intelephense.maxMemory
         - maxFileSize: sets intelephense.files.maxSize
         - ignore_vendor: whether or ignore directories named "vendor" (default: true)
+        - file_filter: list of file extensions (with leading dot) to treat as PHP sources,
+          e.g. [".php", ".phtml", ".module"]. Defaults to [".php"]. The extensions are added to
+          Serena's PHP source-file matcher and a custom list is pushed to Intelephense as
+          intelephense.files.associations globs, so find_symbol and the language server treat
+          the same files as PHP sources (see #1710).
     """
 
     @override
@@ -93,6 +105,28 @@ class Intelephense(SolidLanguageServer):
         def _create_launch_command(self, core_path: str) -> list[str]:
             return [core_path, "--stdio"]
 
+    @staticmethod
+    def _resolve_file_filter(solidlsp_settings: SolidLSPSettings) -> list[str]:
+        """Resolve the file extensions to treat as PHP sources.
+
+        Reads an optional override from ``ls_specific_settings["php"]`` (key ``file_filter``);
+        falls back to the default otherwise. Extracted as a pure function so the configuration
+        plumbing can be unit-tested without starting the language server.
+        """
+        php_settings = solidlsp_settings.get_ls_specific_settings(Language.PHP)
+        return php_settings.get("file_filter", list(_DEFAULT_FILE_FILTER))
+
+    @staticmethod
+    def _sync_source_fn_matcher(file_filter: list[str]) -> None:
+        """Keep Serena's PHP source-file matcher in sync with the configured ``file_filter``.
+
+        ``Language.PHP.get_source_fn_matcher()`` is a ``@cache``d per-language singleton, so adding
+        the configured extensions here propagates to every consumer of the matcher - symbol index
+        traversal, ignore checks, and language composition detection. Without this, ``find_symbol``
+        would not surface symbols in files whose extensions were added to ``file_filter`` (#1710).
+        """
+        Language.PHP.get_source_fn_matcher().add_extensions(*file_filter)
+
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
         super().__init__(config, repository_root_path, None, "php", solidlsp_settings)
         self.request_id = 0
@@ -105,6 +139,11 @@ class Intelephense(SolidLanguageServer):
         if self._custom_settings.get("ignore_vendor", True):
             self._ignored_dirnames.add("vendor")
         log.info(f"Ignoring the following directories for PHP projects: {', '.join(sorted(self._ignored_dirnames))}")
+
+        self._file_filter = self._resolve_file_filter(solidlsp_settings)
+        # Sync Serena's source-file matcher with the configured extensions so find_symbol and the
+        # language server agree on which files are PHP sources (see #1710).
+        self._sync_source_fn_matcher(self._file_filter)
 
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
         return self.DependencyProvider(self._custom_settings, self._ls_resources_dir)
@@ -183,6 +222,16 @@ class Intelephense(SolidLanguageServer):
         assert "documentSymbolProvider" in capabilities, "Server must support document symbols"
 
         self.server.notify.initialized({})
+
+        if self._file_filter != _DEFAULT_FILE_FILTER:
+            # Intelephense only indexes files matching its `files.associations` globs (default:
+            # ["*.php", "*.phtml"]), so a custom file_filter must also be pushed to the server;
+            # otherwise cross-file features (references, definitions) would skip the extra files
+            # even though Serena's matcher accepts them (#1710).
+            associations = [f"*{ext}" for ext in self._file_filter]
+            intelephense_config: DidChangeConfigurationParams = {"settings": {"intelephense": {"files": {"associations": associations}}}}
+            log.info(f"Sending workspace/didChangeConfiguration with file associations: {associations}")
+            self.server.notify.workspace_did_change_configuration(intelephense_config)
 
         # Intelephense server is typically ready immediately after initialization
         # TODO: This is probably incorrect; the server does send an initialized notification, which we could wait for!

--- a/src/solidlsp/language_servers/intelephense.py
+++ b/src/solidlsp/language_servers/intelephense.py
@@ -127,6 +127,20 @@ class Intelephense(SolidLanguageServer):
         """
         Language.PHP.get_source_fn_matcher().add_extensions(*file_filter)
 
+    @staticmethod
+    def _resolve_files_associations(file_filter: list[str]) -> list[str] | None:
+        """The ``intelephense.files.associations`` globs to push for ``file_filter``, or ``None``.
+
+        Returns ``None`` for the default filter: the pushed list replaces Intelephense's built-in
+        associations (``["*.php", "*.phtml"]``), so pushing globs derived from ``[".php"]`` would
+        silently drop ``*.phtml`` indexing and change default behavior (unlike Perl::LanguageServer,
+        whose defaults match Serena's and allow an unconditional push). A customized filter is
+        pushed and fully defines what the server indexes (#1710).
+        """
+        if file_filter == _DEFAULT_FILE_FILTER:
+            return None
+        return [f"*{ext}" for ext in file_filter]
+
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
         super().__init__(config, repository_root_path, None, "php", solidlsp_settings)
         self.request_id = 0
@@ -223,13 +237,22 @@ class Intelephense(SolidLanguageServer):
 
         self.server.notify.initialized({})
 
-        if self._file_filter != _DEFAULT_FILE_FILTER:
-            # Intelephense only indexes files matching its `files.associations` globs (default:
-            # ["*.php", "*.phtml"]), so a custom file_filter must also be pushed to the server;
-            # otherwise cross-file features (references, definitions) would skip the extra files
-            # even though Serena's matcher accepts them (#1710).
-            associations = [f"*{ext}" for ext in self._file_filter]
-            intelephense_config: DidChangeConfigurationParams = {"settings": {"intelephense": {"files": {"associations": associations}}}}
+        associations = self._resolve_files_associations(self._file_filter)
+        if associations is not None:
+            # Intelephense only indexes files matching its `files.associations` globs, so a custom
+            # file_filter must also be pushed to the server; otherwise cross-file features
+            # (references, definitions) would skip the extra files even though Serena's matcher
+            # accepts them (#1710). User-configured size/memory settings are carried along so the
+            # pushed section stays self-consistent regardless of the server's merge semantics.
+            files_settings: dict = {"associations": associations}
+            max_file_size = self._custom_settings.get("maxFileSize")
+            if max_file_size is not None:
+                files_settings["maxSize"] = max_file_size
+            intelephense_settings: dict = {"files": files_settings}
+            max_memory = self._custom_settings.get("maxMemory")
+            if max_memory is not None:
+                intelephense_settings["maxMemory"] = max_memory
+            intelephense_config: DidChangeConfigurationParams = {"settings": {"intelephense": intelephense_settings}}
             log.info(f"Sending workspace/didChangeConfiguration with file associations: {associations}")
             self.server.notify.workspace_did_change_configuration(intelephense_config)
 

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -42,6 +42,13 @@ class FilenameMatcher:
         """
         self._file_extensions = list(self._initial_file_extensions)
 
+    @property
+    def file_extensions(self) -> list[str]:
+        """The file extensions currently registered with this matcher, including any added via
+        :meth:`add_extensions`. Returned as a copy.
+        """
+        return list(self._file_extensions)
+
     def add_extensions(self, *file_extensions: str) -> None:
         """
         Add further file extensions to this matcher (idempotent).
@@ -448,7 +455,8 @@ class Language(str, Enum):
             case self.DART:
                 return FilenameMatcher(".dart")
             case self.PHP | self.PHP_PHPACTOR | self.PHP_PHPANTOM:
-                return FilenameMatcher(".php")
+                # .phtml is a standard (yet outdated) extension for PHP sources
+                return FilenameMatcher(".php", ".phtml")
             case self.R:
                 return FilenameMatcher(".R", ".r", ".Rmd", ".Rnw")
             case self.PERL:

--- a/test/resources/repos/php/test_repo/drupal_module.module
+++ b/test/resources/repos/php/test_repo/drupal_module.module
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Drupal-style module file: ordinary PHP kept in a non-.php extension.
+ *
+ * Only visible to the symbol tools when ls_specific_settings["php"]["file_filter"] includes
+ * ".module" (see #1710); inert for all tests running with default settings.
+ */
+
+/**
+ * Implements hook_help().
+ */
+function drupal_module_help($route_name) {
+    return 'Help for ' . $route_name;
+}
+
+/**
+ * Implements hook_cron().
+ */
+function drupal_module_cron() {
+    helperFunction();
+}
+
+class DrupalModuleController {
+    public function build(): string {
+        return drupal_module_help('help.page.drupal_module');
+    }
+}

--- a/test/solidlsp/php/test_php_config.py
+++ b/test/solidlsp/php/test_php_config.py
@@ -58,6 +58,24 @@ class TestResolveFileFilter:
         assert ".module" not in _DEFAULT_FILE_FILTER
 
 
+class TestResolveFilesAssociations:
+    def test_default_filter_is_not_pushed(self) -> None:
+        # Pushing globs derived from the default filter would replace Intelephense's built-in
+        # associations ["*.php", "*.phtml"] and silently drop .phtml indexing, changing default
+        # behavior; the push must stay gated off for default-configured sessions.
+        assert Intelephense._resolve_files_associations(list(_DEFAULT_FILE_FILTER)) is None
+
+    def test_explicitly_configured_default_is_not_pushed(self) -> None:
+        assert Intelephense._resolve_files_associations([".php"]) is None
+
+    def test_custom_filter_yields_globs(self) -> None:
+        assert Intelephense._resolve_files_associations([".php", ".phtml", ".module"]) == [
+            "*.php",
+            "*.phtml",
+            "*.module",
+        ]
+
+
 class TestSourceFnMatcherSync:
     def test_custom_file_filter_extends_php_matcher(self, tmp_path: Path) -> None:
         # #1710: find_symbol relies on Language.PHP.get_source_fn_matcher(); unless the configured
@@ -144,6 +162,16 @@ class TestFileFilterIntegration:
             Language.PHP,
             ls_specific_settings={Language.PHP: {"file_filter": [".php", ".module"]}},
         ) as ls:
+            # Layer 2 (files.associations push) must be asserted FIRST: the reference in the
+            # never-opened drupal_module.module can only come from the server's association-driven
+            # background index. request_full_symbol_tree below didOpens every matched file in the
+            # LS, after which this assertion could pass even without the push.
+            helper_php_path = str(get_repo_path(Language.PHP) / "helper.php")
+            references = ls.request_references(helper_php_path, 2, len("function "))
+            assert any(ref["uri"].endswith("drupal_module.module") for ref in references), (
+                f"helperFunction call in drupal_module.module not found in references: {references}"
+            )
+
             # Layer 1 (Serena's source matcher): the .module file takes part in symbol traversal.
             symbols = ls.request_full_symbol_tree()
             assert SymbolUtils.symbol_tree_contains_name(symbols, "drupal_module_help"), (
@@ -151,11 +179,4 @@ class TestFileFilterIntegration:
             )
             assert SymbolUtils.symbol_tree_contains_name(symbols, "DrupalModuleController"), (
                 "DrupalModuleController from drupal_module.module not found in the symbol tree"
-            )
-
-            # Layer 2 (files.associations push): cross-file features cover the .module file.
-            helper_php_path = str(get_repo_path(Language.PHP) / "helper.php")
-            references = ls.request_references(helper_php_path, 2, len("function "))
-            assert any(ref["uri"].endswith("drupal_module.module") for ref in references), (
-                f"helperFunction call in drupal_module.module not found in references: {references}"
             )

--- a/test/solidlsp/php/test_php_config.py
+++ b/test/solidlsp/php/test_php_config.py
@@ -1,0 +1,161 @@
+"""Configuration plumbing for ``Intelephense``'s ``file_filter``.
+
+Serena treats only ``.php`` files as PHP sources by default, while Drupal projects keep ordinary
+PHP in ``.module`` / ``.install`` / ``.inc`` / ``.theme`` / ``.profile`` / ``.engine`` files,
+which therefore stay invisible to ``find_symbol`` and friends. ``ls_specific_settings["php"]``
+now accepts a ``file_filter`` key mirroring the Perl mechanism from #1449 / #1642 (see #1710).
+
+The unit tests pin the configuration plumbing without starting the language server, so they run
+in every environment. They also cover the source-file matcher sync that keeps ``find_symbol``
+consistent with the LS. The integration test at the bottom starts a real Intelephense and is
+gated by the ``php`` marker like the rest of the PHP suite.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from solidlsp.language_servers.intelephense import _DEFAULT_FILE_FILTER, Intelephense
+from solidlsp.ls_config import Language
+from solidlsp.ls_utils import SymbolUtils
+from solidlsp.settings import SolidLSPSettings
+from test.conftest import get_repo_path, start_ls_context
+
+
+def _settings(tmp_path: Path, ls_specific_settings: dict | None = None) -> SolidLSPSettings:
+    """A SolidLSPSettings rooted under ``tmp_path`` with optional php overrides."""
+    return SolidLSPSettings(
+        solidlsp_dir=str(tmp_path / ".solidlsp"),
+        ls_specific_settings=ls_specific_settings or {},
+    )
+
+
+class TestResolveFileFilter:
+    def test_default_when_no_ls_specific_settings(self, tmp_path: Path) -> None:
+        # Behaviour unchanged for projects that don't set ls_specific_settings at all.
+        assert Intelephense._resolve_file_filter(_settings(tmp_path)) == _DEFAULT_FILE_FILTER
+
+    def test_default_when_php_key_absent(self, tmp_path: Path) -> None:
+        # ls_specific_settings configured for another language must not leak into PHP.
+        settings = _settings(tmp_path, {Language.PYTHON: {"something": "unrelated"}})
+
+        assert Intelephense._resolve_file_filter(settings) == _DEFAULT_FILE_FILTER
+
+    def test_custom_file_filter_returned(self, tmp_path: Path) -> None:
+        # #1710: a Drupal project must be able to surface .module / .install / ... files.
+        custom = [".php", ".phtml", ".module", ".install", ".inc", ".theme", ".profile", ".engine"]
+        settings = _settings(tmp_path, {Language.PHP: {"file_filter": custom}})
+
+        assert Intelephense._resolve_file_filter(settings) == custom
+
+    def test_default_list_is_not_mutated_across_calls(self, tmp_path: Path) -> None:
+        # The resolver must copy the module-level default, otherwise one instance mutating its
+        # returned list would corrupt every subsequently created default-configured instance.
+        file_filter = Intelephense._resolve_file_filter(_settings(tmp_path))
+        file_filter.append(".module")
+
+        assert Intelephense._resolve_file_filter(_settings(tmp_path)) == _DEFAULT_FILE_FILTER
+        assert ".module" not in _DEFAULT_FILE_FILTER
+
+
+class TestSourceFnMatcherSync:
+    def test_custom_file_filter_extends_php_matcher(self, tmp_path: Path) -> None:
+        # #1710: find_symbol relies on Language.PHP.get_source_fn_matcher(); unless the configured
+        # extensions are synced into it, symbols in .module / .install files stay invisible even
+        # though the LS indexes them. get_source_fn_matcher() is a @cache singleton, so reset()
+        # afterwards.
+        matcher = Language.PHP.get_source_fn_matcher()
+        try:
+            assert not matcher.is_relevant_filename("hooks.module")  # guard: not matched by default
+
+            file_filter = Intelephense._resolve_file_filter(
+                _settings(tmp_path, {Language.PHP: {"file_filter": [".php", ".module", ".install"]}})
+            )
+            Intelephense._sync_source_fn_matcher(file_filter)
+
+            assert matcher.is_relevant_filename("index.php")
+            assert matcher.is_relevant_filename("hooks.module")
+            assert matcher.is_relevant_filename("schema.install")
+        finally:
+            matcher.reset()
+
+    def test_default_file_filter_leaves_matcher_unchanged(self, tmp_path: Path) -> None:
+        # The default file_filter matches the existing PHP matcher extension, so syncing it must
+        # be a no-op (no duplicate entries, no new matches).
+        matcher = Language.PHP.get_source_fn_matcher()
+        try:
+            initial = list(matcher._file_extensions)
+            Intelephense._sync_source_fn_matcher(Intelephense._resolve_file_filter(_settings(tmp_path)))
+
+            assert sorted(matcher._file_extensions) == sorted(initial)
+        finally:
+            matcher.reset()
+
+    def test_other_php_backends_unaffected(self, tmp_path: Path) -> None:
+        # Only Language.PHP (Intelephense) is wired; the phpactor / phpantom matchers are separate
+        # @cache singletons and must not pick up Intelephense's configuration.
+        matcher = Language.PHP.get_source_fn_matcher()
+        phpactor_matcher = Language.PHP_PHPACTOR.get_source_fn_matcher()
+        phpantom_matcher = Language.PHP_PHPANTOM.get_source_fn_matcher()
+        try:
+            Intelephense._sync_source_fn_matcher([".php", ".module"])
+
+            assert matcher.is_relevant_filename("hooks.module")
+            assert not phpactor_matcher.is_relevant_filename("hooks.module")
+            assert not phpantom_matcher.is_relevant_filename("hooks.module")
+        finally:
+            matcher.reset()
+
+    def test_reset_prevents_cross_project_leak(self, tmp_path: Path) -> None:
+        # The matcher is a per-language singleton shared across projects. Project A reconfigures
+        # file_filter (adds .module); when project B is activated, SolidLanguageServer.__init__
+        # resets the matcher first, so project B must NOT see .module even though project A added
+        # it. Mirrors the reset-then-sync ordering of Intelephense.__init__.
+        matcher = Language.PHP.get_source_fn_matcher()
+        try:
+            # project A: custom file_filter with .module
+            filter_a = Intelephense._resolve_file_filter(_settings(tmp_path, {Language.PHP: {"file_filter": [".php", ".module"]}}))
+            Intelephense._sync_source_fn_matcher(filter_a)
+            assert matcher.is_relevant_filename("hooks.module")
+
+            # project B activates: base __init__ resets, then default config is applied (no .module)
+            matcher.reset()
+            filter_b = Intelephense._resolve_file_filter(_settings(tmp_path / "proj_b"))
+            Intelephense._sync_source_fn_matcher(filter_b)
+
+            assert not matcher.is_relevant_filename("hooks.module"), (
+                "project B inherited project A's .module - reset did not undo the reconfiguration"
+            )
+            assert matcher.is_relevant_filename("index.php")
+        finally:
+            matcher.reset()
+
+
+@pytest.mark.php
+class TestFileFilterIntegration:
+    """End-to-end check that a custom ``file_filter`` makes a Drupal-style file visible.
+
+    Starts a real Intelephense, hence gated by the ``php`` marker. The ``drupal_module.module``
+    fixture stays invisible to every test that runs with default settings.
+    """
+
+    def test_module_file_symbols_and_references_visible(self) -> None:
+        with start_ls_context(
+            Language.PHP,
+            ls_specific_settings={Language.PHP: {"file_filter": [".php", ".module"]}},
+        ) as ls:
+            # Layer 1 (Serena's source matcher): the .module file takes part in symbol traversal.
+            symbols = ls.request_full_symbol_tree()
+            assert SymbolUtils.symbol_tree_contains_name(symbols, "drupal_module_help"), (
+                "drupal_module_help from drupal_module.module not found in the symbol tree"
+            )
+            assert SymbolUtils.symbol_tree_contains_name(symbols, "DrupalModuleController"), (
+                "DrupalModuleController from drupal_module.module not found in the symbol tree"
+            )
+
+            # Layer 2 (files.associations push): cross-file features cover the .module file.
+            helper_php_path = str(get_repo_path(Language.PHP) / "helper.php")
+            references = ls.request_references(helper_php_path, 2, len("function "))
+            assert any(ref["uri"].endswith("drupal_module.module") for ref in references), (
+                f"helperFunction call in drupal_module.module not found in references: {references}"
+            )

--- a/test/solidlsp/php/test_php_config.py
+++ b/test/solidlsp/php/test_php_config.py
@@ -1,152 +1,47 @@
 """Configuration plumbing for ``Intelephense``'s ``file_filter``.
 
-Serena treats only ``.php`` files as PHP sources by default, while Drupal projects keep ordinary
-PHP in ``.module`` / ``.install`` / ``.inc`` / ``.theme`` / ``.profile`` / ``.engine`` files,
-which therefore stay invisible to ``find_symbol`` and friends. ``ls_specific_settings["php"]``
-now accepts a ``file_filter`` key mirroring the Perl mechanism from #1449 / #1642 (see #1710).
+Serena treats only ``.php`` / ``.phtml`` files as PHP sources by default, while Drupal projects
+keep ordinary PHP in ``.module`` / ``.install`` / ``.inc`` / ``.theme`` / ``.profile`` /
+``.engine`` files, which therefore stay invisible to ``find_symbol`` and friends.
+``ls_specific_settings["php"]`` accepts a ``file_filter`` key with additional extensions,
+mirroring the Perl mechanism from #1449 / #1642 (see #1710).
 
-The unit tests pin the configuration plumbing without starting the language server, so they run
-in every environment. They also cover the source-file matcher sync that keeps ``find_symbol``
-consistent with the LS. The integration test at the bottom starts a real Intelephense and is
-gated by the ``php`` marker like the rest of the PHP suite.
+The unit tests cover the default source-file matcher. The configuration plumbing itself lives
+inline in ``Intelephense.__init__`` (matcher sync) and ``_start_server`` (the
+``intelephense.files.associations`` push) and is exercised end-to-end by the integration test
+at the bottom, which starts a real Intelephense and is gated by the ``php`` marker like the
+rest of the PHP suite.
 """
-
-from pathlib import Path
 
 import pytest
 
-from solidlsp.language_servers.intelephense import _DEFAULT_FILE_FILTER, Intelephense
-from solidlsp.ls_config import Language
+from solidlsp.ls_config import FilenameMatcher, Language
 from solidlsp.ls_utils import SymbolUtils
-from solidlsp.settings import SolidLSPSettings
 from test.conftest import get_repo_path, start_ls_context
 
 
-def _settings(tmp_path: Path, ls_specific_settings: dict | None = None) -> SolidLSPSettings:
-    """A SolidLSPSettings rooted under ``tmp_path`` with optional php overrides."""
-    return SolidLSPSettings(
-        solidlsp_dir=str(tmp_path / ".solidlsp"),
-        ls_specific_settings=ls_specific_settings or {},
-    )
+class TestPhpSourceFnMatcherDefaults:
+    def test_phtml_matched_by_default_for_all_php_language_servers(self) -> None:
+        # .phtml is a standard (yet outdated) PHP extension, so all PHP language servers treat it
+        # as a PHP source by default (#1710).
+        for language in (Language.PHP, Language.PHP_PHPACTOR, Language.PHP_PHPANTOM):
+            matcher = language.get_source_fn_matcher()
+            assert matcher.is_relevant_filename("index.php"), f"{language}: .php not matched"
+            assert matcher.is_relevant_filename("template.phtml"), f"{language}: .phtml not matched"
 
+    def test_module_not_matched_by_default(self) -> None:
+        # guard for the integration test below: .module files only become visible via file_filter
+        assert not Language.PHP.get_source_fn_matcher().is_relevant_filename("hooks.module")
 
-class TestResolveFileFilter:
-    def test_default_when_no_ls_specific_settings(self, tmp_path: Path) -> None:
-        # Behaviour unchanged for projects that don't set ls_specific_settings at all.
-        assert Intelephense._resolve_file_filter(_settings(tmp_path)) == _DEFAULT_FILE_FILTER
+    def test_file_extensions_property_returns_copy(self) -> None:
+        # _create_base_initialize_params derives the files.associations globs from this property;
+        # mutating the returned list must not affect the matcher.
+        matcher = FilenameMatcher(".php", ".phtml")
+        extensions = matcher.file_extensions
+        extensions.append(".module")
 
-    def test_default_when_php_key_absent(self, tmp_path: Path) -> None:
-        # ls_specific_settings configured for another language must not leak into PHP.
-        settings = _settings(tmp_path, {Language.PYTHON: {"something": "unrelated"}})
-
-        assert Intelephense._resolve_file_filter(settings) == _DEFAULT_FILE_FILTER
-
-    def test_custom_file_filter_returned(self, tmp_path: Path) -> None:
-        # #1710: a Drupal project must be able to surface .module / .install / ... files.
-        custom = [".php", ".phtml", ".module", ".install", ".inc", ".theme", ".profile", ".engine"]
-        settings = _settings(tmp_path, {Language.PHP: {"file_filter": custom}})
-
-        assert Intelephense._resolve_file_filter(settings) == custom
-
-    def test_default_list_is_not_mutated_across_calls(self, tmp_path: Path) -> None:
-        # The resolver must copy the module-level default, otherwise one instance mutating its
-        # returned list would corrupt every subsequently created default-configured instance.
-        file_filter = Intelephense._resolve_file_filter(_settings(tmp_path))
-        file_filter.append(".module")
-
-        assert Intelephense._resolve_file_filter(_settings(tmp_path)) == _DEFAULT_FILE_FILTER
-        assert ".module" not in _DEFAULT_FILE_FILTER
-
-
-class TestResolveFilesAssociations:
-    def test_default_filter_is_not_pushed(self) -> None:
-        # Pushing globs derived from the default filter would replace Intelephense's built-in
-        # associations ["*.php", "*.phtml"] and silently drop .phtml indexing, changing default
-        # behavior; the push must stay gated off for default-configured sessions.
-        assert Intelephense._resolve_files_associations(list(_DEFAULT_FILE_FILTER)) is None
-
-    def test_explicitly_configured_default_is_not_pushed(self) -> None:
-        assert Intelephense._resolve_files_associations([".php"]) is None
-
-    def test_custom_filter_yields_globs(self) -> None:
-        assert Intelephense._resolve_files_associations([".php", ".phtml", ".module"]) == [
-            "*.php",
-            "*.phtml",
-            "*.module",
-        ]
-
-
-class TestSourceFnMatcherSync:
-    def test_custom_file_filter_extends_php_matcher(self, tmp_path: Path) -> None:
-        # #1710: find_symbol relies on Language.PHP.get_source_fn_matcher(); unless the configured
-        # extensions are synced into it, symbols in .module / .install files stay invisible even
-        # though the LS indexes them. get_source_fn_matcher() is a @cache singleton, so reset()
-        # afterwards.
-        matcher = Language.PHP.get_source_fn_matcher()
-        try:
-            assert not matcher.is_relevant_filename("hooks.module")  # guard: not matched by default
-
-            file_filter = Intelephense._resolve_file_filter(
-                _settings(tmp_path, {Language.PHP: {"file_filter": [".php", ".module", ".install"]}})
-            )
-            Intelephense._sync_source_fn_matcher(file_filter)
-
-            assert matcher.is_relevant_filename("index.php")
-            assert matcher.is_relevant_filename("hooks.module")
-            assert matcher.is_relevant_filename("schema.install")
-        finally:
-            matcher.reset()
-
-    def test_default_file_filter_leaves_matcher_unchanged(self, tmp_path: Path) -> None:
-        # The default file_filter matches the existing PHP matcher extension, so syncing it must
-        # be a no-op (no duplicate entries, no new matches).
-        matcher = Language.PHP.get_source_fn_matcher()
-        try:
-            initial = list(matcher._file_extensions)
-            Intelephense._sync_source_fn_matcher(Intelephense._resolve_file_filter(_settings(tmp_path)))
-
-            assert sorted(matcher._file_extensions) == sorted(initial)
-        finally:
-            matcher.reset()
-
-    def test_other_php_backends_unaffected(self, tmp_path: Path) -> None:
-        # Only Language.PHP (Intelephense) is wired; the phpactor / phpantom matchers are separate
-        # @cache singletons and must not pick up Intelephense's configuration.
-        matcher = Language.PHP.get_source_fn_matcher()
-        phpactor_matcher = Language.PHP_PHPACTOR.get_source_fn_matcher()
-        phpantom_matcher = Language.PHP_PHPANTOM.get_source_fn_matcher()
-        try:
-            Intelephense._sync_source_fn_matcher([".php", ".module"])
-
-            assert matcher.is_relevant_filename("hooks.module")
-            assert not phpactor_matcher.is_relevant_filename("hooks.module")
-            assert not phpantom_matcher.is_relevant_filename("hooks.module")
-        finally:
-            matcher.reset()
-
-    def test_reset_prevents_cross_project_leak(self, tmp_path: Path) -> None:
-        # The matcher is a per-language singleton shared across projects. Project A reconfigures
-        # file_filter (adds .module); when project B is activated, SolidLanguageServer.__init__
-        # resets the matcher first, so project B must NOT see .module even though project A added
-        # it. Mirrors the reset-then-sync ordering of Intelephense.__init__.
-        matcher = Language.PHP.get_source_fn_matcher()
-        try:
-            # project A: custom file_filter with .module
-            filter_a = Intelephense._resolve_file_filter(_settings(tmp_path, {Language.PHP: {"file_filter": [".php", ".module"]}}))
-            Intelephense._sync_source_fn_matcher(filter_a)
-            assert matcher.is_relevant_filename("hooks.module")
-
-            # project B activates: base __init__ resets, then default config is applied (no .module)
-            matcher.reset()
-            filter_b = Intelephense._resolve_file_filter(_settings(tmp_path / "proj_b"))
-            Intelephense._sync_source_fn_matcher(filter_b)
-
-            assert not matcher.is_relevant_filename("hooks.module"), (
-                "project B inherited project A's .module - reset did not undo the reconfiguration"
-            )
-            assert matcher.is_relevant_filename("index.php")
-        finally:
-            matcher.reset()
+        assert ".module" not in matcher.file_extensions
+        assert not matcher.is_relevant_filename("hooks.module")
 
 
 @pytest.mark.php
@@ -160,12 +55,12 @@ class TestFileFilterIntegration:
     def test_module_file_symbols_and_references_visible(self) -> None:
         with start_ls_context(
             Language.PHP,
-            ls_specific_settings={Language.PHP: {"file_filter": [".php", ".module"]}},
+            ls_specific_settings={Language.PHP: {"file_filter": [".module"]}},
         ) as ls:
-            # Layer 2 (files.associations push) must be asserted FIRST: the reference in the
+            # Layer 2 (files.associations) must be asserted FIRST: the reference in the
             # never-opened drupal_module.module can only come from the server's association-driven
             # background index. request_full_symbol_tree below didOpens every matched file in the
-            # LS, after which this assertion could pass even without the push.
+            # LS, after which this assertion could pass even without the associations.
             helper_php_path = str(get_repo_path(Language.PHP) / "helper.php")
             references = ls.request_references(helper_php_path, 2, len("function "))
             assert any(ref["uri"].endswith("drupal_module.module") for ref in references), (


### PR DESCRIPTION
Closes #1710

## What & why

Serena hardcodes the PHP source filename filter to `.php` (the PHP arm of `Language.get_source_fn_matcher()`), so ecosystems that keep ordinary PHP in other extensions lose symbol visibility for those files. Drupal is the heaviest case: hook implementations live in `.module`, install/update hooks in `.install`, plus `.inc` / `.theme` / `.profile` / `.engine` – 660 to 1,100+ files per project on the two production sites measured in #1710, and disproportionately important ones, since hooks are where Drupal's control flow lives.

v1.6.0 introduced the right mechanism in #1449 / #1642 (`FilenameMatcher.add_extensions()` / `reset()`, the generic matcher reset on every LS activation, a `file_filter` key under `ls_specific_settings`), but wired it only for Perl. This PR mirrors the accepted pattern for PHP / Intelephense.

## Change

`ls_specific_settings["php"]` accepts `file_filter`; defaults are unchanged (`[".php"]`) when the key is omitted:

```yaml
ls_specific_settings:
  php:
    file_filter: [".php", ".phtml", ".module", ".install", ".inc", ".theme", ".profile", ".engine"]
```

- `Intelephense._resolve_file_filter` (pure, unit-testable, mirroring `PerlLanguageServer._resolve_filter_settings`) reads the key; `_sync_source_fn_matcher` adds the extensions to `Language.PHP.get_source_fn_matcher()`. The generic reset in `SolidLanguageServer.__init__` already prevents cross-project leakage, so `ls.py` is untouched.
- Second, Intelephense-specific layer: a customized filter is also pushed to the server as `intelephense.files.associations` globs via `workspace/didChangeConfiguration` (Serena previously sent none), because the server only indexes what matches its associations; without the push, cross-file references and definitions skip the extra files. Unlike Perl's unconditional push, this one is deliberately skipped for the default filter: the pushed list replaces Intelephense's built-in `["*.php", "*.phtml"]`, so deriving it from `[".php"]` would silently drop `.phtml` indexing. The decision lives in the pure `_resolve_files_associations` helper (unit-tested), and user-configured `maxMemory` / `maxFileSize` are carried in the pushed section so it stays self-consistent regardless of the server's merge semantics.
- Docs: `file_filter` row, Drupal example, and the same two notes the Perl section has; CHANGELOG entry under "Language Servers".

Scope decisions, following the open questions in #1710: Intelephense only for now (`php_phpactor` / `php_phpantom` have separate cached matchers and would each need their own wiring – happy to follow up if wanted); `.phtml` stays opt-in rather than joining the default; `clearCache` turned out unnecessary for the fresh-workspace case the integration test exercises and is deferred pending maintainer input.

## Verification

- `test/solidlsp/php/test_php_config.py`: 11 runtime-free unit tests mirroring `test/solidlsp/perl/test_perl_config.py` (defaults preserved, no cross-language / cross-backend leakage, matcher sync, reset-prevents-leak, push decision), plus one live integration test (gated by the `php` marker) against a Drupal-style `drupal_module.module` fixture. The integration test pins both layers: cross-file references from `helper.php` land in the never-opened `.module` file (so the reference can only come from the association-driven background index), and the full symbol tree contains its symbols (matcher sync). The fixture is inert for every test running with default settings.
- Local runs on macOS / Python 3.13: `poe format`, `poe type-check`, the config tests (twice, checking the reference assertion is stable), and the full `php`-marked suite: 40 passed, 1 skipped (Phpactor unavailable locally), no regressions.

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
