### PR TITLE
Fix project CLI language server aliases

### DIFF
--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -733,9 +733,10 @@ class ProjectCommands(AutoRegisteringGroup):
     @click.option(
         "--ls",
         "--language",
+        "language",
         type=str,
         multiple=True,
-        help="Programming language(s); inferred if not specified. Can be passed multiple times.",
+        help="Language server(s); inferred if not specified. Can be passed multiple times.",
     )
     @click.option("--index", is_flag=True, help="Index the project after creation.")
     @click.option(
@@ -767,9 +768,10 @@ class ProjectCommands(AutoRegisteringGroup):
     @click.option(
         "--ls",
         "--language",
+        "language",
         type=str,
         multiple=True,
-        help="Programming language(s) (only used if auto-creating project.yml). Inferred if not specified.",
+        help="Language server(s) (only used if auto-creating project.yml). Inferred if not specified.",
     )
     @click.option(
         "--log-level",

--- a/test/serena/test_cli_project_commands.py
+++ b/test/serena/test_cli_project_commands.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 import pytest
+from click import Command, Option
 from click.testing import CliRunner
 
 from serena.cli import ProjectCommands, TopLevelCommands, find_project_root
@@ -49,6 +50,14 @@ def temp_project_dir_with_python_file():
 def cli_runner():
     """Create a CliRunner for testing Click commands."""
     return CliRunner()
+
+
+@pytest.mark.parametrize("command", [ProjectCommands.create, ProjectCommands.index])
+def test_language_server_aliases_bind_to_language_parameter(command: Command) -> None:
+    language_option = next(option for option in command.params if isinstance(option, Option) and "--ls" in option.opts)
+
+    assert language_option.name == "language"
+    assert language_option.opts == ["--ls", "--language"]
 
 
 class TestProjectCreate:


### PR DESCRIPTION
## Summary

- Explicitly bind the `--ls` and `--language` aliases to the existing `language` callback parameter for `project create` and `project index`.
- Add regression coverage for the aliases on both commands.
- Document the fix in the changelog.

## Root cause

PR #1739 added `--ls` before `--language` in both Click option declarations. Click consequently inferred `ls` as the callback keyword, while both callbacks still accepted `language`, causing every invocation to fail with `unexpected keyword argument 'ls'`.

## Impact

Both aliases now reach the existing callback parameter, restoring `project create` and `project index` without changing their user-facing options.

## Validation

- `python -m ruff format --check src/serena/cli.py test/serena/test_cli_project_commands.py`
- `python -m ruff check src/serena/cli.py test/serena/test_cli_project_commands.py`
- `python -m ty check src/serena/cli.py test/serena/test_cli_project_commands.py`
- Focused pytest regression coverage: 3 passed

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.
