### PR TITLE
Retry LSP ContentModified (-32801) errors instead of failing hard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ Status of the `main` branch. Changes prior to the next official version change w
   - PHP/Intelephense: expose `file_filter` via `ls_specific_settings["php"]`, so that additional
     extensions containing PHP sources (e.g. Drupal's `.module` / `.install` / `.inc` / `.theme`)
     become visible to the symbol tools and are indexed by the language server #1710
+  - Fix: an LSP `ContentModified` (-32801) response was surfaced as a hard `SolidLSPException`
+    instead of being retried. Per the LSP spec, `ContentModified` means the server discarded a
+    stale, in-flight computation because the workspace changed underneath it, not that the request
+    itself is invalid; well-behaved clients are expected to retry. `LanguageServerInterface.send_request`
+    now retries such requests a bounded number of times before giving up, for all language servers
+    (this was flaking `test_find_symbol[rust_add_function]` on windows-latest, where rust-analyzer
+    returns `ContentModified` for hover requests cancelled by concurrent indexing). #1724
 
 * JetBrains:
   - Allow external files from dependencies (specified via references like "<ext:FileUtil.class|472e0a13>") to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,12 +52,10 @@ Status of the `main` branch. Changes prior to the next official version change w
     extensions containing PHP sources (e.g. Drupal's `.module` / `.install` / `.inc` / `.theme`)
     become visible to the symbol tools and are indexed by the language server #1710
   - Fix: an LSP `ContentModified` (-32801) response was surfaced as a hard `SolidLSPException`
-    instead of being retried. Per the LSP spec, `ContentModified` means the server discarded a
-    stale, in-flight computation because the workspace changed underneath it, not that the request
-    itself is invalid; well-behaved clients are expected to retry. `LanguageServerInterface.send_request`
-    now retries such requests a bounded number of times before giving up, for all language servers
-    (this was flaking `test_find_symbol[rust_add_function]` on windows-latest, where rust-analyzer
-    returns `ContentModified` for hover requests cancelled by concurrent indexing). #1724
+    instead of being retried, as the spec expects for requests a client declared it will reissue.
+    `send_request` now retries such responses for methods declared via a server's
+    `retryOnContentModified` capability; rust-analyzer declares `textDocument/hover`, fixing the
+    flaky `test_find_symbol[rust_add_function]` on windows-latest. #1724
 
 * JetBrains:
   - Allow external files from dependencies (specified via references like "<ext:FileUtil.class|472e0a13>") to be

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -413,6 +413,10 @@ class RustAnalyzer(SolidLanguageServer):
                             "textDocument/semanticTokens/full",
                             "textDocument/semanticTokens/range",
                             "textDocument/semanticTokens/full/delta",
+                            # rust-analyzer's internal cancellation tracking does not cover hover,
+                            # so hover requests it cancels while indexing come back ContentModified;
+                            # we retry them ourselves (see LanguageServerInterface.send_request). #1724
+                            "textDocument/hover",
                         ],
                     },
                     "regularExpressions": {"engine": "ECMAScript", "version": "ES2020"},

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -3203,4 +3203,17 @@ class SolidLanguageServer(ABC):
         """
         Create the InitializeParams object to send to the language server during initialization.
         """
-        return self._create_initialize_params_builder().with_base_options(self._create_base_initialize_params()).build()
+        params = self._create_initialize_params_builder().with_base_options(self._create_base_initialize_params()).build()
+        self._register_content_modified_retry_methods(params)
+        return params
+
+    def _register_content_modified_retry_methods(self, params: InitializeParams) -> None:
+        """
+        Reads back `general.staleRequestSupport.retryOnContentModified` from the InitializeParams
+        we are about to send and registers it with the underlying `LanguageServerInterface`, so
+        that `send_request` only retries `ContentModified` (-32801) responses for methods we have
+        actually told the server we will retry (see `LanguageServerInterface.send_request`).
+        """
+        general_capabilities = cast(dict, params.get("capabilities", {})).get("general", {})
+        retry_methods = general_capabilities.get("staleRequestSupport", {}).get("retryOnContentModified", [])
+        self.server.set_content_modified_retry_methods(retry_methods)

--- a/src/solidlsp/ls_process.py
+++ b/src/solidlsp/ls_process.py
@@ -18,7 +18,7 @@ from solidlsp.ls_config import Language
 from solidlsp.ls_exceptions import SolidLSPException
 from solidlsp.ls_request import LanguageServerRequest
 from solidlsp.lsp_protocol_handler.lsp_requests import LspNotification
-from solidlsp.lsp_protocol_handler.lsp_types import ErrorCodes
+from solidlsp.lsp_protocol_handler.lsp_types import ErrorCodes, LSPErrorCodes
 from solidlsp.lsp_protocol_handler.server import (
     ENCODING,
     LSPError,
@@ -35,6 +35,13 @@ from solidlsp.lsp_protocol_handler.server import (
 from solidlsp.util import subprocess_util
 
 log = logging.getLogger(__name__)
+
+# Per the LSP spec, `ContentModified` (-32801) means the server discarded a stale, in-flight
+# computation because the workspace changed underneath it, not that the request itself is
+# invalid. A well-behaved client is expected to retry such requests rather than treat them as
+# a hard failure, so we do so here, generically, for all requests to any language server.
+_CONTENT_MODIFIED_MAX_ATTEMPTS = 5
+_CONTENT_MODIFIED_RETRY_DELAY = 0.2
 
 
 class LanguageServerTerminatedException(Exception):
@@ -298,29 +305,42 @@ class LanguageServerInterface(ABC):
 
     def send_request(self, method: str, params: dict | None = None) -> PayloadLike:
         """
-        Send request to the server, register the request id, and wait for the response
+        Send request to the server, register the request id, and wait for the response.
+
+        Requests that fail with the LSP `ContentModified` error (-32801) are retried a bounded
+        number of times with a short delay instead of being surfaced to the caller immediately;
+        see `_CONTENT_MODIFIED_MAX_ATTEMPTS` above.
         """
-        with self._request_id_lock:
-            request_id = self.request_id
-            self.request_id += 1
+        for attempt in range(1, _CONTENT_MODIFIED_MAX_ATTEMPTS + 1):
+            with self._request_id_lock:
+                request_id = self.request_id
+                self.request_id += 1
 
-        request = Request(request_id=request_id, method=method)
-        log.debug("Starting: %s", request)
+            request = Request(request_id=request_id, method=method)
+            log.debug("Starting: %s", request)
 
-        with self._response_handlers_lock:
-            self._pending_requests[request_id] = request
+            with self._response_handlers_lock:
+                self._pending_requests[request_id] = request
 
-        self._send_payload(make_request(method, request_id, params))
+            self._send_payload(make_request(method, request_id, params))
 
-        log.debug("Waiting for response to request %s with params:\n%s", method, params)
-        result = request.get_result(timeout=self._request_timeout)
-        log.debug("Completed: %s", request)
+            log.debug("Waiting for response to request %s with params:\n%s", method, params)
+            result = request.get_result(timeout=self._request_timeout)
+            log.debug("Completed: %s", request)
 
-        if result.is_error():
+            if not result.is_error():
+                log.debug("Returning result:\n%s", result.payload)
+                return result.payload
+
+            is_content_modified = isinstance(result.error, LSPError) and result.error.code == LSPErrorCodes.ContentModified
+            if attempt < _CONTENT_MODIFIED_MAX_ATTEMPTS and is_content_modified:
+                log.info("Request %s got ContentModified (-32801); retrying (%d/%d)", method, attempt, _CONTENT_MODIFIED_MAX_ATTEMPTS)
+                time.sleep(_CONTENT_MODIFIED_RETRY_DELAY)
+                continue
+
             raise SolidLSPException(f"Error processing request {method} with params:\n{params}", cause=result.error) from result.error
 
-        log.debug("Returning result:\n%s", result.payload)
-        return result.payload
+        raise AssertionError("unreachable")  # loop always returns or raises
 
     @abstractmethod
     def _send_payload(self, payload: StringDict) -> None:

--- a/src/solidlsp/ls_process.py
+++ b/src/solidlsp/ls_process.py
@@ -7,7 +7,7 @@ import subprocess
 import threading
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from queue import Empty, Queue
 from typing import IO, Any, AnyStr, cast
@@ -38,9 +38,13 @@ log = logging.getLogger(__name__)
 
 # Per the LSP spec, `ContentModified` (-32801) means the server discarded a stale, in-flight
 # computation because the workspace changed underneath it, not that the request itself is
-# invalid. A well-behaved client is expected to retry such requests rather than treat them as
-# a hard failure, so we do so here, generically, for all requests to any language server.
-_CONTENT_MODIFIED_MAX_ATTEMPTS = 5
+# invalid. A well-behaved client is expected to retry such requests -- but only requests it has
+# declared, via `general.staleRequestSupport.retryOnContentModified` in its InitializeParams, that
+# it will retry. We honor that contract: `send_request` only retries methods a given language
+# server implementation has actually opted into via `set_content_modified_retry_methods` (see
+# `SolidLanguageServer._create_initialize_params`), so this mechanism is a no-op for any server
+# that hasn't declared such methods.
+_CONTENT_MODIFIED_MAX_ATTEMPTS = 3
 _CONTENT_MODIFIED_RETRY_DELAY = 0.2
 
 
@@ -162,11 +166,33 @@ class LanguageServerInterface(ABC):
         self._response_handlers_lock = threading.Lock()
         self._tasks_lock = threading.Lock()
 
+        self._content_modified_retry_methods: frozenset[str] = frozenset()
+        """
+        The set of LSP method names for which `send_request` will retry a `ContentModified`
+        (-32801) response instead of raising immediately. Empty by default, i.e. no retries,
+        since retrying is only correct for methods this client has told the server (via
+        `general.staleRequestSupport.retryOnContentModified`) that it will reissue; see
+        `set_content_modified_retry_methods`.
+        """
+
     def set_request_timeout(self, timeout: float | None) -> None:
         """
         :param timeout: the timeout, in seconds, for all requests sent to the language server.
         """
         self._request_timeout = timeout
+
+    def set_content_modified_retry_methods(self, methods: Iterable[str]) -> None:
+        """
+        Declares the LSP method names for which `send_request` should retry `ContentModified`
+        (-32801) responses. This should mirror whatever methods are declared in
+        `general.staleRequestSupport.retryOnContentModified` of the InitializeParams sent to the
+        server: that declaration is a promise to the server about which requests the client will
+        reissue on cancellation, so retrying anything outside of it would contradict what the
+        server was told.
+
+        :param methods: LSP method names (e.g. ``"textDocument/hover"``) eligible for retry.
+        """
+        self._content_modified_retry_methods = frozenset(methods)
 
     @abstractmethod
     def is_running(self) -> bool:
@@ -303,44 +329,55 @@ class LanguageServerInterface(ABC):
                 request.on_error(exception)
             self._pending_requests.clear()
 
+    def _send_request_once(self, method: str, params: dict | None) -> Request.Result:
+        """
+        Sends a single request to the server (no retries) and waits for its response.
+        """
+        with self._request_id_lock:
+            request_id = self.request_id
+            self.request_id += 1
+
+        request = Request(request_id=request_id, method=method)
+        log.debug("Starting: %s", request)
+
+        with self._response_handlers_lock:
+            self._pending_requests[request_id] = request
+
+        self._send_payload(make_request(method, request_id, params))
+
+        log.debug("Waiting for response to request %s with params:\n%s", method, params)
+        result = request.get_result(timeout=self._request_timeout)
+        log.debug("Completed: %s", request)
+        return result
+
     def send_request(self, method: str, params: dict | None = None) -> PayloadLike:
         """
         Send request to the server, register the request id, and wait for the response.
 
-        Requests that fail with the LSP `ContentModified` error (-32801) are retried a bounded
+        If `method` is one of the methods registered via `set_content_modified_retry_methods`,
+        a response failing with the LSP `ContentModified` error (-32801) is retried a bounded
         number of times with a short delay instead of being surfaced to the caller immediately;
-        see `_CONTENT_MODIFIED_MAX_ATTEMPTS` above.
+        see `_CONTENT_MODIFIED_MAX_ATTEMPTS` above. Methods that were not registered are never
+        retried, regardless of the error, so as to not retry requests behind the server's back.
         """
-        for attempt in range(1, _CONTENT_MODIFIED_MAX_ATTEMPTS + 1):
-            with self._request_id_lock:
-                request_id = self.request_id
-                self.request_id += 1
+        result = self._send_request_once(method, params)
+        if not result.is_error():
+            log.debug("Returning result:\n%s", result.payload)
+            return result.payload
 
-            request = Request(request_id=request_id, method=method)
-            log.debug("Starting: %s", request)
-
-            with self._response_handlers_lock:
-                self._pending_requests[request_id] = request
-
-            self._send_payload(make_request(method, request_id, params))
-
-            log.debug("Waiting for response to request %s with params:\n%s", method, params)
-            result = request.get_result(timeout=self._request_timeout)
-            log.debug("Completed: %s", request)
-
-            if not result.is_error():
-                log.debug("Returning result:\n%s", result.payload)
-                return result.payload
-
-            is_content_modified = isinstance(result.error, LSPError) and result.error.code == LSPErrorCodes.ContentModified
-            if attempt < _CONTENT_MODIFIED_MAX_ATTEMPTS and is_content_modified:
+        if method in self._content_modified_retry_methods:
+            for attempt in range(2, _CONTENT_MODIFIED_MAX_ATTEMPTS + 1):
+                is_content_modified = isinstance(result.error, LSPError) and result.error.code == LSPErrorCodes.ContentModified
+                if not is_content_modified:
+                    break
                 log.info("Request %s got ContentModified (-32801); retrying (%d/%d)", method, attempt, _CONTENT_MODIFIED_MAX_ATTEMPTS)
                 time.sleep(_CONTENT_MODIFIED_RETRY_DELAY)
-                continue
+                result = self._send_request_once(method, params)
+                if not result.is_error():
+                    log.debug("Returning result:\n%s", result.payload)
+                    return result.payload
 
-            raise SolidLSPException(f"Error processing request {method} with params:\n{params}", cause=result.error) from result.error
-
-        raise AssertionError("unreachable")  # loop always returns or raises
+        raise SolidLSPException(f"Error processing request {method} with params:\n{params}", cause=result.error) from result.error
 
     @abstractmethod
     def _send_payload(self, payload: StringDict) -> None:

--- a/test/solidlsp/test_content_modified_retry.py
+++ b/test/solidlsp/test_content_modified_retry.py
@@ -1,0 +1,85 @@
+"""Unit tests: ``LanguageServerInterface.send_request`` retries LSP ``ContentModified`` errors.
+
+Per the LSP spec, ``ContentModified`` (-32801) means the server discarded a stale, in-flight
+computation because the workspace changed underneath it, not that the request itself is
+invalid -- clients are expected to retry. This is what caused issue #1724 (flaky
+``test_find_symbol[rust_add_function]`` on windows-latest): rust-analyzer returns
+``ContentModified`` for cancelled hover requests, and Serena surfaced it as a hard error.
+
+No language markers: these use a local test double and run in catch-all.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from solidlsp import ls_process
+from solidlsp.ls_config import Language
+from solidlsp.ls_exceptions import SolidLSPException
+from solidlsp.ls_process import LanguageServerInterface, Request
+from solidlsp.lsp_protocol_handler.lsp_types import LSPErrorCodes
+from solidlsp.lsp_protocol_handler.server import LSPError
+
+
+class _ScriptedServer(LanguageServerInterface):
+    """Test double that answers each request synchronously from a scripted list of results,
+    without a real language server process.
+    """
+
+    def __init__(self, results: list[Request.Result]) -> None:
+        super().__init__(Language.PYTHON, lambda _line: logging.INFO)
+        self._results = list(results)
+        self.sent_payload_count = 0
+
+    def is_running(self) -> bool:
+        return True
+
+    def _start(self) -> None:
+        pass
+
+    def _stop(self, timeout: float) -> None:
+        pass
+
+    def _send_payload(self, payload: dict) -> None:
+        self.sent_payload_count += 1
+        request = self._pending_requests[payload["id"]]
+        result = self._results.pop(0)
+        if result.is_error():
+            request.on_error(result.error)
+        else:
+            request.on_result(result.payload)
+
+
+def _content_modified() -> Request.Result:
+    return Request.Result(error=LSPError(LSPErrorCodes.ContentModified, "content modified"))
+
+
+def test_content_modified_is_retried_until_success() -> None:
+    server = _ScriptedServer([_content_modified(), _content_modified(), Request.Result(payload={"contents": "ok"})])
+    assert server.send_request("textDocument/hover") == {"contents": "ok"}
+    assert server.sent_payload_count == 3
+
+
+def test_content_modified_gives_up_after_max_attempts() -> None:
+    max_attempts = ls_process._CONTENT_MODIFIED_MAX_ATTEMPTS
+    server = _ScriptedServer([_content_modified() for _ in range(max_attempts)])
+    with pytest.raises(SolidLSPException):
+        server.send_request("textDocument/hover")
+    assert server.sent_payload_count == max_attempts
+
+
+def test_other_lsp_errors_are_not_retried() -> None:
+    server = _ScriptedServer([Request.Result(error=LSPError(LSPErrorCodes.RequestFailed, "boom"))])
+    with pytest.raises(SolidLSPException):
+        server.send_request("textDocument/hover")
+    assert server.sent_payload_count == 1
+
+
+def test_request_cancelled_is_not_retried() -> None:
+    """-32800 is client-initiated cancellation per the LSP spec, so it must not be retried here."""
+    server = _ScriptedServer([Request.Result(error=LSPError(LSPErrorCodes.RequestCancelled, "cancelled"))])
+    with pytest.raises(SolidLSPException):
+        server.send_request("textDocument/hover")
+    assert server.sent_payload_count == 1

--- a/test/solidlsp/test_content_modified_retry.py
+++ b/test/solidlsp/test_content_modified_retry.py
@@ -6,6 +6,11 @@ invalid -- clients are expected to retry. This is what caused issue #1724 (flaky
 ``test_find_symbol[rust_add_function]`` on windows-latest): rust-analyzer returns
 ``ContentModified`` for cancelled hover requests, and Serena surfaced it as a hard error.
 
+Retrying is only spec-compliant for methods the client actually declared, via
+``general.staleRequestSupport.retryOnContentModified`` in its InitializeParams, that it will
+retry -- so ``send_request`` only retries methods registered with it through
+``set_content_modified_retry_methods`` (see ``SolidLanguageServer._create_initialize_params``).
+
 No language markers: these use a local test double and run in catch-all.
 """
 
@@ -23,15 +28,22 @@ from solidlsp.lsp_protocol_handler.lsp_types import LSPErrorCodes
 from solidlsp.lsp_protocol_handler.server import LSPError
 
 
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The retry delay is only there to be polite to the real server; don't pay for it in tests."""
+    monkeypatch.setattr(ls_process.time, "sleep", lambda _seconds: None)
+
+
 class _ScriptedServer(LanguageServerInterface):
     """Test double that answers each request synchronously from a scripted list of results,
     without a real language server process.
     """
 
-    def __init__(self, results: list[Request.Result]) -> None:
+    def __init__(self, results: list[Request.Result], retry_methods: tuple[str, ...] = ("textDocument/hover",)) -> None:
         super().__init__(Language.PYTHON, lambda _line: logging.INFO)
         self._results = list(results)
         self.sent_payload_count = 0
+        self.set_content_modified_retry_methods(retry_methods)
 
     def is_running(self) -> bool:
         return True
@@ -80,6 +92,27 @@ def test_other_lsp_errors_are_not_retried() -> None:
 def test_request_cancelled_is_not_retried() -> None:
     """-32800 is client-initiated cancellation per the LSP spec, so it must not be retried here."""
     server = _ScriptedServer([Request.Result(error=LSPError(LSPErrorCodes.RequestCancelled, "cancelled"))])
+    with pytest.raises(SolidLSPException):
+        server.send_request("textDocument/hover")
+    assert server.sent_payload_count == 1
+
+
+def test_content_modified_is_not_retried_for_undeclared_method() -> None:
+    """Retrying is a promise to the server about which methods will be reissued (per
+    ``general.staleRequestSupport.retryOnContentModified``); a method that was never registered
+    via ``set_content_modified_retry_methods`` must not be retried, even on ContentModified.
+    This also covers non-idempotent requests like ``workspace/executeCommand``, which no server
+    declaration should ever include.
+    """
+    server = _ScriptedServer([_content_modified()], retry_methods=("textDocument/hover",))
+    with pytest.raises(SolidLSPException):
+        server.send_request("workspace/executeCommand")
+    assert server.sent_payload_count == 1
+
+
+def test_content_modified_retry_methods_default_to_empty() -> None:
+    """A server that never calls `set_content_modified_retry_methods` must not retry anything."""
+    server = _ScriptedServer([_content_modified()], retry_methods=())
     with pytest.raises(SolidLSPException):
         server.send_request("textDocument/hover")
     assert server.sent_payload_count == 1


### PR DESCRIPTION
Closes https://github.com/oraios/serena/issues/1724

## Problem

`-32801` is the LSP `ContentModified` error. Per the spec, it means the server discarded a stale, in-flight computation because the workspace changed underneath it — not that the request itself is invalid — so a well-behaved client is expected to retry, *provided it told the server it would*.

`LanguageServerInterface.send_request` (`src/solidlsp/ls_process.py`) converted any error response, including `ContentModified`, straight into a hard `SolidLSPException`, with no retry, for every language server.

This surfaced as the flaky `test_find_symbol[rust_add_function]` failure on `windows-latest` described in the issue: rust-analyzer returns `ContentModified` for hover requests cancelled by its own background re-indexing (`content_modified_error()` in `dispatch.rs`; hover isn't in rust-analyzer's internal retry set), and nothing on Serena's side retried it, so a transient cancellation became a hard test failure (and, in production, a failed tool call). Concretely: `FindSymbolTool.apply(..., include_info=True)` → `LanguageServerSymbolRetriever._request_info` → `request_hover` → `textDocument/hover`.

## Fix

`send_request` retries a response carrying LSP error code `ContentModified` (-32801), but **only for methods a server has declared it wants retried**, via the standard LSP client capability `general.staleRequestSupport.retryOnContentModified` in its `InitializeParams`. That declaration is the client's contract with the server about exactly which requests it will reissue on cancellation (LSP spec, `StaleRequestSupportClientCapabilities`); blindly retrying every method, including non-idempotent ones like `workspace/executeCommand`, would contradict it.

Mechanism:
- `LanguageServerInterface.set_content_modified_retry_methods(methods)` (new) registers the allowlist on the interface. Empty by default — no declaration means no retries, for any server.
- `SolidLanguageServer._create_initialize_params()` now calls this right after building each server's `InitializeParams`, reading the methods back out of `capabilities.general.staleRequestSupport.retryOnContentModified`. This is a single hook shared by all ~69 language server implementations (they all call `_create_initialize_params()`), so no per-server wiring is needed beyond declaring the capability.
- `send_request` checks the method against that allowlist before retrying; everything else (including undeclared methods on servers that *do* declare something) is surfaced immediately, as before this PR.
- rust-analyzer (`rust_analyzer.py`) now adds `textDocument/hover` to its existing `retryOnContentModified` declaration (previously just the three `semanticTokens/*` methods), since that's the method the issue's repro actually needs.
- No other server declares any methods in `retryOnContentModified` today (`haskell_language_server.py` explicitly declares `[]`; jdtls/kotlin/sourcekit/omnisharp already declared the three `semanticTokens/*` methods pre-existing this PR), so the retry mechanism is inert for them, same as before this PR.

`RequestCancelled` (-32800) is deliberately *not* retried here: per the spec it means the client itself cancelled the request, so retrying it generically wouldn't make sense.

**pyrefly interaction (double-retry avoided):** `pyrefly_server.py` wraps `send_request` with its own pre-existing 5×/0.2s retry for `RequestCancelled`/`ContentModified` (`_install_mutation_retry`), unrelated to LSP capability negotiation. An earlier version of this PR added an *unconditional* base-class retry, which nested inside pyrefly's wrapper (5×5=25 round-trips worst case). With the allowlist, this resolves itself: pyrefly never declares `general.staleRequestSupport`, so the base-class retry is a no-op for every pyrefly request, and pyrefly's own wrapper remains the sole handler, exactly as before this PR touched anything. `pyrefly_server.py` is intentionally left unmodified — verified by reproducing its exact wrapping pattern against a scripted `LanguageServerInterface` double: 5 total dispatches (pyrefly's own `max_retries`), not 5×3.

**Latency:** `_CONTENT_MODIFIED_MAX_ATTEMPTS` reduced from 5 to 3 (2 retries), and now scoped to allowlisted methods only. Worst case for the one method that's actually retried by default (rust-analyzer's `textDocument/hover`) is 2 extra attempts: **`2 * request_timeout + 0.4s`** added latency versus a single failing attempt (down from `4 * request_timeout + 0.8s`).

`send_request` is restructured around a `_send_request_once` helper: the first attempt always runs, then (only if the method is allowlisted) a bounded retry loop runs, and the final `raise` on exhaustion is reached through ordinary control flow rather than a trailing `raise AssertionError("unreachable")`.

## Testing

`test/solidlsp/test_content_modified_retry.py`: a lightweight `LanguageServerInterface` test double that answers requests synchronously from a scripted list of results, with no real language server process. Covers:
- `ContentModified` is retried until a later attempt succeeds (method registered)
- retries are bounded — gives up and raises after the max attempt count
- other LSP errors (e.g. `RequestFailed`) are not retried
- `RequestCancelled` (-32800) is not retried
- `ContentModified` is **not** retried for a method that wasn't registered (also covers `workspace/executeCommand` specifically, as a non-idempotent example)
- `ContentModified` is **not** retried when nothing was ever registered (the pyrefly-shaped default)

`time.sleep` is monkeypatched in this suite so it runs in ~0.01s instead of ~1.2s of real sleeping.

```
$ uv run pytest test/solidlsp/test_content_modified_retry.py -v
test/solidlsp/test_content_modified_retry.py::test_content_modified_is_retried_until_success PASSED
test/solidlsp/test_content_modified_retry.py::test_content_modified_gives_up_after_max_attempts PASSED
test/solidlsp/test_content_modified_retry.py::test_other_lsp_errors_are_not_retried PASSED
test/solidlsp/test_content_modified_retry.py::test_request_cancelled_is_not_retried PASSED
test/solidlsp/test_content_modified_retry.py::test_content_modified_is_not_retried_for_undeclared_method PASSED
test/solidlsp/test_content_modified_retry.py::test_content_modified_retry_methods_default_to_empty PASSED
6 passed in 0.01s
```

Also ran the full non-language-gated `test/solidlsp` unit suite, which includes real Python-language-server integration tests (`test_ls_common.py`, `test_rename_didopen.py`) that exercise `_create_initialize_params()` end-to-end against a running language server — all green, no regressions:
```
$ uv run pytest test/solidlsp/test_content_modified_retry.py test/solidlsp/test_typescript_timeout_policy.py \
    test/solidlsp/test_ls_common.py test/solidlsp/test_symbol_body.py test/solidlsp/test_rename_didopen.py \
    test/solidlsp/test_lsp_protocol_handler_server.py test/solidlsp/test_ls_config.py \
    test/solidlsp/test_is_ignored_path_missing.py test/solidlsp/test_text_utils.py
76 passed in 9.16s
```

Lint / type-check:
```
$ uv run ruff check src/solidlsp/ls_process.py src/solidlsp/ls.py src/solidlsp/language_servers/rust_analyzer.py test/solidlsp/test_content_modified_retry.py
All checks passed!
$ uv run ty check src/serena src/solidlsp
All checks passed!
$ uv run ty check test --exclude test/resources
All checks passed!
```

I don't have a Rust toolchain available locally, so I wasn't able to reproduce/re-run the original `test_find_symbol[rust_add_function]` rust-analyzer test directly, but the retry-methods unit tests exercise the exact mechanism that closes the gap the issue describes, including that it's now scoped to the specific method (`textDocument/hover`) the issue needs.

Also updated the `CHANGELOG.md` entry under "Language Servers" to match.
