### PR TITLE
Docs: use SessionEnd for Codex hook cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Hooks:
   - Add `serena-hooks --client=grok`, including Grok-native PreToolUse allow/deny output.
+  - Use `SessionEnd` for Codex 0.145.0+ cleanup hooks, retaining `Stop` compatibility for older Codex versions.
   - PreToolUse remind hook: coerce non-string shell command values instead of failing, and recognize
     `target_file`/`targetFile` file-path keys (shared payload parsing, applies to all hook clients).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Hooks:
   - Add `serena-hooks --client=grok`, including Grok-native PreToolUse allow/deny output.
-  - Use `SessionEnd` for Codex 0.145.0+ cleanup hooks, retaining `Stop` compatibility for older Codex versions.
+  - Use `SessionEnd` for Codex 0.145.0+ cleanup hooks and document the known `Stop` compatibility issue affecting older Codex versions.
   - PreToolUse remind hook: coerce non-string shell command values instead of failing, and recognize
     `target_file`/`targetFile` file-path keys (shared payload parsing, applies to all hook clients).
 

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -355,7 +355,7 @@ Then create `~/.codex/hooks.json` with the following content:
                 ]
             }
         ],
-        "Stop": [
+        "SessionEnd": [
             {
                 "hooks": [
                     {
@@ -368,6 +368,10 @@ Then create `~/.codex/hooks.json` with the following content:
     }
 }
 ```
+
+The `SessionEnd` cleanup hook requires Codex 0.145.0 or newer. On older Codex versions, replace
+`SessionEnd` with `Stop` in the example above. Configure cleanup under exactly one of these events,
+never both: `Stop` runs after every turn, while `SessionEnd` runs when Codex tears down the root thread.
 
 The hooks will:
 

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -369,9 +369,11 @@ Then create `~/.codex/hooks.json` with the following content:
 }
 ```
 
-The `SessionEnd` cleanup hook requires Codex 0.145.0 or newer. On older Codex versions, replace
-`SessionEnd` with `Stop` in the example above. Configure cleanup under exactly one of these events,
-never both: `Stop` runs after every turn, while `SessionEnd` runs when Codex tears down the root thread.
+The `SessionEnd` cleanup hook requires Codex 0.145.0 or newer. Older Codex versions only support
+`Stop` for cleanup, which currently has a [known compatibility issue](https://github.com/oraios/serena/issues/1533).
+If you still configure it, replace `SessionEnd` with `Stop` in the example above. Configure cleanup
+under exactly one of these events, never both: `Stop` runs after every turn, while `SessionEnd` runs
+when Codex tears down the root thread.
 
 The hooks will:
 


### PR DESCRIPTION
## Summary

- use Codex `SessionEnd` for Serena hook-data cleanup on Codex 0.145.0 and newer
- document `Stop` as the only cleanup event on older Codex versions and link its known compatibility issue
- add the lifecycle change to the Unreleased Hooks changelog

## Why

Codex 0.145.0 added `SessionEnd` for root-thread teardown. Serena's current Codex example instead runs cleanup from `Stop`, which fires after every turn and removes the per-session hook counters between prompts.

Older Codex versions only expose `Stop` for cleanup. Serena currently has a known output-compatibility issue with that event, tracked in #1533. The documentation now states that limitation instead of presenting `Stop` as a working fallback. #1687 is a possible follow-up fix, not a dependency for this documentation change.

Related to #1533. Codex lifecycle change: https://github.com/openai/codex/pull/33895

## Validation

- `uv run --frozen --extra dev pytest test/serena/test_hooks.py::TestSessionEndCleanupHook test/serena/test_hooks.py::TestHookCli::test_cleanup_command -q` (3 passed)
- `uv run --frozen --extra dev poe doc-build`
- parsed the documented Codex JSON and verified cleanup appears exactly once under `SessionEnd`
- synthetic hook lifecycle smoke test verified state persists across repeated calls and is removed by `SessionEnd`
- `git diff --check`
