### PR TITLE
Fix: execute_shell_command has no timeout, wedging the task executor on a hung command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Status of the `main` branch. Changes prior to the next official version change w
   - The `languages` key in project configurations was changed to `language_servers` to better reflect
     the actual semantics (configurations are automatically migrated)
   - Fix: glob matching bare `*` and `?` in non-`**` patterns matched across `/`, contradicting documented behaviour #1732
+  - Fix: `execute_shell_command` had no timeout, so a hung command blocked indefinitely. Since the
+    agent's task executor runs on a single dispatcher thread that waits for the current task before
+    picking up the next, this also stalled every subsequent tool call, not just the shell command
+    itself. `ExecuteShellCommandTool` now bounds shell commands with the existing `tool_timeout`
+    config value and terminates the process tree (not just the top-level shell) on expiry #1251
 
 * Language Servers: 
   - Allow language server priorities to be configured in `serena_config.yml` (for auto-detection during 

--- a/src/serena/tools/cmd_tools.py
+++ b/src/serena/tools/cmd_tools.py
@@ -47,6 +47,6 @@ class ExecuteShellCommandTool(Tool, ToolMarkerCanEdit):
                         f"Specified a relative working directory ({cwd}), but the resulting path is not a directory: {_cwd}"
                     )
 
-        result = execute_shell_command(command, cwd=_cwd, capture_stderr=capture_stderr)
+        result = execute_shell_command(command, cwd=_cwd, capture_stderr=capture_stderr, timeout=self.agent.serena_config.tool_timeout)
         result = result.model_dump_json()
         return self._limit_length(result, max_answer_chars)

--- a/src/serena/util/shell.py
+++ b/src/serena/util/shell.py
@@ -3,7 +3,7 @@ import subprocess
 
 from pydantic import BaseModel
 
-from solidlsp.util.subprocess_util import subprocess_kwargs
+from solidlsp.util.subprocess_util import subprocess_kwargs, terminate_process_tree_with_kill_fallback
 
 
 class ShellCommandResult(BaseModel):
@@ -13,13 +13,18 @@ class ShellCommandResult(BaseModel):
     stderr: str | None = None
 
 
-def execute_shell_command(command: str, cwd: str | None = None, capture_stderr: bool = False) -> ShellCommandResult:
+def execute_shell_command(
+    command: str, cwd: str | None = None, capture_stderr: bool = False, timeout: float | None = None
+) -> ShellCommandResult:
     """
     Execute a shell command and return the output.
 
     :param command: The command to execute.
     :param cwd: The working directory to execute the command in. If None, the current working directory will be used.
     :param capture_stderr: Whether to capture the stderr output.
+    :param timeout: The maximum time to wait for the command to complete, in seconds. If it does not complete in
+        time, the process (and any children it spawned) is terminated and subprocess.TimeoutExpired is raised.
+        None (the default) waits indefinitely.
     :return: The output of the command.
     """
     if cwd is None:
@@ -38,7 +43,13 @@ def execute_shell_command(command: str, cwd: str | None = None, capture_stderr: 
         **subprocess_kwargs(),
     )
 
-    stdout, stderr = process.communicate()
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        terminate_process_tree_with_kill_fallback(process, terminate_timeout=5.0, process_name="Shell command")
+        process.communicate()  # reap the process now that it has been terminated
+        raise
+
     return ShellCommandResult(stdout=stdout, stderr=stderr, return_code=process.returncode, cwd=cwd)
 
 

--- a/test/serena/util/test_shell.py
+++ b/test/serena/util/test_shell.py
@@ -1,0 +1,43 @@
+import platform
+import subprocess
+import time
+
+import psutil
+import pytest
+
+from serena.util.shell import execute_shell_command
+
+
+class TestExecuteShellCommandTimeout:
+    def test_no_timeout_runs_to_completion(self):
+        result = execute_shell_command("echo hello")
+        assert result.stdout.strip() == "hello"
+        assert result.return_code == 0
+
+    def test_timeout_raises_and_kills_process(self):
+        command = "sleep 60"
+        start = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired):
+            execute_shell_command(command, timeout=1)
+        elapsed = time.monotonic() - start
+        # the call must not block for anywhere near the full duration of the hung command
+        assert elapsed < 30
+
+        # give the OS a moment to reflect the kill, then confirm no "sleep 60" process survives
+        time.sleep(1)
+        for proc in psutil.process_iter(["cmdline"]):
+            cmdline = " ".join(proc.info.get("cmdline") or [])
+            assert command not in cmdline, f"orphaned process still running: {proc.info}"
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="shell pipeline spawns differ on Windows")
+    def test_timeout_kills_child_of_shell_pipeline(self):
+        # the actual long-running process is a grandchild of the shell serena spawns (shell=True),
+        # so the fix must terminate the whole process tree, not just the top-level shell pid
+        command = "sh -c 'sleep 60'"
+        with pytest.raises(subprocess.TimeoutExpired):
+            execute_shell_command(command, timeout=1)
+
+        time.sleep(1)
+        for proc in psutil.process_iter(["cmdline"]):
+            cmdline = " ".join(proc.info.get("cmdline") or [])
+            assert "sleep 60" not in cmdline, f"orphaned child process still running: {proc.info}"


### PR DESCRIPTION
This addresses Finding #2 of #1251 ("Shell execution with no timeout"). The other five findings in that issue are broader design questions (memory path traversal, cross-project memory, directory activation, prompt injection surface, system prompt exposure); this PR is scoped to the shell timeout only and does not close the issue.

Root cause: `execute_shell_command` (src/serena/util/shell.py) calls `process.communicate()` with no timeout, so a hung or long-running command blocks forever. The impact is bigger than the single tool call: `TaskExecutor._process_task_queue` (src/serena/task_executor.py) runs on one dispatcher thread that waits on the current task (`task.wait_until_done(timeout=task.timeout)`, and `ExecuteShellCommandTool`'s call site never passes a `timeout`, so it waits indefinitely) before it will pick up the next queued task. `Tool.apply_ex` separately waits on the same future with `serena_config.tool_timeout` (240s default) and turns an expiry into an error message for the caller, which makes it look like the situation is recovered, but the dispatcher thread underneath is still blocked on the original hung subprocess and never starts any task queued after it.

I confirmed this with a standalone script against the real `TaskExecutor`/`execute_shell_command` classes (no mocks): issuing a `sleep 30` shell task with no timeout, then a trivial second task right after. The caller's own 5s wait on the first task times out as expected, but the second task is still not done 3s later, the dispatcher never even started it.

Fix: `execute_shell_command` takes an optional `timeout` parameter (default `None`, preserving current behavior for its other callers in `client_setup.py`). On expiry it terminates the whole process tree via the existing `terminate_process_tree_with_kill_fallback` helper (already used in `agent.py` and `ls_process.py`) rather than just the top-level shell process, since `shell=True` means the actual long-running command is a child of the shell. `TimeoutExpired` then propagates, which `Tool.apply_ex`'s existing exception handling already turns into a clean error message for the caller. `ExecuteShellCommandTool` now passes `timeout=self.agent.serena_config.tool_timeout`, so a shell command is bounded by the same value the tool call was already conceptually bounded by.

Verified in a clean Docker container (python:3.12-slim, `uv sync --extra dev --locked`):
- New regression test (`test/serena/util/test_shell.py`) fails on main (`TypeError: execute_shell_command() got an unexpected keyword argument 'timeout'`) and passes on this branch, including a case where the hung process is a child of a `sh -c` pipeline (confirms the whole tree is killed, not just the top pid).
- The same standalone dispatcher-wedge script above, re-run against the fixed code with `timeout=2`, shows the second queued task now completes shortly after the first fails, instead of never starting.
- `uv run poe lint`, `uv run poe type-check`, and `codespell` on the changed files are all clean.
- Full `uv run poe test` catch-all matrix: 1007 passed, 32 failed, 97 errors, all failures/errors are in scss/solidity/typescript/vue language-server tests that need Node-based LSP toolchains not installed in this minimal image; none touch `serena/util/shell.py`, `serena/tools/cmd_tools.py`, or `serena/task_executor.py`. The directly relevant suites (`test/serena/util/test_shell.py`, `test/serena/config/test_client_setup.py`, `test/serena/test_cli_setup.py`, `test/serena/config/test_context_mode.py`, all other `execute_shell_command` callers) pass in full.

Not verified: behavior under the real MCP/agent stack end to end (the dispatcher-wedge proof above uses `TaskExecutor` and `execute_shell_command` directly, not a live agent session), and the full pytest matrix on the Node-based language servers (environment limitation, not exercised by this change).
