### PR TITLE
Fix: reflect externally-made file edits in symbolic queries (workspace/didChangeWatchedFiles)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Status of the `main` branch. Changes prior to the next official version change will appear here.
 
 * General:
+  - Fix: a warm language server served stale symbol results for files edited outside of Serena's own
+    tools (another editor, a second agent, a `git` checkout, a build step). The
+    `workspace/didChangeWatchedFiles` notification was defined but never sent, so such edits were
+    invisible to symbolic queries (`find_referencing_symbols`, `find_symbol`, etc.) until a restart.
+    Before each symbolic tool call, Serena now checks its tracked source files for external changes and
+    notifies the language server (new `Project.poll_and_notify_file_changes`). Controlled by the new
+    `detect_external_file_changes` config option (enabled by default; disable on very large repositories
+    where the per-query filesystem walk is not worth it).
   - Fix: `FileUtils.read_file`'s `charset_normalizer` fallback (used when a file cannot be decoded with
     the project's configured `encoding`) decoded the raw bytes directly and therefore skipped the
     universal-newline translation that the primary read path applies. CR characters from disk thus

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -874,6 +874,15 @@ class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
     """
     tool_timeout: float = DEFAULT_TOOL_TIMEOUT
 
+    detect_external_file_changes: bool = True
+    """Whether, before each symbolic tool call, Serena should check the project's source files for
+    changes made outside of its own tools (another editor, a second agent, a git checkout, a build
+    step) and notify the language server so symbolic queries reflect the current files on disk.
+    Enabled by default because a warm language server otherwise silently serves stale symbol data
+    for such edits. The check performs one directory walk plus an ``os.stat`` per tracked source
+    file per symbolic call; set this to False on very large repositories where that cost outweighs
+    the staleness risk (e.g. when all edits go through Serena anyway)."""
+
     token_count_estimator: str = RegisteredTokenCountEstimator.CHAR_COUNT.name
     """Only relevant if `record_tool_usage` is True; the name of the token count estimator to use for tool usage statistics.
     See the `RegisteredTokenCountEstimator` enum for available options.

--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -21,6 +21,11 @@ from serena.util.file_system import GitignoreParser, match_path, scan_directory
 from serena.util.text_utils import MatchedConsecutiveLines, search_files
 from solidlsp import SolidLanguageServer
 from solidlsp.ls_config import Language
+from solidlsp.lsp_protocol_handler.lsp_types import (
+    DidChangeWatchedFilesParams,
+    FileChangeType,
+    FileEvent,
+)
 
 if TYPE_CHECKING:
     from serena.agent import SerenaAgent
@@ -59,6 +64,13 @@ class Project(ToStringMixin):
         self._language_server_manager_init_error: Exception | None = None
         self.is_newly_created = is_newly_created
         self._agent: Optional["SerenaAgent"] = None
+
+        # State for detecting externally-made file changes (see poll_and_notify_file_changes).
+        # Maps relative source-file path -> mtime last observed by the poll. None until the first
+        # poll, which only establishes the baseline (it must not report the project's entire
+        # pre-existing file set as newly created).
+        self._freshness_last_seen_mtimes: dict[str, float] | None = None
+        self._freshness_lock = threading.Lock()
 
         # create .gitignore file in the project's Serena data folder if not yet present
         serena_data_gitignore_path = os.path.join(self._serena_data_folder, ".gitignore")
@@ -361,6 +373,74 @@ class Project(ToStringMixin):
                             f"File {abs_file_path} not found (possibly due it being a symlink), skipping it in request_parsed_files",
                         )
             return rel_file_paths
+
+    def poll_and_notify_file_changes(self) -> int:
+        """Detects source files that were changed, created or deleted on disk since the last call
+        and notifies every language server managed for this project via the LSP
+        ``workspace/didChangeWatchedFiles`` notification.
+
+        This exists because Serena's own file and symbol tools notify the language server inline
+        (via didOpen/didChange/didClose) when they edit a file, but edits made through any other
+        channel (another editor, a second agent, a git checkout, a build step) are otherwise
+        invisible to a warm language server, causing symbolic queries to answer from a stale index.
+
+        The set of files considered is exactly the set Serena itself tracks (see
+        :meth:`gather_source_files`), so no separate file-discovery logic has to be kept in sync.
+        The dominant cost is the directory walk plus one ``os.stat`` per tracked file; this is
+        intended to be called before symbolic tool invocations rather than on a timer.
+
+        :return: the number of change events sent (0 if nothing changed, if no language server is
+            running yet, or on the first call, which only establishes the baseline).
+        """
+        current: dict[str, float] = {}
+        for rel_path in self.gather_source_files():
+            try:
+                current[rel_path] = os.stat(os.path.join(self.project_root, rel_path)).st_mtime
+            except OSError:
+                continue
+
+        # Read-diff-swap under the lock only; the filesystem walk above and the LSP notifications
+        # below stay outside it so concurrent callers do not serialize on I/O.
+        with self._freshness_lock:
+            previous = self._freshness_last_seen_mtimes
+            self._freshness_last_seen_mtimes = current
+            if previous is None:
+                return 0
+            events: list[tuple[str, FileChangeType]] = []
+            for rel_path, mtime in current.items():
+                prev_mtime = previous.get(rel_path)
+                if prev_mtime is None:
+                    events.append((rel_path, FileChangeType.Created))
+                elif mtime > prev_mtime:
+                    events.append((rel_path, FileChangeType.Changed))
+            events.extend((rel_path, FileChangeType.Deleted) for rel_path in previous if rel_path not in current)
+
+        if not events or self.language_server_manager is None:
+            return 0
+
+        changes: list[FileEvent] = [
+            {"uri": Path(self.project_root, rel_path).resolve().as_uri(), "type": change_type} for rel_path, change_type in events
+        ]
+        params: DidChangeWatchedFilesParams = {"changes": changes}
+        created_paths = [rel_path for rel_path, change_type in events if change_type == FileChangeType.Created]
+
+        for ls in self.language_server_manager.iter_language_servers():
+            try:
+                ls.server.notify.did_change_watched_files(params)
+            except Exception:
+                log.warning("Failed to notify language server of watched file changes", exc_info=True)
+            # A didChangeWatchedFiles(Created) notification alone is not enough for every backend
+            # (observed with pyright) to fold a brand-new file into its cross-file reference graph;
+            # an open/close cycle forces the parse+bind that Serena's own file tools trigger via
+            # SolidLanguageServer.open_file().
+            for rel_path in created_paths:
+                try:
+                    with ls.open_file(rel_path):
+                        pass
+                except Exception:
+                    log.warning(f"Failed to refresh newly created file {rel_path!r} in language server", exc_info=True)
+
+        return len(events)
 
     def _create_file_collection(self, relative_path: str, code_files_only: bool) -> FileCollection:
         if FileProxy.is_external_path(relative_path):

--- a/src/serena/tools/tools_base.py
+++ b/src/serena/tools/tools_base.py
@@ -319,6 +319,26 @@ class Tool(Component):
     def is_symbolic(self) -> bool:
         return issubclass(self.__class__, ToolMarkerSymbolicRead) or issubclass(self.__class__, ToolMarkerSymbolicEdit)
 
+    def _maybe_refresh_project_freshness(self) -> None:
+        """Before a symbolic tool call, give the active project's language server(s) a chance to
+        learn about files that changed on disk outside of Serena's own tools
+        (see :meth:`serena.project.Project.poll_and_notify_file_changes`).
+
+        No-op for non-symbolic tools: file tools read the filesystem directly (always current), and
+        editing tools notify the language server inline. Controlled by the
+        ``detect_external_file_changes`` configuration option. Best-effort: a failure here must
+        never prevent the tool from running.
+        """
+        if not self.is_symbolic() or not self.agent.serena_config.detect_external_file_changes:
+            return
+        project = self.agent.get_active_project()
+        if project is None:
+            return
+        try:
+            project.poll_and_notify_file_changes()
+        except Exception:
+            log.warning("Failed to poll for external file changes before symbolic tool call", exc_info=True)
+
     @classmethod
     def get_param_aliases(cls) -> dict[str, str]:
         """
@@ -370,6 +390,10 @@ class Tool(Component):
                             "No active project. Ask the user to provide the project path or to select a project from this list of known projects: "
                             + f"{self.agent.serena_config.project_names}"
                         )
+
+                # reflect any externally-made file changes in the language server index before a
+                # symbolic query (no-op for non-symbolic tools and when disabled via config)
+                self._maybe_refresh_project_freshness()
 
                 # construct apply kwargs, adding session_id if the tool is session-aware
                 apply_kwargs = dict(kwargs)

--- a/test/serena/test_external_file_freshness.py
+++ b/test/serena/test_external_file_freshness.py
@@ -1,0 +1,167 @@
+"""End-to-end test for detecting externally-made file changes.
+
+Reproduces the staleness bug and verifies the fix: a warm language server serves stale symbol
+results for files edited outside of Serena's own tools, and ``Project.poll_and_notify_file_changes``
+makes those edits visible again by firing ``workspace/didChangeWatchedFiles`` (plus an open/close
+cycle for newly created files).
+
+Exercises all three ``FileChangeType`` branches against a real pyright backend:
+Created (new caller file), Changed (append a second caller), Deleted (remove the caller file).
+"""
+
+import os
+import shutil
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import Language
+from test.conftest import get_repo_path, project_with_ls_context
+
+pytestmark = pytest.mark.python
+
+# A method that already has a call site in the fixture, so its baseline reference set is non-empty.
+_TARGET_FILE = os.path.join("test_repo", "services.py")
+_TARGET_SYMBOL = "create_user"
+
+_CALLER_REL_PATH = os.path.join("test_repo", "external_caller.py")
+_CALLER_ONE = "external_caller_one"
+_CALLER_TWO = "external_caller_two"
+
+
+def _caller_source(*function_names: str) -> str:
+    body = "\n\n".join(
+        f"def {name}() -> User:\n    return UserService().{_TARGET_SYMBOL}('x', 'y', 'z@example.com')" for name in function_names
+    )
+    return "from test_repo.models import User\nfrom test_repo.services import UserService\n\n\n" + body + "\n"
+
+
+def _referencing_symbol_names(ls: SolidLanguageServer) -> list[str]:
+    """Names of the symbols that reference ``_TARGET_SYMBOL``, per the warm language server."""
+    document_symbols = ls.request_document_symbols(_TARGET_FILE).get_all_symbols_and_roots()
+    target = next((s for s in document_symbols[0] if s.get("name") == _TARGET_SYMBOL), None)
+    assert target is not None and "selectionRange" in target, f"{_TARGET_SYMBOL} not found in {_TARGET_FILE}"
+    start = target["selectionRange"]["start"]
+    references = ls.request_referencing_symbols(_TARGET_FILE, start["line"], start["character"])
+    return [ref.symbol["name"] for ref in references]
+
+
+def test_external_edits_become_visible_after_poll(tmp_path):
+    # Work on an isolated copy so we can freely create/edit/delete files under the project root.
+    repo_root = tmp_path / "repo"
+    shutil.copytree(get_repo_path(Language.PYTHON), repo_root)
+    caller_abs = repo_root / _CALLER_REL_PATH
+
+    with project_with_ls_context(Language.PYTHON, str(repo_root)) as project:
+        language_server = next(iter(project.language_server_manager.iter_language_servers()))
+
+        # Warm the reference index, then establish the freshness baseline (first poll never notifies).
+        _referencing_symbol_names(language_server)
+        assert project.poll_and_notify_file_changes() == 0, "first poll must only establish the baseline"
+
+        # --- Created -------------------------------------------------------------------------------
+        caller_abs.write_text(_caller_source(_CALLER_ONE), encoding="utf-8")
+
+        # Adversarial: without the poll, the warm server has never seen the new file -> stale.
+        assert _CALLER_ONE not in _referencing_symbol_names(language_server), "expected the new caller to be invisible before poll"
+
+        assert project.poll_and_notify_file_changes() == 1, "one Created event expected"
+        assert _CALLER_ONE in _referencing_symbol_names(language_server), "new caller must be visible after poll"
+
+        # --- Changed -------------------------------------------------------------------------------
+        caller_abs.write_text(_caller_source(_CALLER_ONE, _CALLER_TWO), encoding="utf-8")
+        assert project.poll_and_notify_file_changes() == 1, "one Changed event expected"
+        names_after_change = _referencing_symbol_names(language_server)
+        assert _CALLER_TWO in names_after_change, "appended caller must be visible after poll"
+        assert _CALLER_ONE in names_after_change
+
+        # --- Deleted -------------------------------------------------------------------------------
+        caller_abs.unlink()
+        assert project.poll_and_notify_file_changes() == 1, "one Deleted event expected"
+        names_after_delete = _referencing_symbol_names(language_server)
+        assert _CALLER_ONE not in names_after_delete, "deleted caller must disappear after poll"
+        assert _CALLER_TWO not in names_after_delete
+
+
+def test_first_poll_is_baseline_only(tmp_path):
+    """A newly-loaded project must not report its entire pre-existing file set as changed."""
+    repo_root = tmp_path / "repo"
+    shutil.copytree(get_repo_path(Language.PYTHON), repo_root)
+    with project_with_ls_context(Language.PYTHON, str(repo_root)) as project:
+        assert project.poll_and_notify_file_changes() == 0
+        # No external edits between the two calls -> still nothing to report.
+        assert project.poll_and_notify_file_changes() == 0
+
+
+# --- Fast wiring tests for Tool._maybe_refresh_project_freshness (no language server needed) --------
+
+
+class _StubConfig:
+    def __init__(self, detect_external_file_changes: bool) -> None:
+        self.detect_external_file_changes = detect_external_file_changes
+
+
+class _StubProject:
+    def __init__(self) -> None:
+        self.poll_calls = 0
+
+    def poll_and_notify_file_changes(self) -> int:
+        self.poll_calls += 1
+        return 0
+
+
+class _StubAgent:
+    def __init__(self, *, detect: bool, project) -> None:
+        self.serena_config = _StubConfig(detect)
+        self._project = project
+
+    def get_active_project(self):
+        return self._project
+
+
+class _StubTool:
+    """Minimal stand-in used only to drive Tool._maybe_refresh_project_freshness in isolation."""
+
+    def __init__(self, *, symbolic: bool, detect: bool = True, project=None) -> None:
+        self._symbolic = symbolic
+        self.agent = _StubAgent(detect=detect, project=project if project is not None else _StubProject())
+
+    def is_symbolic(self) -> bool:
+        return self._symbolic
+
+
+def _refresh(tool: "_StubTool") -> None:
+    from serena.tools.tools_base import Tool
+
+    Tool._maybe_refresh_project_freshness(tool)  # type: ignore[arg-type]
+
+
+def test_refresh_polls_only_for_symbolic_tools_when_enabled():
+    symbolic = _StubTool(symbolic=True)
+    _refresh(symbolic)
+    assert symbolic.agent._project.poll_calls == 1
+
+    non_symbolic = _StubTool(symbolic=False)
+    _refresh(non_symbolic)
+    assert non_symbolic.agent._project.poll_calls == 0
+
+
+def test_refresh_is_skipped_when_disabled_by_config():
+    tool = _StubTool(symbolic=True, detect=False)
+    _refresh(tool)
+    assert tool.agent._project.poll_calls == 0
+
+
+def test_refresh_is_noop_without_active_project():
+    tool = _StubTool(symbolic=True, project=None)
+    tool.agent._project = None  # type: ignore[assignment]
+    _refresh(tool)  # must not raise
+
+
+def test_refresh_swallows_poll_errors():
+    class _Boom(_StubProject):
+        def poll_and_notify_file_changes(self) -> int:
+            raise RuntimeError("boom")
+
+    tool = _StubTool(symbolic=True, project=_Boom())
+    _refresh(tool)  # a poll failure must never break the tool call


### PR DESCRIPTION
Fix: reflect externally-made file edits in symbolic queries (`workspace/didChangeWatchedFiles`)

Fixes #1718.

## Problem

`workspace/didChangeWatchedFiles` is defined
(`solidlsp/lsp_protocol_handler/lsp_requests.py`) and declared as a client
capability by every bundled language server, but it is never sent — there are
zero call sites. A resident language server therefore never learns about files
changed on disk outside of Serena's own tools (another editor, a second agent, a
`git` checkout, a build step), so symbolic queries such as
`find_referencing_symbols` and `find_symbol` silently return stale results until
a restart. Edits made through Serena's own tools are unaffected (they notify the
LS inline via didOpen/didChange/didClose); only external edits fall through.

See the linked issue for the full write-up and repro.

## Fix

A per-symbolic-query freshness check that reuses primitives already in the tree,
adds no dependency and no background thread:

- **`Project.poll_and_notify_file_changes()`** — walks
  `gather_source_files()` (so the tracked set is exactly what Serena itself
  reads/edits, honoring `.gitignore` / `ignored_paths` / language masks),
  `stat()`s each file, and diffs mtimes against the previous poll. For
  Created/Changed/Deleted files it sends `did_change_watched_files` to every
  language server the project manages. For **Created** files it additionally
  runs a short `open_file()` (didOpen/didClose) cycle — empirically pyright does
  not fold a brand-new file into its cross-file reference graph on the
  notification alone; Changed and Deleted do not need this. The first call only
  establishes the baseline (it must not report a project's entire pre-existing
  file set as newly created).

- **`Tool._maybe_refresh_project_freshness()`**, called in `Tool.apply_ex`
  before the tool runs, gated on `is_symbolic()`. This is the single choke point
  both delivery paths pass through — the stdio-MCP path and the HTTP
  query-server path (`ProjectServer` also calls `tool.apply_ex`). Non-symbolic
  tools skip it: file tools read disk directly, and editing tools notify inline.
  Poll failures are swallowed so a poll can never break a tool call.

- **`SerenaConfig.detect_external_file_changes`** (default `True`) — toggles the
  behavior. Enabled by default because a warm LS otherwise silently serves stale
  data; can be disabled on very large repositories where the per-query
  filesystem walk is not worth the staleness protection.

### Concurrency

The read-diff-swap of the shared last-seen-mtimes state is done under a
`threading.Lock`; the filesystem walk and the LSP calls stay outside the lock so
concurrent callers (`ProjectServer` runs Werkzeug with `threaded=True`) don't
serialize on I/O. A load test on the prototype this is derived from reproduced a
real `dict` mutation race and a torn-read spurious-event storm without the lock.

### Cost / limitations

- `O(tracked source files)` per symbolic query — one `os.walk` + one `os.stat`
  per file. Well within the warm-query budget on a ~1700-file project; on a
  multi-thousand-file monorepo it starts to dominate query latency, which is
  what the config flag (and, as a possible follow-up, a persistent
  filesystem watcher) is for.
- Detects changes only at query time by design — that is exactly what makes it
  cheap and dependency-free.

## Testing

`test/serena/test_external_file_freshness.py`:

- **End-to-end against the real pyright backend** (`test_external_edits_become_visible_after_poll`):
  starts a warm project language server, then — adversarially — asserts a new
  external caller is **invisible before** the poll (reproducing the bug) and
  **visible after** it. Exercises all three change types in one warm session:
  Created (new caller file, via the `open_file()` path), Changed (appended
  caller), Deleted (removed caller file).
- **Baseline-only first poll** (`test_first_poll_is_baseline_only`): a freshly
  loaded project reports zero changes.
- **Wiring/guard unit tests** (no language server): the `apply_ex` hook polls
  only for symbolic tools, is skipped when disabled by config or when there is
  no active project, and swallows poll errors.

`ruff check`, `ruff format --check`, and `ty check` are clean on the changed
files. The existing Python symbolic-tool suites
(`test/serena/test_serena_agent.py` symbolic cases,
`test/solidlsp/python/test_symbol_retrieval.py`, `test/serena/test_symbol.py`,
`test/serena/test_hooks.py`) pass with the change.

## Notes for reviewers

- Whether `poll_and_notify_file_changes` should live on `Project` (it already
  owns `gather_source_files` and the ignore machinery) or in a small standalone
  module is a style call — happy to relocate.
- The default of `detect_external_file_changes=True` treats this as a
  correctness fix for everyone; if you'd prefer it opt-in initially, flipping the
  default is a one-line change.
