### PR TITLE
Fix: dashboard "Last Execution" panel stuck on "Loading..." when no execution exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ Status of the `main` branch. Changes prior to the next official version change w
     - used in `JetBrainsFindDeclarationTool`
     when using plugin version 2023.3.3+
 
+* Dashboard:
+  - Fix: the "Last Execution" panel stayed on "Loading..." forever when there was no logged execution
+    (e.g. a fresh server / no tool run yet), because `loadLastExecution()` only rendered the panel when
+    the backend returned a non-null execution; the empty state is now rendered via the existing
+    `displayLastExecution(null)` path, mirroring the other panels #1713
+
 * Dependencies:
   - Bump mcp from 1.27.0 to 1.28.1
 

--- a/src/serena/resources/dashboard/dashboard.js
+++ b/src/serena/resources/dashboard/dashboard.js
@@ -913,6 +913,8 @@ class Dashboard {
                 if (response.status === 'success') {
                     if (response.last_execution !== null && response.last_execution.logged) {
                         self.displayLastExecution(response.last_execution);
+                    } else {
+                        self.displayLastExecution(null);
                     }
                 } else {
                     console.error('Error loading last execution:', response.message);


### PR DESCRIPTION
## Problem

On the web dashboard, the **Last Execution** panel shows `Loading...` indefinitely and never resolves whenever there is no logged execution yet (e.g. a fresh server, or `ACTIVE PROJECT: None` / no tool has run). The `Tool Usage` and `Executions Queue` panels correctly show their own empty states, but `Last Execution` never clears its initial placeholder.

## Root cause

As diagnosed by @hub012 in the issue: the backend behaves correctly (`GET /last_execution` returns `{"last_execution": null, "status": "success"}`), but in `src/serena/resources/dashboard/dashboard.js`, `loadLastExecution()`'s success handler only calls `self.displayLastExecution(...)` when `response.last_execution` is non-null and `logged`. There is no `else` branch for the `null` case, so the `Loading...` placeholder from `index.html` is never replaced.

`displayLastExecution(null)` already renders the correct empty state (`No executions yet.`) — it just was never being called.

## Fix

Add the missing `else` branch so the empty state is rendered, mirroring how the other panels already handle their empty state:

```js
if (response.last_execution !== null && response.last_execution.logged) {
    self.displayLastExecution(response.last_execution);
} else {
    self.displayLastExecution(null);
}
```

Also added a `CHANGELOG.md` entry under "Dashboard" per `CONTRIBUTING.md`.

## Testing

This is a small, self-contained frontend fix. The repo has no existing JS test harness for `dashboard.js` (only `test/serena/test_dashboard.py`, which covers backend project/language listing, not the frontend JS), so I verified by inspection:
- Traced `loadLastExecution()`'s AJAX success handler and confirmed the `null`/non-`logged` case previously fell through with no action, leaving the `<div class="loading">Loading...</div>` placeholder from `index.html` untouched.
- Confirmed `displayLastExecution(null)` already has a dedicated `if (!execution)` branch that renders `<div class="no-stats-message">No executions yet.</div>`, matching the empty-state pattern used by `Tool Usage` / `Executions Queue`.
- The change is a minimal, additive 2-line diff with no behavior change to the non-null path.

Fixes #1713
https://github.com/oraios/serena/issues/1713