### PR TITLE
Add first-class Devin CLI support (one-command setup, context reminders, full instructions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: a tool call exceeding the timeout blocked the task executor indefinitely; the executor now
     recovers without user-induced cancellation
   - Add Grok Build support (context `grok`, setup CLI, hooks)
-  - Add Devin CLI support (context `devin`, setup CLI, hooks)
+  - Add Devin CLI support (context `devin`, setup CLI, hooks, one-command installer with permissions, hooks, query-projects mode and web-dashboard disable)
   - The `languages` key in project configurations was changed to `language_servers` to better reflect
     the actual semantics (configurations are automatically migrated)
   - Fix: glob matching bare `*` and `?` in non-`**` patterns matched across `/`, contradicting documented behaviour #1732

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: a tool call exceeding the timeout blocked the task executor indefinitely; the executor now
     recovers without user-induced cancellation
   - Add Grok Build support (context `grok`, setup CLI, hooks)
+  - Add Devin CLI support (context `devin`, setup CLI, hooks)
   - The `languages` key in project configurations was changed to `language_servers` to better reflect
     the actual semantics (configurations are automatically migrated)
   - Fix: glob matching bare `*` and `?` in non-`**` patterns matched across `/`, contradicting documented behaviour #1732

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -694,6 +694,89 @@ CodeBuddy supports the same hook system as Claude Code. To set up hooks, add the
   permission mode (`acceptEdits` or `auto`), so blanket approvals cover Serena's destructive
   tools (e.g. `replace_symbol_body`, `rename_symbol`) instead of prompting on every call.
 
+## Devin CLI
+
+Serena can be used as an MCP server inside Devin CLI. To set up the Serena MCP server for Devin CLI, simply run:
+
+    serena setup devin
+
+### Manual Setup
+
+**Global Configuration**. To add the Serena MCP server for all your projects, use Devin CLI's user-level configuration and the `--project-from-cwd` flag:
+
+```bash
+devin mcp add -s user serena -- serena start-mcp-server --context=devin --project-from-cwd
+```
+
+**Project-Level Configuration**. To add the Serena MCP server for a single project only:
+
+```bash
+devin mcp add -s project serena -- serena start-mcp-server --context=devin --project "$(pwd)"
+```
+
+**Verification.**
+Run `devin mcp list` and verify that Serena is listed as an MCP server.
+
+### Hooks
+
+Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the `hooks` key in `~/.config/devin/config.json` (global). To enable Serena's hooks globally, add the following under the `hooks` key in `~/.config/devin/config.json`:
+
+```json
+{
+  "SessionStart": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "serena-hooks activate --client=devin",
+          "timeout": 5
+        }
+      ]
+    }
+  ],
+  "PreToolUse": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "serena-hooks remind --client=devin",
+          "timeout": 5
+        }
+      ]
+    },
+    {
+      "matcher": "mcp__serena__*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "serena-hooks auto-approve --client=devin",
+          "timeout": 5
+        }
+      ]
+    }
+  ],
+  "SessionEnd": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "serena-hooks cleanup --client=devin",
+          "timeout": 5
+        }
+      ]
+    }
+  ]
+}
+```
+
+The hooks will:
+
+- **`activate`**: Prompt the agent to activate the project at the start of the session and read Serena's instructions.
+- **`remind`**: Nudge (and temporarily block) the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between.
+- **`auto-approve`**: Auto-approve Serena symbolic tool calls so blanket approvals cover Serena's destructive tools (e.g. `replace_symbol_body`, `rename_symbol`) instead of prompting on every call.
+- **`cleanup`**: Clean up hook session data when the session ends.
+
 ## Other Clients
 
 For other clients, follow the [general instructions](#clients-general-instructions) above to set up Serena as an MCP server.

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -744,9 +744,11 @@ Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the 
           "timeout": 5
         }
       ]
-    },
+    }
+  ],
+  "PermissionRequest": [
     {
-      "matcher": "mcp__serena__*",
+      "matcher": "mcp__serena__.*",
       "hooks": [
         {
           "type": "command",
@@ -773,7 +775,7 @@ Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the 
 The hooks will:
 
 - **`activate`**: Prompt the agent to activate the project at the start of the session and read Serena's instructions.
-- **`remind`**: Nudge (and temporarily block) the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between.
+- **`remind`**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between. The original tool call is rewritten to a harmless no-op, so the agent cycle keeps running.
 - **`auto-approve`**: Auto-approve Serena symbolic tool calls so blanket approvals cover Serena's destructive tools (e.g. `replace_symbol_body`, `rename_symbol`) instead of prompting on every call.
 - **`cleanup`**: Clean up hook session data when the session ends.
 

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -782,7 +782,7 @@ Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the 
 The hooks will:
 
 - **`activate`**: Prompt the agent to activate the project at the start of the session and read Serena's instructions.
-- **`remind`**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between. When the threshold is reached, the triggering `read`/`grep` call is blocked with a reason (which is shown to the agent); the counter resets, so the agent can immediately continue if it still needs to.
+- **`remind`**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between. When the threshold is reached, the triggering `read`/`grep`/`exec` call is rewritten to a harmless no-op that returns the reminder as its output, so the agent sees the nudge and keeps going. A blocking decision is deliberately avoided here, because Devin CLI cancels the agent's turn on a `block`; the counter resets, so the agent can continue immediately.
 - **`cleanup`**: Clean up hook session data when the session ends.
 
 ## Other Clients

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -717,6 +717,25 @@ devin mcp add -s project serena -- serena start-mcp-server --context=devin --pro
 **Verification.**
 Run `devin mcp list` and verify that Serena is listed as an MCP server.
 
+### Auto-Approving Serena's Tools
+
+MCP tools default to prompting for approval in Devin CLI. To auto-approve Serena's tools (so its
+destructive symbolic tools such as `replace_symbol_body` and `rename_symbol` don't prompt on every
+call), use Devin CLI's native permission allow-list rather than a hook. Add the following under the
+`permissions` key in `~/.config/devin/config.json` (or `.devin/config.json` for a single project):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__serena__*"
+    ]
+  }
+}
+```
+
+See Devin CLI's [permissions documentation](https://docs.devin.ai/cli/reference/permissions#mcp-tool-permissions) for details.
+
 ### Hooks
 
 Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the `hooks` key in `~/.config/devin/config.json` (global). To enable Serena's hooks globally, add the following under the `hooks` key in `~/.config/devin/config.json`:
@@ -746,18 +765,6 @@ Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the 
       ]
     }
   ],
-  "PermissionRequest": [
-    {
-      "matcher": "mcp__serena__.*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "serena-hooks auto-approve --client=devin",
-          "timeout": 5
-        }
-      ]
-    }
-  ],
   "SessionEnd": [
     {
       "hooks": [
@@ -775,8 +782,7 @@ Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the 
 The hooks will:
 
 - **`activate`**: Prompt the agent to activate the project at the start of the session and read Serena's instructions.
-- **`remind`**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between. The original tool call is rewritten to a harmless no-op, so the agent cycle keeps running.
-- **`auto-approve`**: Auto-approve Serena symbolic tool calls so blanket approvals cover Serena's destructive tools (e.g. `replace_symbol_body`, `rename_symbol`) instead of prompting on every call.
+- **`remind`**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between. When the threshold is reached, the triggering `read`/`grep` call is blocked with a reason (which is shown to the agent); the counter resets, so the agent can immediately continue if it still needs to.
 - **`cleanup`**: Clean up hook session data when the session ends.
 
 ## Other Clients

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -700,18 +700,32 @@ Serena can be used as an MCP server inside Devin CLI. To set up the Serena MCP s
 
     serena setup devin
 
+This single command configures everything:
+
+- Registers `serena` as an MCP server with the `devin` context (excluding Devin CLI's built-in `read`, `edit`, `grep`, `glob` and `exec` tools).
+- Enables cross-project querying via `--add-mode query-projects`.
+- Disables the web dashboard (`--enable-web-dashboard false --open-web-dashboard false`).
+- Auto-approves all Serena MCP tools via Devin CLI's `permissions.allow` list.
+- Installs Serena's lifecycle hooks for `SessionStart`, `PreToolUse`, `PostToolUse`, `PostCompaction` and `SessionEnd`.
+
+For a per-project setup instead of a global one, run:
+
+    serena setup devin --project
+
+This writes `.devin/config.json` in the current directory.
+
 ### Manual Setup
 
-**Global Configuration**. To add the Serena MCP server for all your projects, use Devin CLI's user-level configuration and the `--project-from-cwd` flag:
+If you prefer to configure Devin CLI manually, the equivalent global command is:
 
 ```bash
-devin mcp add -s user serena -- serena start-mcp-server --context=devin --project-from-cwd
+devin mcp add -s user serena -- serena start-mcp-server --context=devin --project-from-cwd --enable-web-dashboard false --open-web-dashboard false --add-mode query-projects
 ```
 
-**Project-Level Configuration**. To add the Serena MCP server for a single project only:
+And for a single project:
 
 ```bash
-devin mcp add -s project serena -- serena start-mcp-server --context=devin --project "$(pwd)"
+devin mcp add -s project serena -- serena start-mcp-server --context=devin --project "$(pwd)" --enable-web-dashboard false --open-web-dashboard false --add-mode query-projects
 ```
 
 **Verification.**
@@ -719,10 +733,7 @@ Run `devin mcp list` and verify that Serena is listed as an MCP server.
 
 ### Auto-Approving Serena's Tools
 
-MCP tools default to prompting for approval in Devin CLI. To auto-approve Serena's tools (so its
-destructive symbolic tools such as `replace_symbol_body` and `rename_symbol` don't prompt on every
-call), use Devin CLI's native permission allow-list rather than a hook. Add the following under the
-`permissions` key in `~/.config/devin/config.json` (or `.devin/config.json` for a single project):
+`serena setup devin` adds `mcp__serena__*` to Devin CLI's permission allow-list. If you configure things manually, add the following under the `permissions` key:
 
 ```json
 {
@@ -738,7 +749,7 @@ See Devin CLI's [permissions documentation](https://docs.devin.ai/cli/reference/
 
 ### Hooks
 
-Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the `hooks` key in `~/.config/devin/config.json` (global). To enable Serena's hooks globally, add the following under the `hooks` key in `~/.config/devin/config.json`:
+`serena setup devin` writes the following hooks into Devin CLI's configuration:
 
 ```json
 {
@@ -748,7 +759,7 @@ Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the 
         {
           "type": "command",
           "command": "serena-hooks activate --client=devin",
-          "timeout": 5
+          "timeout": 10
         }
       ]
     }
@@ -761,6 +772,29 @@ Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the 
           "type": "command",
           "command": "serena-hooks remind --client=devin",
           "timeout": 5
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "serena-hooks post-remind --client=devin",
+          "timeout": 5
+        }
+      ]
+    }
+  ],
+  "PostCompaction": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "serena-hooks activate --client=devin --include-instructions --event PostCompaction",
+          "timeout": 10
         }
       ]
     }
@@ -781,9 +815,11 @@ Devin CLI supports lifecycle hooks via `.devin/hooks.v1.json` (project) and the 
 
 The hooks will:
 
-- **`activate`**: Prompt the agent to activate the project at the start of the session and read Serena's instructions.
-- **`remind`**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between. When the threshold is reached, the triggering `read`/`grep`/`exec` call is rewritten to a harmless no-op that returns the reminder as its output, so the agent sees the nudge and keeps going. A blocking decision is deliberately avoided here, because Devin CLI cancels the agent's turn on a `block`; the counter resets, so the agent can continue immediately.
-- **`cleanup`**: Clean up hook session data when the session ends.
+- **`activate` (SessionStart)**: Prompt the agent to activate the project and read Serena's instructions.
+- **`remind` (PreToolUse)**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between. The triggering `read`/`grep`/`exec` call is rewritten to a harmless no-op that returns the reminder as its output, so the agent sees the nudge and keeps going. A blocking decision is deliberately avoided here, because Devin CLI cancels the agent's turn on a `block`; the counter resets, so the agent can continue immediately.
+- **`post-remind` (PostToolUse)**: After a raw read or grep, briefly remind the agent that Serena's symbolic tools are usually more efficient.
+- **`activate --include-instructions` (PostCompaction)**: Re-inject the full Serena system prompt after Devin CLI compacts context, so the model does not lose Serena's instructions.
+- **`cleanup` (SessionEnd)**: Clean up hook session data when the session ends.
 
 ## Other Clients
 

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -706,7 +706,7 @@ This single command configures everything:
 - Enables cross-project querying via `--add-mode query-projects`.
 - Disables the web dashboard (`--enable-web-dashboard false --open-web-dashboard false`).
 - Auto-approves all Serena MCP tools via Devin CLI's `permissions.allow` list.
-- Installs Serena's lifecycle hooks for `SessionStart`, `PreToolUse`, `PostToolUse`, `PostCompaction` and `SessionEnd`.
+- Installs Serena's lifecycle hooks for `SessionStart`, `PreToolUse`, `PostCompaction` and `SessionEnd`.
 
 For a per-project setup instead of a global one, run:
 
@@ -758,7 +758,7 @@ See Devin CLI's [permissions documentation](https://docs.devin.ai/cli/reference/
       "hooks": [
         {
           "type": "command",
-          "command": "serena-hooks activate --client=devin",
+          "command": "serena-hooks activate --client=devin --include-instructions --event SessionStart",
           "timeout": 10
         }
       ]
@@ -771,18 +771,6 @@ See Devin CLI's [permissions documentation](https://docs.devin.ai/cli/reference/
         {
           "type": "command",
           "command": "serena-hooks remind --client=devin",
-          "timeout": 5
-        }
-      ]
-    }
-  ],
-  "PostToolUse": [
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "serena-hooks post-remind --client=devin",
           "timeout": 5
         }
       ]
@@ -815,12 +803,10 @@ See Devin CLI's [permissions documentation](https://docs.devin.ai/cli/reference/
 
 The hooks will:
 
-- **`activate` (SessionStart)**: Prompt the agent to activate the project and read Serena's instructions.
-- **`remind` (PreToolUse)**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive code-search or code-file-read calls without using Serena tools in between. The triggering `read`/`grep`/`exec` call is rewritten to a harmless no-op that returns the reminder as its output, so the agent sees the nudge and keeps going. A blocking decision is deliberately avoided here, because Devin CLI cancels the agent's turn on a `block`; the counter resets, so the agent can continue immediately.
-- **`post-remind` (PostToolUse)**: After a raw read or grep, briefly remind the agent that Serena's symbolic tools are usually more efficient.
+- **`activate --include-instructions` (SessionStart)**: Re-inject the full Serena system prompt at the start of the session so the model starts with Serena's capabilities in context.
+- **`remind` (PreToolUse)**: Add a short reminder in `additionalContext` when the agent makes several consecutive `read`/`grep`/`exec` calls without using Serena's symbolic tools. No tool call is rewritten or blocked; Devin CLI's `block`/`deny` semantics are too fragile and can cancel the turn, so the hook only nudges via context and resets the counter.
 - **`activate --include-instructions` (PostCompaction)**: Re-inject the full Serena system prompt after Devin CLI compacts context, so the model does not lose Serena's instructions.
 - **`cleanup` (SessionEnd)**: Clean up hook session data when the session ends.
-
 ## Other Clients
 
 For other clients, follow the [general instructions](#clients-general-instructions) above to set up Serena as an MCP server.

--- a/docs/02-usage/050_configuration.md
+++ b/docs/02-usage/050_configuration.md
@@ -74,6 +74,7 @@ Serena comes with pre-defined contexts:
   The full set of Serena's tools is provided, as the application is assumed to have no prior coding-specific capabilities.
 * `claude-code`: Optimized for use with Claude Code, it disables tools that would duplicate Claude Code's built-in capabilities.
 * `codex`: Optimized for use with OpenAI Codex.
+* `devin`: Optimized for use with Devin CLI, it disables tools that would duplicate Devin CLI's built-in capabilities.
 * `grok`: Optimized for use with xAI's Grok Build CLI.
 * `ide`: Generic context for IDE assistants/coding agents, e.g. VSCode, Cursor, or Cline, focusing on augmenting existing capabilities.
   Basic file operations and shell execution are assumed to be handled by the assistant's own capabilities.
@@ -83,7 +84,7 @@ Choose the context that best matches the type of integration you are using.
 
 Find the concrete definitions of the above contexts [here](https://github.com/oraios/serena/tree/main/src/serena/resources/config/contexts).
 
-Note that the contexts `ide`, `claude-code`, and `grok` are **single-project contexts** (defining `single_project: true`).
+Note that the contexts `ide`, `claude-code`, `devin`, and `grok` are **single-project contexts** (defining `single_project: true`).
 For such contexts, if a project is provided at startup, the set of tools is limited to those required by the project's
 concrete configuration, and other tools are excluded completely, allowing the set of tools to be minimal.
 Tools explicitly disabled by the project will not be available at all. Since changing the active project

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -62,8 +62,8 @@ For details on mode configuration, see
 """
 
 
-def find_project_root(root: str | Path | None = None, start: str | Path | None = None) -> str | None:
-    """Find project root by walking up from ``start`` (or CWD if omitted).
+def find_project_root(root: str | Path | None = None) -> str | None:
+    """Find project root by walking up from CWD.
 
     Returns the nearest ancestor that is either an explicit Serena project
     (contains .serena/project.yml) or a git root (contains .git, which may be a
@@ -78,10 +78,9 @@ def find_project_root(root: str | Path | None = None, start: str | Path | None =
 
     :param root: If provided, constrains the search to this directory and below
                  (acts as a virtual filesystem root). Search stops at this boundary.
-    :param start: Directory to start the search from. Defaults to the current working directory.
     :return: absolute path to project root or None if not suitable root is found
     """
-    current = Path(start).resolve() if start is not None else Path.cwd().resolve()
+    current = Path.cwd().resolve()
     boundary = Path(root).resolve() if root is not None else None
 
     def ancestors() -> Iterator[Path]:
@@ -359,15 +358,12 @@ class TopLevelCommands(AutoRegisteringGroup):
         if project_from_cwd:
             if project is not None or project_file_arg is not None:
                 raise click.UsageError("--project-from-cwd cannot be used with --project or positional project argument")
-            # Devin CLI sets DEVIN_PROJECT_DIR to the project root for hooks and MCP server processes.
-            # Prefer it when available, then fall back to detecting from the current working directory.
+            # Devin CLI exports DEVIN_PROJECT_DIR as the project root for hook and MCP server
+            # processes; honor it directly (Serena creates its project config there if needed),
+            # since the MCP server may be spawned from a different working directory. Otherwise,
+            # detect the project root by walking up from the current working directory.
             devin_project_dir = os.environ.get("DEVIN_PROJECT_DIR")
-            if devin_project_dir:
-                project = find_project_root(start=devin_project_dir, root=devin_project_dir)
-            else:
-                project = None
-            if project is None:
-                project = find_project_root()
+            project = devin_project_dir or find_project_root()
             if project is not None:
                 log.info("Auto-detected project root: %s", project)
             else:

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -62,8 +62,8 @@ For details on mode configuration, see
 """
 
 
-def find_project_root(root: str | Path | None = None) -> str | None:
-    """Find project root by walking up from CWD.
+def find_project_root(root: str | Path | None = None, start: str | Path | None = None) -> str | None:
+    """Find project root by walking up from ``start`` (the current working directory by default).
 
     Returns the nearest ancestor that is either an explicit Serena project
     (contains .serena/project.yml) or a git root (contains .git, which may be a
@@ -78,9 +78,12 @@ def find_project_root(root: str | Path | None = None) -> str | None:
 
     :param root: If provided, constrains the search to this directory and below
                  (acts as a virtual filesystem root). Search stops at this boundary.
+    :param start: Directory to start the (upward) search from; defaults to the current
+                  working directory. Useful when the process is launched from outside the
+                  project (e.g. Devin CLI exports the project root via ``DEVIN_PROJECT_DIR``).
     :return: absolute path to project root or None if not suitable root is found
     """
-    current = Path.cwd().resolve()
+    current = Path(start).resolve() if start is not None else Path.cwd().resolve()
     boundary = Path(root).resolve() if root is not None else None
 
     def ancestors() -> Iterator[Path]:
@@ -358,12 +361,13 @@ class TopLevelCommands(AutoRegisteringGroup):
         if project_from_cwd:
             if project is not None or project_file_arg is not None:
                 raise click.UsageError("--project-from-cwd cannot be used with --project or positional project argument")
-            # Devin CLI exports DEVIN_PROJECT_DIR as the project root for hook and MCP server
-            # processes; honor it directly (Serena creates its project config there if needed),
-            # since the MCP server may be spawned from a different working directory. Otherwise,
-            # detect the project root by walking up from the current working directory.
-            devin_project_dir = os.environ.get("DEVIN_PROJECT_DIR")
-            project = devin_project_dir or find_project_root()
+            # Devin CLI exports DEVIN_PROJECT_DIR to hook/MCP processes and may spawn the MCP
+            # server from a different working directory, so start the search there when it is set
+            # (falling back to CWD otherwise). Walking up still resolves the real repo root when
+            # DEVIN_PROJECT_DIR points at a subdirectory; if it is not inside any git/Serena
+            # project, honor it directly (Serena will create its project config there).
+            devin_project_dir = os.environ.get("DEVIN_PROJECT_DIR") or None
+            project = find_project_root(start=devin_project_dir) or devin_project_dir
             if project is not None:
                 log.info("Auto-detected project root: %s", project)
             else:

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -211,13 +211,23 @@ class TopLevelCommands(AutoRegisteringGroup):
         help="Set up Serena for use with a specific client by registering it as an MCP server.",
         context_settings={"max_content_width": _MAX_CONTENT_WIDTH},
     )
+    @click.option(
+        "--project",
+        "project_scope",
+        is_flag=True,
+        default=False,
+        help="For Devin CLI, write project-level config (.devin/config.json) instead of user-level config.",
+    )
     @click.argument(
         "client",
         type=click.Choice([h.name for h in client_setup_handlers]),
     )
-    def setup(client: str) -> None:
+    def setup(client: str, project_scope: bool) -> None:
         # find the matching handler
         handler = next(h for h in client_setup_handlers if h.name == client)
+
+        # Devin CLI supports per-project setup via an optional --project flag
+        handler.set_project_scope(project_scope)
 
         # check applicability
         if not handler.is_applicable():

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -62,8 +62,8 @@ For details on mode configuration, see
 """
 
 
-def find_project_root(root: str | Path | None = None) -> str | None:
-    """Find project root by walking up from CWD.
+def find_project_root(root: str | Path | None = None, start: str | Path | None = None) -> str | None:
+    """Find project root by walking up from ``start`` (or CWD if omitted).
 
     Returns the nearest ancestor that is either an explicit Serena project
     (contains .serena/project.yml) or a git root (contains .git, which may be a
@@ -78,9 +78,10 @@ def find_project_root(root: str | Path | None = None) -> str | None:
 
     :param root: If provided, constrains the search to this directory and below
                  (acts as a virtual filesystem root). Search stops at this boundary.
+    :param start: Directory to start the search from. Defaults to the current working directory.
     :return: absolute path to project root or None if not suitable root is found
     """
-    current = Path.cwd().resolve()
+    current = Path(start).resolve() if start is not None else Path.cwd().resolve()
     boundary = Path(root).resolve() if root is not None else None
 
     def ancestors() -> Iterator[Path]:
@@ -358,7 +359,15 @@ class TopLevelCommands(AutoRegisteringGroup):
         if project_from_cwd:
             if project is not None or project_file_arg is not None:
                 raise click.UsageError("--project-from-cwd cannot be used with --project or positional project argument")
-            project = find_project_root()
+            # Devin CLI sets DEVIN_PROJECT_DIR to the project root for hooks and MCP server processes.
+            # Prefer it when available, then fall back to detecting from the current working directory.
+            devin_project_dir = os.environ.get("DEVIN_PROJECT_DIR")
+            if devin_project_dir:
+                project = find_project_root(start=devin_project_dir, root=devin_project_dir)
+            else:
+                project = None
+            if project is None:
+                project = find_project_root()
             if project is not None:
                 log.info("Auto-detected project root: %s", project)
             else:

--- a/src/serena/config/client_setup.py
+++ b/src/serena/config/client_setup.py
@@ -215,7 +215,7 @@ class ClientSetupHandlerDevin(ClientSetupHandler):
             click.echo(f"  Config: {config_path}")
             click.echo("  MCP server: serena")
             click.echo("  Permissions: auto-approve mcp__serena__*")
-            click.echo("  Hooks: SessionStart, PreToolUse, PostToolUse, PostCompaction, SessionEnd")
+            click.echo("  Hooks: SessionStart, PreToolUse, PostCompaction, SessionEnd")
             return True
         except Exception as e:
             click.echo(f"Failed to update Devin CLI config: {e}")
@@ -255,21 +255,30 @@ class ClientSetupHandlerDevin(ClientSetupHandler):
     def _merge_serena_hooks(self, config: dict[str, Any]) -> None:
         hooks = config.setdefault("hooks", {})
 
-        session_start_command = "serena-hooks activate --client=devin"
+        session_start_command = "serena-hooks activate --client=devin --include-instructions --event SessionStart"
         pre_tool_use_command = "serena-hooks remind --client=devin"
-        post_tool_use_command = "serena-hooks post-remind --client=devin"
         post_compaction_command = "serena-hooks activate --client=devin --include-instructions --event PostCompaction"
         session_end_command = "serena-hooks cleanup --client=devin"
 
         # Remove stale experimental serena-devin.js hooks that this installer
-        # may have created in earlier iterations; they duplicate the native
-        # serena-hooks commands we register below.
+        # may have created in earlier iterations.
         for event, event_list in hooks.items():
             hooks[event] = [entry for entry in event_list if not self._is_stale_serena_hook(entry)]
 
+        # Remove any existing serena-hooks entries for the events we are about
+        # to register, so repeated installs replace old commands with the
+        # current ones instead of accumulating duplicates. Also drop the
+        # obsolete PostToolUse entries that previous versions may have created.
+        for event in ("SessionStart", "PreToolUse", "PostToolUse", "PostCompaction", "SessionEnd"):
+            event_list = hooks.get(event, [])
+            cleaned = [entry for entry in event_list if not self._is_serena_hooks_entry(entry)]
+            if cleaned:
+                hooks[event] = cleaned
+            elif event in hooks:
+                del hooks[event]
+
         self._add_hook_event(hooks, "SessionStart", session_start_command)
         self._add_hook_event(hooks, "PreToolUse", pre_tool_use_command, matcher="")
-        self._add_hook_event(hooks, "PostToolUse", post_tool_use_command, matcher="")
         self._add_hook_event(hooks, "PostCompaction", post_compaction_command)
         self._add_hook_event(hooks, "SessionEnd", session_end_command)
 
@@ -277,6 +286,13 @@ class ClientSetupHandlerDevin(ClientSetupHandler):
         for hook in entry.get("hooks", []):
             command = hook.get("command", "")
             if "serena-devin.js" in command:
+                return True
+        return False
+
+    def _is_serena_hooks_entry(self, entry: Any) -> bool:
+        for hook in entry.get("hooks", []):
+            command = hook.get("command", "")
+            if command.startswith("serena-hooks"):
                 return True
         return False
 

--- a/src/serena/config/client_setup.py
+++ b/src/serena/config/client_setup.py
@@ -1,4 +1,10 @@
+import json
+import os
+import platform
+import shlex
 from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
 
 import click
 
@@ -8,6 +14,9 @@ from serena.util.shell import execute_shell_command
 class ClientSetupHandler(ABC):
     def __init__(self, name: str) -> None:
         self.name = name
+
+    def set_project_scope(self, project_scope: bool) -> None:
+        """Optional hook for handlers that support project-level setup."""
 
     @abstractmethod
     def is_applicable(self) -> bool:
@@ -141,10 +150,19 @@ class ClientSetupHandlerGrok(ClientSetupHandler):
 class ClientSetupHandlerDevin(ClientSetupHandler):
     """
     Setup for Devin CLI.
+
+    Registers Serena as an MCP server and writes the minimal supporting
+    configuration (permissions + hooks) into Devin CLI's JSON configuration
+    file. One command therefore enables the full Devin/serena integration.
     """
 
     def __init__(self) -> None:
         super().__init__("devin")
+        self._project_scope = False
+
+    def set_project_scope(self, project_scope: bool) -> None:
+        """When set, configure project-level Devin CLI config instead of user-level."""
+        self._project_scope = project_scope
 
     def is_applicable(self) -> bool:
         result = execute_shell_command("devin --version", capture_stderr=True)
@@ -155,17 +173,121 @@ class ClientSetupHandlerDevin(ClientSetupHandler):
         return mcp_result.return_code == 0 and "Add a new MCP server" in mcp_result.stdout
 
     def get_mcp_server_options(self) -> list[str]:
-        return ["--context=devin", "--project-from-cwd"]
+        options = [
+            "--context=devin",
+            "--enable-web-dashboard",
+            "false",
+            "--open-web-dashboard",
+            "false",
+            "--add-mode",
+            "query-projects",
+        ]
+        if self._project_scope:
+            options.extend(["--project", str(Path.cwd().resolve())])
+        else:
+            options.append("--project-from-cwd")
+        return options
+
+    def get_mcp_server_command(self) -> str:
+        # shlex.join is safer than a plain join because some arguments (project path) may contain spaces.
+        return f"serena start-mcp-server {shlex.join(self.get_mcp_server_options())}"
 
     def apply(self) -> bool:
-        cmd = f"devin mcp add -s user serena -- {self.get_mcp_server_command()}"
-        is_success = self._run_shell_command(cmd)
-        if is_success:
-            click.echo("\nIMPORTANT: For the best experience we additionally recommend auto-approving Serena's tools")
-            click.echo("   (Devin CLI's `permissions.allow`) and enabling Serena's hooks.")
-            click.echo("   Please read the instructions here:")
-            click.echo("   https://oraios.github.io/serena/02-usage/030_clients.html#devin-cli")
-        return is_success
+        # Detailed instructions: https://oraios.github.io/serena/02-usage/030_clients.html#devin-cli
+        scope = "project" if self._project_scope else "user"
+        cmd = f"devin mcp add -s {scope} serena -- {self.get_mcp_server_command()}"
+        if not self._run_shell_command(cmd):
+            return False
+        return self._configure_devin_config(scope)
+
+    def _configure_devin_config(self, scope: str) -> bool:
+        config_path = self._devin_config_path(scope)
+        if config_path is None:
+            click.echo("Could not determine Devin CLI configuration path.")
+            return False
+        try:
+            config = self._read_devin_config(config_path)
+            self._merge_serena_permissions(config)
+            self._merge_serena_hooks(config)
+            self._write_devin_config(config_path, config)
+            click.echo("\nSerena Devin CLI integration configured:")
+            click.echo(f"  Scope: {scope}")
+            click.echo(f"  Config: {config_path}")
+            click.echo("  MCP server: serena")
+            click.echo("  Permissions: auto-approve mcp__serena__*")
+            click.echo("  Hooks: SessionStart, PreToolUse, PostToolUse, PostCompaction, SessionEnd")
+            return True
+        except Exception as e:
+            click.echo(f"Failed to update Devin CLI config: {e}")
+            return False
+
+    def _devin_config_path(self, scope: str) -> Path | None:
+        if scope == "project":
+            return Path.cwd() / ".devin" / "config.json"
+        if scope == "local":
+            return Path.cwd() / ".devin" / "config.local.json"
+        if platform.system() == "Windows":
+            appdata = os.environ.get("APPDATA")
+            if not appdata:
+                return None
+            return Path(appdata) / "devin" / "config.json"
+        return Path.home() / ".config" / "devin" / "config.json"
+
+    def _read_devin_config(self, config_path: Path) -> dict[str, Any]:
+        if not config_path.exists():
+            return {}
+        try:
+            return json.loads(config_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Invalid JSON in {config_path}: {e}") from e
+
+    def _write_devin_config(self, config_path: Path, config: dict[str, Any]) -> None:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    def _merge_serena_permissions(self, config: dict[str, Any]) -> None:
+        permissions = config.setdefault("permissions", {})
+        allow = permissions.setdefault("allow", [])
+        pattern = "mcp__serena__*"
+        if pattern not in allow:
+            allow.append(pattern)
+
+    def _merge_serena_hooks(self, config: dict[str, Any]) -> None:
+        hooks = config.setdefault("hooks", {})
+
+        session_start_command = "serena-hooks activate --client=devin"
+        pre_tool_use_command = "serena-hooks remind --client=devin"
+        post_tool_use_command = "serena-hooks post-remind --client=devin"
+        post_compaction_command = "serena-hooks activate --client=devin --include-instructions --event PostCompaction"
+        session_end_command = "serena-hooks cleanup --client=devin"
+
+        self._add_hook_event(hooks, "SessionStart", session_start_command)
+        self._add_hook_event(hooks, "PreToolUse", pre_tool_use_command, matcher="")
+        self._add_hook_event(hooks, "PostToolUse", post_tool_use_command, matcher="")
+        self._add_hook_event(hooks, "PostCompaction", post_compaction_command)
+        self._add_hook_event(hooks, "SessionEnd", session_end_command)
+
+    def _add_hook_event(
+        self,
+        hooks: dict[str, Any],
+        event: str,
+        command: str,
+        matcher: str | None = None,
+    ) -> None:
+        event_list = hooks.setdefault(event, [])
+        if self._has_hook_command(event_list, command):
+            return
+        entry: dict[str, Any] = {"hooks": [{"type": "command", "command": command, "timeout": 10}]}
+        if matcher is not None:
+            entry["matcher"] = matcher
+        event_list.append(entry)
+
+    def _has_hook_command(self, event_list: list[Any], command: str) -> bool:
+        for entry in event_list:
+            for hook in entry.get("hooks", []):
+                if hook.get("command") == command:
+                    return True
+        return False
 
 
 client_setup_handlers = [

--- a/src/serena/config/client_setup.py
+++ b/src/serena/config/client_setup.py
@@ -138,9 +138,39 @@ class ClientSetupHandlerGrok(ClientSetupHandler):
         return is_success
 
 
+class ClientSetupHandlerDevin(ClientSetupHandler):
+    """
+    Setup for Devin CLI.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("devin")
+
+    def is_applicable(self) -> bool:
+        result = execute_shell_command("devin --version", capture_stderr=True)
+        if result.return_code != 0 or not result.stdout.lower().startswith("devin "):
+            return False
+
+        mcp_result = execute_shell_command("devin mcp add --help", capture_stderr=True)
+        return mcp_result.return_code == 0 and "Add a new MCP server" in mcp_result.stdout
+
+    def get_mcp_server_options(self) -> list[str]:
+        return ["--context=devin", "--project-from-cwd"]
+
+    def apply(self) -> bool:
+        cmd = f"devin mcp add -s user serena -- {self.get_mcp_server_command()}"
+        is_success = self._run_shell_command(cmd)
+        if is_success:
+            click.echo("\nIMPORTANT: We additionally recommend to set up hooks for Devin CLI to ensure the best experience.")
+            click.echo("   Please read the instructions here:")
+            click.echo("   https://oraios.github.io/serena/02-usage/030_clients.html#devin-cli")
+        return is_success
+
+
 client_setup_handlers = [
     ClientSetupHandlerClaudeCode(),
     ClientSetupHandlerCodeBuddy(),
     ClientSetupHandlerCodex(),
     ClientSetupHandlerGrok(),
+    ClientSetupHandlerDevin(),
 ]

--- a/src/serena/config/client_setup.py
+++ b/src/serena/config/client_setup.py
@@ -261,11 +261,24 @@ class ClientSetupHandlerDevin(ClientSetupHandler):
         post_compaction_command = "serena-hooks activate --client=devin --include-instructions --event PostCompaction"
         session_end_command = "serena-hooks cleanup --client=devin"
 
+        # Remove stale experimental serena-devin.js hooks that this installer
+        # may have created in earlier iterations; they duplicate the native
+        # serena-hooks commands we register below.
+        for event, event_list in hooks.items():
+            hooks[event] = [entry for entry in event_list if not self._is_stale_serena_hook(entry)]
+
         self._add_hook_event(hooks, "SessionStart", session_start_command)
         self._add_hook_event(hooks, "PreToolUse", pre_tool_use_command, matcher="")
         self._add_hook_event(hooks, "PostToolUse", post_tool_use_command, matcher="")
         self._add_hook_event(hooks, "PostCompaction", post_compaction_command)
         self._add_hook_event(hooks, "SessionEnd", session_end_command)
+
+    def _is_stale_serena_hook(self, entry: Any) -> bool:
+        for hook in entry.get("hooks", []):
+            command = hook.get("command", "")
+            if "serena-devin.js" in command:
+                return True
+        return False
 
     def _add_hook_event(
         self,

--- a/src/serena/config/client_setup.py
+++ b/src/serena/config/client_setup.py
@@ -161,7 +161,8 @@ class ClientSetupHandlerDevin(ClientSetupHandler):
         cmd = f"devin mcp add -s user serena -- {self.get_mcp_server_command()}"
         is_success = self._run_shell_command(cmd)
         if is_success:
-            click.echo("\nIMPORTANT: We additionally recommend to set up hooks for Devin CLI to ensure the best experience.")
+            click.echo("\nIMPORTANT: For the best experience we additionally recommend auto-approving Serena's tools")
+            click.echo("   (Devin CLI's `permissions.allow`) and enabling Serena's hooks.")
             click.echo("   Please read the instructions here:")
             click.echo("   https://oraios.github.io/serena/02-usage/030_clients.html#devin-cli")
         return is_success

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -571,15 +571,20 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
 
 
 class SessionStartActivateProjectHook(Hook):
+    #: cache files older than this many days are considered stale
+    _STALE_INDEX_DAYS = 7
+
     def execute(self) -> None:
         # Devin CLI exposes the project root via DEVIN_PROJECT_DIR; including it in the prompt
         # lets the agent know exactly which project is active without guessing from CWD.
         devin_project_dir = os.environ.get("DEVIN_PROJECT_DIR")
         project_clause = f" The current project directory is {devin_project_dir}." if devin_project_dir else ""
+        index_clause = self._index_clause(devin_project_dir)
         message = (
             f"**IMPORTANT**: If the current directory is a coding project you are working on:{project_clause}"
             " 1. activate it using Serena's activate_project tool unless already done. "
             " 2. if you haven't read Serena Instructions Manual yet, do so. "
+            f" 3. {index_clause}"
             "Follow this instruction before doing anything else."
         )
         result = {
@@ -589,6 +594,54 @@ class SessionStartActivateProjectHook(Hook):
             }
         }
         click.echo(json.dumps(result))
+
+    def _index_clause(self, project_dir: str | None) -> str:
+        """Return an index-status clause for the activation message.
+
+        If the project directory is known and the cache is missing or stale, the
+        clause explicitly tells the agent to remind the user to run
+        ``serena project index``. Otherwise it gives a generic reminder or
+        confirms the index looks up to date.
+        """
+        if project_dir is None:
+            return (
+                "if the project has not been indexed recently, remind the user to run "
+                "`serena project index` once to avoid delays when searching symbols."
+            )
+        status = self._check_index_status(project_dir)
+        if status == "missing":
+            return (
+                f"the project at {project_dir} does not appear to be indexed yet; "
+                "remind the user to run `serena project index` in that directory "
+                "before doing heavy symbol searches."
+            )
+        if status == "stale":
+            return (
+                f"the project index at {project_dir} appears to be stale "
+                f"({self._STALE_INDEX_DAYS}+ days old); remind the user to run "
+                "`serena project index` to refresh it."
+            )
+        return "the project appears to be indexed; no need to index again unless many files have changed since the last index run."
+
+    def _check_index_status(self, project_dir: str) -> str:
+        """Check whether the project has a recent Serena symbol cache.
+
+        :return: ``"missing"`` if no cache exists, ``"stale"`` if the newest cache
+            file is older than :attr:`_STALE_INDEX_DAYS`, or ``"ok"`` otherwise.
+        """
+        cache_dir = Path(project_dir) / ".serena" / "cache"
+        if not cache_dir.is_dir():
+            return "missing"
+        newest_mtime: float | None = None
+        for file in cache_dir.rglob("*"):
+            if file.is_file():
+                mtime = file.stat().st_mtime
+                if newest_mtime is None or mtime > newest_mtime:
+                    newest_mtime = mtime
+        if newest_mtime is None:
+            return "missing"
+        age_days = (datetime.now().timestamp() - newest_mtime) / 86400
+        return "stale" if age_days > self._STALE_INDEX_DAYS else "ok"
 
 
 class SessionEndCleanupHook(Hook):

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Literal, Self
 
 import click
+import oslex
 
 from serena.util.cli_util import AutoRegisteringGroup
 
@@ -88,6 +89,7 @@ class PreToolUseHook(Hook, ABC):
         permission_decision: Literal["deny", "allow"]
         permission_decision_reason: str
         additional_context: str = ""
+        updated_input: dict | None = None
 
         def to_json_string(self, client: HookClient) -> str:
             if client == HookClient.GROK:
@@ -97,12 +99,20 @@ class PreToolUseHook(Hook, ABC):
                 return json.dumps(grok_output)
 
             if client == HookClient.DEVIN:
-                # Devin CLI hooks control the outcome with a top-level "decision" ("approve"/"block")
-                # plus a "reason" that is shown to the agent. This mirrors Claude Code's deny mechanic:
-                # a blocked read/grep tells the agent why and lets it continue with symbolic tools.
-                # https://docs.devin.ai/cli/extensibility/hooks/overview#output-format
-                decision = "approve" if self.permission_decision == "allow" else "block"
-                return json.dumps({"decision": decision, "reason": self.additional_context or self.permission_decision_reason})
+                # A top-level "block"/deny decision *cancels the agent's turn* in Devin CLI (unlike
+                # Claude Code's deny, which just rejects the one call and lets the agent continue), so
+                # it is far too harsh for a nudge. Instead we soft-enforce: rewrite the wasteful
+                # read/grep/exec call to a harmless no-op that returns the reminder as its output
+                # (see _build_devin_noop_input), keeping the agent cycle alive. The reminder is also
+                # passed as additionalContext. When no no-op applies, we inject context only and let
+                # the tool run — we never emit a "decision", so a reminder can never end the turn.
+                hook_specific: dict = {
+                    "hookEventName": "PreToolUse",
+                    "additionalContext": self.additional_context or self.permission_decision_reason,
+                }
+                if self.updated_input:
+                    hook_specific["updatedInput"] = self.updated_input
+                return json.dumps({"hookSpecificOutput": hook_specific})
 
             hook_output = {
                 "hookSpecificOutput": {
@@ -489,6 +499,12 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
             # reset burst counters so the next interval starts fresh, then record
             # the deny timestamp and emit. The is_hook_active() guard at the top
             # ensures we never reach this branch within the rate-limit window.
+            if self._client == HookClient.DEVIN:
+                # Soft-enforce for Devin: rewrite the offending call to a no-op that surfaces the
+                # reminder, rather than blocking (a block would cancel the agent's turn). See
+                # OutputData.to_json_string / _build_devin_noop_input.
+                message = output_data.additional_context or output_data.permission_decision_reason
+                output_data.updated_input = self._build_devin_noop_input(message)
             self._tool_call_counter.reset()
             self._tool_call_counter.last_deny_timestamp = self.triggered_at_timestamp
             click.echo(output_data.to_json_string(self._client))
@@ -528,6 +544,36 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
                 "now if needed, the counter was reset."
             ),
         )
+
+    def _build_devin_noop_input(self, message: str) -> dict | None:
+        """Return a Devin tool_input that prevents the original action while keeping the cycle alive.
+
+        The tool still executes, but with harmless arguments, and its output is replaced by the
+        reminder message so the model sees what to do next. ``read`` and ``grep`` are pointed at a
+        dedicated nudge file, ``glob`` at a literal file path, and ``exec`` commands are replaced
+        with a ``printf`` of the warning. Returns ``None`` for tools without a safe no-op; the
+        caller then injects the reminder as context only (never a blocking decision).
+        """
+        nudge_file = Path(self.session_persistence_dir) / "devin_nudge.txt"
+        nudge_file.parent.mkdir(parents=True, exist_ok=True)
+        # Repeat the message so it survives either 0-indexed or 1-indexed offsets.
+        nudge_file.write_text(message + "\n" + message, encoding="utf-8")
+
+        if self._tool_name == "read":
+            return {"file_path": str(nudge_file), "offset": 1, "limit": 1000}
+        if self._tool_name == "grep":
+            return {
+                "pattern": ".*",
+                "path": str(nudge_file),
+                "output_mode": "content",
+                "max_results": 100,
+            }
+        if self._tool_name == "glob":
+            return {"pattern": str(nudge_file)}
+        if self._tool_name == "exec" and self._is_shell_command_call():
+            quoted_message = oslex.quote(message)
+            return {"command": f"printf '%s\\n' {quoted_message}"}
+        return None
 
 
 class SessionStartActivateProjectHook(Hook):

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -573,8 +573,12 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
 
 class SessionStartActivateProjectHook(Hook):
     def execute(self) -> None:
+        # Devin CLI exposes the project root via DEVIN_PROJECT_DIR; including it in the prompt
+        # lets the agent know exactly which project is active without guessing from CWD.
+        devin_project_dir = os.environ.get("DEVIN_PROJECT_DIR")
+        project_clause = f" The current project directory is {devin_project_dir}." if devin_project_dir else ""
         message = (
-            "**IMPORTANT**: If the current directory is a coding project you are working on:"
+            f"**IMPORTANT**: If the current directory is a coding project you are working on:{project_clause}"
             " 1. activate it using Serena's activate_project tool unless already done. "
             " 2. if you haven't read Serena Instructions Manual yet, do so. "
             "Follow this instruction before doing anything else."

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -542,18 +542,29 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
         )
 
     def _build_devin_noop_input(self, message: str) -> dict | None:
-        """Return a Devin tool_input that performs a no-op while keeping the agent cycle alive.
+        """Return a Devin tool_input that prevents the original action while keeping the cycle alive.
 
-        Mirrors the ENFORCE_SOFT pattern: the original tool runs, but with harmless arguments,
-        and the warning message is emitted as additional context.``exec`` commands are replaced
-        with a ``printf`` that echoes the reminder so the model sees the nudge in the tool output.
+        The tool still executes, but with harmless arguments, and its output is replaced by the
+        reminder message so the model sees what to do next.``read`` and ``grep`` are pointed at a
+        dedicated nudge file, ``glob`` at a literal file path, and ``exec`` commands are replaced
+        with a ``printf`` of the warning.
         """
+        nudge_file = Path(self.session_persistence_dir) / "devin_nudge.txt"
+        nudge_file.parent.mkdir(parents=True, exist_ok=True)
+        # Repeat the message so it survives either 0-indexed or 1-indexed offsets.
+        nudge_file.write_text(message + "\n" + message, encoding="utf-8")
+
         if self._tool_name == "read":
-            return {"file_path": os.devnull}
+            return {"file_path": str(nudge_file), "offset": 1, "limit": 1000}
         if self._tool_name == "grep":
-            return {"pattern": "__SERENA_SUPPRESSED__", "output_mode": "content", "max_results": 0}
+            return {
+                "pattern": ".*",
+                "path": str(nudge_file),
+                "output_mode": "content",
+                "max_results": 100,
+            }
         if self._tool_name == "glob":
-            return {"pattern": "__SERENA_SUPPRESSED__"}
+            return {"pattern": str(nudge_file)}
         if self._tool_name == "exec" and self._is_shell_command_call():
             quoted_message = oslex.quote(message)
             return {"command": f"printf '%s\\n' {quoted_message}"}

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -2,6 +2,7 @@ import json
 import os
 import pickle
 import shutil
+import subprocess
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -570,9 +571,65 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
         return None
 
 
+class PostToolUseRemindAboutSymbolicToolsHook(PreToolUseRemindAboutSymbolicToolsHook):
+    """Post-tool-use hook that nudges the agent after raw reads/greps.
+
+    Unlike :class:`PreToolUseRemindAboutSymbolicToolsHook`, this hook does not
+    block or rewrite the tool call; it only adds context after the tool has run.
+    A short cooldown prevents the reminder from becoming noisy.
+    """
+
+    _COOLDOWN_SECONDS = 90
+    _LAST_REMIND_FILE = "last_post_remind.txt"
+
+    def execute(self) -> None:
+        if not (self.is_grep_call() or self.is_read_code_file_call()):
+            return
+        if self._on_cooldown():
+            return
+
+        tool_label = self._tool_name or "this tool"
+        message = (
+            f"You just used `{tool_label}` on a code file. Consider using Serena's "
+            "symbolic tools (e.g. `find_symbol`, `get_symbols_overview`, `query_project`) "
+            "for faster, more targeted reads and edits."
+        )
+        result = {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": message,
+            }
+        }
+        click.echo(json.dumps(result))
+        self._update_cooldown()
+
+    def _on_cooldown(self) -> bool:
+        path = Path(self.session_persistence_dir) / self._LAST_REMIND_FILE
+        if not path.exists():
+            return False
+        return (datetime.now().timestamp() - path.stat().st_mtime) < self._COOLDOWN_SECONDS
+
+    def _update_cooldown(self) -> None:
+        path = Path(self.session_persistence_dir) / self._LAST_REMIND_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(str(datetime.now().timestamp()))
+
+
 class SessionStartActivateProjectHook(Hook):
     #: cache files older than this many days are considered stale
     _STALE_INDEX_DAYS = 7
+
+    def __init__(
+        self,
+        client: HookClient,
+        include_instructions: bool = False,
+        event_name: str | None = None,
+    ) -> None:
+        super().__init__(client)
+        self._include_instructions = include_instructions
+        # Devin CLI sends the triggering event name in the payload; if it is absent
+        # (older clients or manual invocation), fall back to the provided default.
+        self._event_name = event_name or self._input_data.get("hook_event_name") or self._input_data.get("hookEventName") or "SessionStart"
 
     def execute(self) -> None:
         # Devin CLI exposes the project root via DEVIN_PROJECT_DIR; including it in the prompt
@@ -587,13 +644,35 @@ class SessionStartActivateProjectHook(Hook):
             f" 3. {index_clause}"
             "Follow this instruction before doing anything else."
         )
+        instructions = self._full_instructions() if self._include_instructions else ""
+        additional_context = f"{instructions}\n{message}" if instructions and message else instructions or message
         result = {
             "hookSpecificOutput": {
-                "hookEventName": "SessionStart",
-                "additionalContext": message,
+                "hookEventName": self._event_name,
+                "additionalContext": additional_context,
             }
         }
         click.echo(json.dumps(result))
+
+    def _full_instructions(self) -> str:
+        """Return Serena's system-prompt instructions for the devin context.
+
+        This is useful for Devin CLI's PostCompaction hook, where the model may have
+        lost the original system prompt and needs to be reminded of Serena's capabilities.
+        """
+        try:
+            result = subprocess.run(
+                ["serena", "print-system-prompt", "--only-instructions", "--context=devin"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except Exception:
+            pass
+        return ""
 
     def _index_clause(self, project_dir: str | None) -> str:
         """Return an index-status clause for the activation message.
@@ -708,8 +787,12 @@ class HookCommands(AutoRegisteringGroup):
         help="Set this as hook at session startup to prompt the agent to activate the project at the start of the session and read Serena's instructions",
     )
     @_client_option
-    def activate(client: str) -> None:
-        SessionStartActivateProjectHook(HookClient(client)).execute()
+    @click.option(
+        "--include-instructions", is_flag=True, default=False, help="Include the full Serena system prompt (useful for PostCompaction)."
+    )
+    @click.option("--event", default="SessionStart", help="The Devin hook event name to emit in the response.")
+    def activate(client: str, include_instructions: bool, event: str) -> None:
+        SessionStartActivateProjectHook(HookClient(client), include_instructions=include_instructions, event_name=event).execute()
 
     @staticmethod
     @click.command("cleanup", help="Set this as hook at session end all hook data for the current session")
@@ -725,6 +808,15 @@ class HookCommands(AutoRegisteringGroup):
     @_client_option
     def remind(client: str) -> None:
         PreToolUseRemindAboutSymbolicToolsHook(HookClient(client)).execute()
+
+    @staticmethod
+    @click.command(
+        "post-remind",
+        help="Set this as hook at PostToolUse to nudge the agent after raw read/grep calls",
+    )
+    @_client_option
+    def post_remind(client: str) -> None:
+        PostToolUseRemindAboutSymbolicToolsHook(HookClient(client)).execute()
 
     @staticmethod
     @click.command(

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Literal, Self
 
 import click
-import oslex
 
 from serena.util.cli_util import AutoRegisteringGroup
 
@@ -89,7 +88,6 @@ class PreToolUseHook(Hook, ABC):
         permission_decision: Literal["deny", "allow"]
         permission_decision_reason: str
         additional_context: str = ""
-        updated_input: dict | None = None
 
         def to_json_string(self, client: HookClient) -> str:
             if client == HookClient.GROK:
@@ -99,17 +97,10 @@ class PreToolUseHook(Hook, ABC):
                 return json.dumps(grok_output)
 
             if client == HookClient.DEVIN:
-                # Devin CLI PreToolUse hooks use top-level "decision" (approve/block) with a reason,
-                # or rewrite the tool input to a no-op when updated_input is provided (soft-enforce).
-                if self.updated_input:
-                    devin_output = {
-                        "hookSpecificOutput": {
-                            "hookEventName": "PreToolUse",
-                            "updatedInput": self.updated_input,
-                            "additionalContext": self.additional_context or self.permission_decision_reason,
-                        }
-                    }
-                    return json.dumps(devin_output)
+                # Devin CLI hooks control the outcome with a top-level "decision" ("approve"/"block")
+                # plus a "reason" that is shown to the agent. This mirrors Claude Code's deny mechanic:
+                # a blocked read/grep tells the agent why and lets it continue with symbolic tools.
+                # https://docs.devin.ai/cli/extensibility/hooks/overview#output-format
                 decision = "approve" if self.permission_decision == "allow" else "block"
                 return json.dumps({"decision": decision, "reason": self.additional_context or self.permission_decision_reason})
 
@@ -498,9 +489,6 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
             # reset burst counters so the next interval starts fresh, then record
             # the deny timestamp and emit. The is_hook_active() guard at the top
             # ensures we never reach this branch within the rate-limit window.
-            if self._client == HookClient.DEVIN:
-                message = output_data.additional_context or output_data.permission_decision_reason
-                output_data.updated_input = self._build_devin_noop_input(message)
             self._tool_call_counter.reset()
             self._tool_call_counter.last_deny_timestamp = self.triggered_at_timestamp
             click.echo(output_data.to_json_string(self._client))
@@ -540,35 +528,6 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
                 "now if needed, the counter was reset."
             ),
         )
-
-    def _build_devin_noop_input(self, message: str) -> dict | None:
-        """Return a Devin tool_input that prevents the original action while keeping the cycle alive.
-
-        The tool still executes, but with harmless arguments, and its output is replaced by the
-        reminder message so the model sees what to do next.``read`` and ``grep`` are pointed at a
-        dedicated nudge file, ``glob`` at a literal file path, and ``exec`` commands are replaced
-        with a ``printf`` of the warning.
-        """
-        nudge_file = Path(self.session_persistence_dir) / "devin_nudge.txt"
-        nudge_file.parent.mkdir(parents=True, exist_ok=True)
-        # Repeat the message so it survives either 0-indexed or 1-indexed offsets.
-        nudge_file.write_text(message + "\n" + message, encoding="utf-8")
-
-        if self._tool_name == "read":
-            return {"file_path": str(nudge_file), "offset": 1, "limit": 1000}
-        if self._tool_name == "grep":
-            return {
-                "pattern": ".*",
-                "path": str(nudge_file),
-                "output_mode": "content",
-                "max_results": 100,
-            }
-        if self._tool_name == "glob":
-            return {"pattern": str(nudge_file)}
-        if self._tool_name == "exec" and self._is_shell_command_call():
-            quoted_message = oslex.quote(message)
-            return {"command": f"printf '%s\\n' {quoted_message}"}
-        return None
 
 
 class SessionStartActivateProjectHook(Hook):
@@ -620,9 +579,8 @@ class PreToolUseAutoApproveSerenaHook(PreToolUseHook):
     #: the canonical mode strings emitted by Claude Code's hook payload.
     _AUTO_APPROVE_MODES: frozenset[str] = frozenset({"acceptEdits", "auto"})
 
-    # Devin CLI does not expose a permission mode in PreToolUse payloads; auto-approve is unconditional for it.
     def is_auto_approve_mode(self) -> bool:
-        return self._client == HookClient.DEVIN or self._permission_mode in self._AUTO_APPROVE_MODES
+        return self._permission_mode in self._AUTO_APPROVE_MODES
 
     def execute(self) -> None:
         # only emit a decision when both the tool and the mode match; stay silent otherwise
@@ -633,11 +591,7 @@ class PreToolUseAutoApproveSerenaHook(PreToolUseHook):
         # (the same hook handles multiple modes now)
         output_data = self.OutputData(
             permission_decision="allow",
-            permission_decision_reason=(
-                "Auto-approved: Serena symbolic tool call in Devin CLI."
-                if self._client == HookClient.DEVIN
-                else f"Auto-approved: Serena tool call while client is in {self._permission_mode} mode."
-            ),
+            permission_decision_reason=f"Auto-approved: Serena tool call while client is in {self._permission_mode} mode.",
         )
         click.echo(output_data.to_json_string(self._client))
 

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Literal, Self
 
 import click
-import oslex
 
 from serena.util.cli_util import AutoRegisteringGroup
 
@@ -496,23 +495,12 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
             output_data = self._build_non_symbolic_deny()
 
         if output_data is not None:
-            emit = True
-            if self._client == HookClient.DEVIN:
-                # Soft-enforce for Devin: rewrite the offending call to a no-op that surfaces the
-                # reminder (a block would cancel the whole turn). If the triggering tool has no safe
-                # no-op — only reachable from stale/mixed counter state, since the burst tools are
-                # always read/grep/exec — stay silent and keep the burst state, so the next
-                # read/grep/exec gets nudged instead of the turn being cancelled or the tool spoofed.
-                message = output_data.additional_context or output_data.permission_decision_reason
-                output_data.updated_input = self._build_devin_noop_input(message)
-                emit = output_data.updated_input is not None
-            if emit:
-                # reset burst counters so the next interval starts fresh, then record the deny
-                # timestamp. The is_hook_active() guard at the top ensures we never reach this
-                # branch within the rate-limit window.
-                self._tool_call_counter.reset()
-                self._tool_call_counter.last_deny_timestamp = self.triggered_at_timestamp
-                click.echo(output_data.to_json_string(self._client))
+            # reset burst counters so the next interval starts fresh, then record the deny
+            # timestamp. The is_hook_active() guard at the top ensures we never reach this
+            # branch within the rate-limit window.
+            self._tool_call_counter.reset()
+            self._tool_call_counter.last_deny_timestamp = self.triggered_at_timestamp
+            click.echo(output_data.to_json_string(self._client))
         self._tool_call_counter.save(self)
 
     def _build_grep_deny(self) -> "PreToolUseHook.OutputData":
@@ -549,70 +537,6 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
                 "now if needed, the counter was reset."
             ),
         )
-
-    def _build_devin_noop_input(self, message: str) -> dict | None:
-        """Rewrite the offending call to a harmless no-op whose *output is the reminder*, so the
-        agent sees the nudge and its turn continues (a ``block`` would cancel the turn in Devin).
-
-        ``exec`` becomes a ``printf`` of the message; ``read``/``grep`` are pointed at a small
-        nudge file that holds the message. Returns ``None`` for any other tool — the caller then
-        stays silent rather than blocking. Only the burst tools (``read``/``grep``/``exec``) ever
-        reach a deny, so ``None`` is a defensive fallback for stale counter state.
-        """
-        if self._tool_name == "exec" and self._is_shell_command_call():
-            return {"command": f"printf '%s\\n' {oslex.quote(message)}"}
-        if self._tool_name in ("read", "grep"):
-            nudge_file = Path(self.session_persistence_dir) / "devin_nudge.txt"
-            nudge_file.parent.mkdir(parents=True, exist_ok=True)
-            nudge_file.write_text(message + "\n", encoding="utf-8")
-            if self._tool_name == "read":
-                return {"file_path": str(nudge_file)}
-            return {"pattern": ".*", "path": str(nudge_file), "output_mode": "content"}
-        return None
-
-
-class PostToolUseRemindAboutSymbolicToolsHook(PreToolUseRemindAboutSymbolicToolsHook):
-    """Post-tool-use hook that nudges the agent after raw reads/greps.
-
-    Unlike :class:`PreToolUseRemindAboutSymbolicToolsHook`, this hook does not
-    block or rewrite the tool call; it only adds context after the tool has run.
-    A short cooldown prevents the reminder from becoming noisy.
-    """
-
-    _COOLDOWN_SECONDS = 90
-    _LAST_REMIND_FILE = "last_post_remind.txt"
-
-    def execute(self) -> None:
-        if not (self.is_grep_call() or self.is_read_code_file_call()):
-            return
-        if self._on_cooldown():
-            return
-
-        tool_label = self._tool_name or "this tool"
-        message = (
-            f"You just used `{tool_label}` on a code file. Consider using Serena's "
-            "symbolic tools (e.g. `find_symbol`, `get_symbols_overview`, `query_project`) "
-            "for faster, more targeted reads and edits."
-        )
-        result = {
-            "hookSpecificOutput": {
-                "hookEventName": "PostToolUse",
-                "additionalContext": message,
-            }
-        }
-        click.echo(json.dumps(result))
-        self._update_cooldown()
-
-    def _on_cooldown(self) -> bool:
-        path = Path(self.session_persistence_dir) / self._LAST_REMIND_FILE
-        if not path.exists():
-            return False
-        return (datetime.now().timestamp() - path.stat().st_mtime) < self._COOLDOWN_SECONDS
-
-    def _update_cooldown(self) -> None:
-        path = Path(self.session_persistence_dir) / self._LAST_REMIND_FILE
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(str(datetime.now().timestamp()))
 
 
 class SessionStartActivateProjectHook(Hook):
@@ -654,12 +578,39 @@ class SessionStartActivateProjectHook(Hook):
         }
         click.echo(json.dumps(result))
 
+    #: seconds for which the generated system prompt instructions remain fresh
+    _INSTRUCTIONS_CACHE_TTL = 3600
+
     def _full_instructions(self) -> str:
         """Return Serena's system-prompt instructions for the devin context.
 
-        This is useful for Devin CLI's PostCompaction hook, where the model may have
-        lost the original system prompt and needs to be reminded of Serena's capabilities.
+        The result is cached on disk for :attr:`_INSTRUCTIONS_CACHE_TTL` seconds
+        because generating it requires loading the full Serena agent and context.
         """
+        cache_path = Path(serena_home_dir) / "devin_instructions_cache.json"
+        try:
+            if cache_path.exists():
+                cache = json.loads(cache_path.read_text(encoding="utf-8"))
+                age = datetime.now().timestamp() - cache.get("timestamp", 0)
+                if age < self._INSTRUCTIONS_CACHE_TTL:
+                    return cache.get("text", "")
+        except Exception:
+            pass
+
+        text = self._generate_full_instructions()
+        if text:
+            try:
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                cache_path.write_text(
+                    json.dumps({"timestamp": datetime.now().timestamp(), "text": text}, ensure_ascii=False),
+                    encoding="utf-8",
+                )
+            except Exception:
+                pass
+        return text
+
+    def _generate_full_instructions(self) -> str:
+        """Generate instructions by delegating to the CLI."""
         try:
             result = subprocess.run(
                 ["serena", "print-system-prompt", "--only-instructions", "--context=devin"],
@@ -784,11 +735,14 @@ class HookCommands(AutoRegisteringGroup):
     @staticmethod
     @click.command(
         "activate",
-        help="Set this as hook at session startup to prompt the agent to activate the project at the start of the session and read Serena's instructions",
+        help="Set this as hook at SessionStart to prompt the agent to activate the project and read Serena's instructions, or at PostCompaction to re-inject the full instructions.",
     )
     @_client_option
     @click.option(
-        "--include-instructions", is_flag=True, default=False, help="Include the full Serena system prompt (useful for PostCompaction)."
+        "--include-instructions",
+        is_flag=True,
+        default=False,
+        help="Include the full Serena system prompt (useful for SessionStart and PostCompaction).",
     )
     @click.option("--event", default="SessionStart", help="The Devin hook event name to emit in the response.")
     def activate(client: str, include_instructions: bool, event: str) -> None:
@@ -808,15 +762,6 @@ class HookCommands(AutoRegisteringGroup):
     @_client_option
     def remind(client: str) -> None:
         PreToolUseRemindAboutSymbolicToolsHook(HookClient(client)).execute()
-
-    @staticmethod
-    @click.command(
-        "post-remind",
-        help="Set this as hook at PostToolUse to nudge the agent after raw read/grep calls",
-    )
-    @_client_option
-    def post_remind(client: str) -> None:
-        PostToolUseRemindAboutSymbolicToolsHook(HookClient(client)).execute()
 
     @staticmethod
     @click.command(

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Literal, Self
 
 import click
+import oslex
 
 from serena.util.cli_util import AutoRegisteringGroup
 
@@ -88,6 +89,7 @@ class PreToolUseHook(Hook, ABC):
         permission_decision: Literal["deny", "allow"]
         permission_decision_reason: str
         additional_context: str = ""
+        updated_input: dict | None = None
 
         def to_json_string(self, client: HookClient) -> str:
             if client == HookClient.GROK:
@@ -97,7 +99,17 @@ class PreToolUseHook(Hook, ABC):
                 return json.dumps(grok_output)
 
             if client == HookClient.DEVIN:
-                # Devin CLI PreToolUse hooks use top-level "decision" (approve/block) with a reason.
+                # Devin CLI PreToolUse hooks use top-level "decision" (approve/block) with a reason,
+                # or rewrite the tool input to a no-op when updated_input is provided (soft-enforce).
+                if self.updated_input:
+                    devin_output = {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "updatedInput": self.updated_input,
+                            "additionalContext": self.additional_context or self.permission_decision_reason,
+                        }
+                    }
+                    return json.dumps(devin_output)
                 decision = "approve" if self.permission_decision == "allow" else "block"
                 return json.dumps({"decision": decision, "reason": self.additional_context or self.permission_decision_reason})
 
@@ -486,6 +498,9 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
             # reset burst counters so the next interval starts fresh, then record
             # the deny timestamp and emit. The is_hook_active() guard at the top
             # ensures we never reach this branch within the rate-limit window.
+            if self._client == HookClient.DEVIN:
+                message = output_data.additional_context or output_data.permission_decision_reason
+                output_data.updated_input = self._build_devin_noop_input(message)
             self._tool_call_counter.reset()
             self._tool_call_counter.last_deny_timestamp = self.triggered_at_timestamp
             click.echo(output_data.to_json_string(self._client))
@@ -525,6 +540,24 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
                 "now if needed, the counter was reset."
             ),
         )
+
+    def _build_devin_noop_input(self, message: str) -> dict | None:
+        """Return a Devin tool_input that performs a no-op while keeping the agent cycle alive.
+
+        Mirrors the ENFORCE_SOFT pattern: the original tool runs, but with harmless arguments,
+        and the warning message is emitted as additional context.``exec`` commands are replaced
+        with a ``printf`` that echoes the reminder so the model sees the nudge in the tool output.
+        """
+        if self._tool_name == "read":
+            return {"file_path": os.devnull}
+        if self._tool_name == "grep":
+            return {"pattern": "__SERENA_SUPPRESSED__", "output_mode": "content", "max_results": 0}
+        if self._tool_name == "glob":
+            return {"pattern": "__SERENA_SUPPRESSED__"}
+        if self._tool_name == "exec" and self._is_shell_command_call():
+            quoted_message = oslex.quote(message)
+            return {"command": f"printf '%s\\n' {quoted_message}"}
+        return None
 
 
 class SessionStartActivateProjectHook(Hook):

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -100,12 +100,11 @@ class PreToolUseHook(Hook, ABC):
 
             if client == HookClient.DEVIN:
                 # A top-level "block"/deny decision *cancels the agent's turn* in Devin CLI (unlike
-                # Claude Code's deny, which just rejects the one call and lets the agent continue), so
-                # it is far too harsh for a nudge. Instead we soft-enforce: rewrite the wasteful
-                # read/grep/exec call to a harmless no-op that returns the reminder as its output
-                # (see _build_devin_noop_input), keeping the agent cycle alive. The reminder is also
-                # passed as additionalContext. When no no-op applies, we inject context only and let
-                # the tool run — we never emit a "decision", so a reminder can never end the turn.
+                # Claude Code's deny, which rejects only the one call and lets the agent continue),
+                # so it is far too harsh for a nudge. We therefore never emit a "decision": the
+                # reminder is delivered by rewriting the wasteful read/grep/exec call to a harmless
+                # no-op whose output is the reminder (updated_input, see _build_devin_noop_input),
+                # which keeps the turn alive. The reminder text is also passed as additionalContext.
                 hook_specific: dict = {
                     "hookEventName": "PreToolUse",
                     "additionalContext": self.additional_context or self.permission_decision_reason,
@@ -496,18 +495,23 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
             output_data = self._build_non_symbolic_deny()
 
         if output_data is not None:
-            # reset burst counters so the next interval starts fresh, then record
-            # the deny timestamp and emit. The is_hook_active() guard at the top
-            # ensures we never reach this branch within the rate-limit window.
+            emit = True
             if self._client == HookClient.DEVIN:
                 # Soft-enforce for Devin: rewrite the offending call to a no-op that surfaces the
-                # reminder, rather than blocking (a block would cancel the agent's turn). See
-                # OutputData.to_json_string / _build_devin_noop_input.
+                # reminder (a block would cancel the whole turn). If the triggering tool has no safe
+                # no-op — only reachable from stale/mixed counter state, since the burst tools are
+                # always read/grep/exec — stay silent and keep the burst state, so the next
+                # read/grep/exec gets nudged instead of the turn being cancelled or the tool spoofed.
                 message = output_data.additional_context or output_data.permission_decision_reason
                 output_data.updated_input = self._build_devin_noop_input(message)
-            self._tool_call_counter.reset()
-            self._tool_call_counter.last_deny_timestamp = self.triggered_at_timestamp
-            click.echo(output_data.to_json_string(self._client))
+                emit = output_data.updated_input is not None
+            if emit:
+                # reset burst counters so the next interval starts fresh, then record the deny
+                # timestamp. The is_hook_active() guard at the top ensures we never reach this
+                # branch within the rate-limit window.
+                self._tool_call_counter.reset()
+                self._tool_call_counter.last_deny_timestamp = self.triggered_at_timestamp
+                click.echo(output_data.to_json_string(self._client))
         self._tool_call_counter.save(self)
 
     def _build_grep_deny(self) -> "PreToolUseHook.OutputData":
@@ -546,33 +550,23 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
         )
 
     def _build_devin_noop_input(self, message: str) -> dict | None:
-        """Return a Devin tool_input that prevents the original action while keeping the cycle alive.
+        """Rewrite the offending call to a harmless no-op whose *output is the reminder*, so the
+        agent sees the nudge and its turn continues (a ``block`` would cancel the turn in Devin).
 
-        The tool still executes, but with harmless arguments, and its output is replaced by the
-        reminder message so the model sees what to do next. ``read`` and ``grep`` are pointed at a
-        dedicated nudge file, ``glob`` at a literal file path, and ``exec`` commands are replaced
-        with a ``printf`` of the warning. Returns ``None`` for tools without a safe no-op; the
-        caller then injects the reminder as context only (never a blocking decision).
+        ``exec`` becomes a ``printf`` of the message; ``read``/``grep`` are pointed at a small
+        nudge file that holds the message. Returns ``None`` for any other tool — the caller then
+        stays silent rather than blocking. Only the burst tools (``read``/``grep``/``exec``) ever
+        reach a deny, so ``None`` is a defensive fallback for stale counter state.
         """
-        nudge_file = Path(self.session_persistence_dir) / "devin_nudge.txt"
-        nudge_file.parent.mkdir(parents=True, exist_ok=True)
-        # Repeat the message so it survives either 0-indexed or 1-indexed offsets.
-        nudge_file.write_text(message + "\n" + message, encoding="utf-8")
-
-        if self._tool_name == "read":
-            return {"file_path": str(nudge_file), "offset": 1, "limit": 1000}
-        if self._tool_name == "grep":
-            return {
-                "pattern": ".*",
-                "path": str(nudge_file),
-                "output_mode": "content",
-                "max_results": 100,
-            }
-        if self._tool_name == "glob":
-            return {"pattern": str(nudge_file)}
         if self._tool_name == "exec" and self._is_shell_command_call():
-            quoted_message = oslex.quote(message)
-            return {"command": f"printf '%s\\n' {quoted_message}"}
+            return {"command": f"printf '%s\\n' {oslex.quote(message)}"}
+        if self._tool_name in ("read", "grep"):
+            nudge_file = Path(self.session_persistence_dir) / "devin_nudge.txt"
+            nudge_file.parent.mkdir(parents=True, exist_ok=True)
+            nudge_file.write_text(message + "\n", encoding="utf-8")
+            if self._tool_name == "read":
+                return {"file_path": str(nudge_file)}
+            return {"pattern": ".*", "path": str(nudge_file), "output_mode": "content"}
         return None
 
 

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -26,6 +26,7 @@ class HookClient(Enum):
     VSCODE = "vscode"
     CODEX = "codex"
     GROK = "grok"
+    DEVIN = "devin"
 
 
 class Hook(ABC):
@@ -94,6 +95,11 @@ class PreToolUseHook(Hook, ABC):
                 if self.permission_decision == "deny":
                     grok_output["reason"] = self.permission_decision_reason
                 return json.dumps(grok_output)
+
+            if client == HookClient.DEVIN:
+                # Devin CLI PreToolUse hooks use top-level "decision" (approve/block) with a reason.
+                decision = "approve" if self.permission_decision == "allow" else "block"
+                return json.dumps({"decision": decision, "reason": self.additional_context or self.permission_decision_reason})
 
             hook_output = {
                 "hookSpecificOutput": {
@@ -381,7 +387,7 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
     def is_grep_call(self) -> bool:
         if self._client in (HookClient.CLAUDE_CODE, HookClient.CODEBUDDY):
             return self._tool_name == "grep" or "search_for_pattern" in self._tool_name
-        if self._client == HookClient.GROK:
+        if self._client in (HookClient.GROK, HookClient.DEVIN):
             return self._tool_name == "grep" or (self._is_shell_command_call() and self._command_name in self._GREP_SHELL_COMMANDS)
         if self._client == HookClient.CODEX and self._is_shell_command_call():
             return self._command_name in self._GREP_SHELL_COMMANDS
@@ -391,8 +397,9 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
     def is_read_call(self) -> bool:
         if self._client in (HookClient.CLAUDE_CODE, HookClient.CODEBUDDY):
             return self._tool_name == "read" or "read_file" in self._tool_name
-        if self._client == HookClient.GROK:
-            return self._tool_name == "read_file" or (self._is_shell_command_call() and self._command_name in self._READ_SHELL_COMMANDS)
+        if self._client in (HookClient.GROK, HookClient.DEVIN):
+            read_tool = "read_file" if self._client == HookClient.GROK else "read"
+            return self._tool_name == read_tool or (self._is_shell_command_call() and self._command_name in self._READ_SHELL_COMMANDS)
         if self._client == HookClient.CODEX and self._is_shell_command_call():
             return self._command_name in self._READ_SHELL_COMMANDS
         # heuristic for other clients
@@ -417,7 +424,7 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
         if self._file_path is not None:
             return self._is_code_file_path(self._file_path)
 
-        if self._client in (HookClient.CODEX, HookClient.GROK) and self._command_args_str is not None:
+        if self._client in (HookClient.CODEX, HookClient.GROK, HookClient.DEVIN) and self._command_args_str is not None:
             return any(self._is_code_file_path(argument) for argument in self._iter_shell_path_arguments())
 
         return True
@@ -565,8 +572,9 @@ class PreToolUseAutoApproveSerenaHook(PreToolUseHook):
     #: the canonical mode strings emitted by Claude Code's hook payload.
     _AUTO_APPROVE_MODES: frozenset[str] = frozenset({"acceptEdits", "auto"})
 
+    # Devin CLI does not expose a permission mode in PreToolUse payloads; auto-approve is unconditional for it.
     def is_auto_approve_mode(self) -> bool:
-        return self._permission_mode in self._AUTO_APPROVE_MODES
+        return self._client == HookClient.DEVIN or self._permission_mode in self._AUTO_APPROVE_MODES
 
     def execute(self) -> None:
         # only emit a decision when both the tool and the mode match; stay silent otherwise
@@ -577,7 +585,11 @@ class PreToolUseAutoApproveSerenaHook(PreToolUseHook):
         # (the same hook handles multiple modes now)
         output_data = self.OutputData(
             permission_decision="allow",
-            permission_decision_reason=f"Auto-approved: Serena tool call while client is in {self._permission_mode} mode.",
+            permission_decision_reason=(
+                "Auto-approved: Serena symbolic tool call in Devin CLI."
+                if self._client == HookClient.DEVIN
+                else f"Auto-approved: Serena tool call while client is in {self._permission_mode} mode."
+            ),
         )
         click.echo(output_data.to_json_string(self._client))
 

--- a/src/serena/resources/config/contexts/devin.yml
+++ b/src/serena/resources/config/contexts/devin.yml
@@ -1,0 +1,46 @@
+description: Devin CLI (CLI agent where read, edit, grep, glob and exec are built-in; single project mode)
+prompt: |
+  You are running in Devin CLI, a terminal coding agent where read, edit, grep, glob and exec are handled by your own internal tools.
+
+  You have access to Serena's code intelligence tools that exploit the symbolic structure of the code and are much more efficient than your own tools for most coding scenarios.
+  If you are working on any coding task and Serena's tools are deferred, load them all immediately before performing any read, grep or exec commands.
+  If Serena's tools can be used to achieve your task, prioritize them.
+
+  **CRITICAL**: If you haven't seen Serena's tools yet, use the tool search tool to load all of them **right now**.
+  For exploring and reading code in a token-efficient manner, use Serena's code-centric overview and symbolic search tools.
+  For edits, prefer Serena's editing tools since they are more token efficient.
+  Especially when editing code you have read through Serena, **ALWAYS** use Serena's tools for editing, because your built-in tools will deny such edits (they will assume you haven't read the content).
+  **CRITICAL**: Never use a tool before having read its schema via the tool-search tool!
+
+  **CRITICAL**: You have a preference for relying on your own tools like grep, read and edit. It is of paramount importance that you overcome this preference and instead develop a preference for using Serena's tools since they are superior for most coding tasks. Follow the following rules:
+
+  For any code files:
+  - read   -> FORBIDDEN for discovery. Use get_symbols_overview, then find_symbol with include_body.
+              You may use read only if you already have an overview of the file and if reading whole symbols is inappropriate (e.g., a few lines of code).
+  - glob   -> Allowed for discovery only.
+  - grep   -> Allowed for discovery only; follow-up reads or reference searches must be Serena.
+  - edit   -> FORBIDDEN. Use replace_symbol_body / insert_*_symbol / replace_content.
+
+  Disallowed reasoning. Do NOT use any of the following to justify read/edit on a code file:
+    - "I already know the path"
+    - "one read call is faster than three Serena calls"
+    - "the built-in tool description says to use read for known paths"
+  If you catch yourself reaching for one of these, that is the signal to switch to Serena.
+
+excluded_tools:
+  - create_text_file
+  - read_file
+  - execute_shell_command
+  - find_file
+  - list_dir
+  - search_for_pattern
+
+tool_description_overrides: {}
+
+# whether to assume that Serena shall only work on a single project in this context (provided that a project is given
+# when Serena is started).
+# If set to true and a project is provided at startup, the set of tools is limited to those required by the project's
+# concrete configuration, and other tools are excluded completely, allowing the set of tools to be minimal.
+# Tools explicitly disabled by the project will not be available at all.
+# The `activate_project` tool is always disabled in this case, as project switching cannot be allowed.
+single_project: true

--- a/test/serena/config/test_client_setup.py
+++ b/test/serena/config/test_client_setup.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 import pytest
 
 from serena.config.client_setup import ClientSetupHandlerDevin, ClientSetupHandlerGrok, client_setup_handlers
@@ -167,9 +170,12 @@ def test_devin_setup_handler_apply_uses_devin_mcp_add(monkeypatch):
         return True
 
     monkeypatch.setattr(ClientSetupHandlerDevin, "_run_shell_command", fake_run_shell_command)
+    monkeypatch.setattr(ClientSetupHandlerDevin, "_configure_devin_config", lambda self, scope: True)
 
     assert ClientSetupHandlerDevin().apply() is True
-    assert commands == ["devin mcp add -s user serena -- serena start-mcp-server --context=devin --project-from-cwd"]
+    assert commands == [
+        "devin mcp add -s user serena -- serena start-mcp-server --context=devin --enable-web-dashboard false --open-web-dashboard false --add-mode query-projects --project-from-cwd"
+    ]
 
 
 @pytest.mark.parametrize(
@@ -213,3 +219,29 @@ def test_devin_setup_handler_rejects_mcp_add_help_without_expected_text(monkeypa
 
     assert ClientSetupHandlerDevin().is_applicable() is False
     assert commands == ["devin --version", "devin mcp add --help"]
+
+
+def test_devin_setup_handler_writes_full_config(monkeypatch, tmp_path: Path):
+    handler = ClientSetupHandlerDevin()
+    config_path = tmp_path / "config.json"
+    initial = {
+        "mcpServers": {
+            "serena": {
+                "command": "serena",
+                "args": ["start-mcp-server", "--context=devin", "--project-from-cwd"],
+            }
+        }
+    }
+    config_path.write_text(json.dumps(initial))
+    monkeypatch.setattr(handler, "_devin_config_path", lambda scope: config_path)
+
+    assert handler._configure_devin_config("user") is True
+
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    assert config["mcpServers"]["serena"]["command"] == "serena"
+    assert "mcp__serena__*" in config["permissions"]["allow"]
+    assert any(entry.get("hooks", [])[0].get("command") == "serena-hooks remind --client=devin" for entry in config["hooks"]["PreToolUse"])
+    assert any(
+        entry.get("hooks", [])[0].get("command") == "serena-hooks post-remind --client=devin" for entry in config["hooks"]["PostToolUse"]
+    )
+    assert any("--include-instructions" in entry.get("hooks", [])[0].get("command", "") for entry in config["hooks"]["PostCompaction"])

--- a/test/serena/config/test_client_setup.py
+++ b/test/serena/config/test_client_setup.py
@@ -245,3 +245,25 @@ def test_devin_setup_handler_writes_full_config(monkeypatch, tmp_path: Path):
         entry.get("hooks", [])[0].get("command") == "serena-hooks post-remind --client=devin" for entry in config["hooks"]["PostToolUse"]
     )
     assert any("--include-instructions" in entry.get("hooks", [])[0].get("command", "") for entry in config["hooks"]["PostCompaction"])
+
+
+def test_devin_setup_handler_removes_stale_node_hooks(monkeypatch, tmp_path: Path):
+    handler = ClientSetupHandlerDevin()
+    config_path = tmp_path / "config.json"
+    initial = {
+        "mcpServers": {"serena": {"command": "serena", "args": ["start-mcp-server"]}},
+        "hooks": {
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": 'node "$HOME/.config/devin/hooks/serena/serena-devin.js" SessionStart'}]},
+                {"hooks": [{"type": "command", "command": "serena-hooks activate --client=devin"}]},
+            ]
+        },
+    }
+    config_path.write_text(json.dumps(initial))
+    monkeypatch.setattr(handler, "_devin_config_path", lambda scope: config_path)
+
+    assert handler._configure_devin_config("user") is True
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    session_start = config["hooks"]["SessionStart"]
+    assert all("serena-devin.js" not in entry["hooks"][0]["command"] for entry in session_start)
+    assert any(entry["hooks"][0]["command"] == "serena-hooks activate --client=devin" for entry in session_start)

--- a/test/serena/config/test_client_setup.py
+++ b/test/serena/config/test_client_setup.py
@@ -242,9 +242,13 @@ def test_devin_setup_handler_writes_full_config(monkeypatch, tmp_path: Path):
     assert "mcp__serena__*" in config["permissions"]["allow"]
     assert any(entry.get("hooks", [])[0].get("command") == "serena-hooks remind --client=devin" for entry in config["hooks"]["PreToolUse"])
     assert any(
-        entry.get("hooks", [])[0].get("command") == "serena-hooks post-remind --client=devin" for entry in config["hooks"]["PostToolUse"]
+        entry.get("hooks", [])[0].get("command") == "serena-hooks activate --client=devin --include-instructions --event SessionStart"
+        for entry in config["hooks"]["SessionStart"]
     )
-    assert any("--include-instructions" in entry.get("hooks", [])[0].get("command", "") for entry in config["hooks"]["PostCompaction"])
+    assert any(
+        entry.get("hooks", [])[0].get("command") == "serena-hooks activate --client=devin --include-instructions --event PostCompaction"
+        for entry in config["hooks"]["PostCompaction"]
+    )
 
 
 def test_devin_setup_handler_removes_stale_node_hooks(monkeypatch, tmp_path: Path):
@@ -266,4 +270,7 @@ def test_devin_setup_handler_removes_stale_node_hooks(monkeypatch, tmp_path: Pat
     config = json.loads(config_path.read_text(encoding="utf-8"))
     session_start = config["hooks"]["SessionStart"]
     assert all("serena-devin.js" not in entry["hooks"][0]["command"] for entry in session_start)
-    assert any(entry["hooks"][0]["command"] == "serena-hooks activate --client=devin" for entry in session_start)
+    assert any(
+        entry["hooks"][0]["command"] == "serena-hooks activate --client=devin --include-instructions --event SessionStart"
+        for entry in session_start
+    )

--- a/test/serena/config/test_client_setup.py
+++ b/test/serena/config/test_client_setup.py
@@ -1,6 +1,6 @@
 import pytest
 
-from serena.config.client_setup import ClientSetupHandlerGrok, client_setup_handlers
+from serena.config.client_setup import ClientSetupHandlerDevin, ClientSetupHandlerGrok, client_setup_handlers
 from serena.config.context_mode import SerenaAgentContext
 from serena.util.shell import ShellCommandResult
 
@@ -129,3 +129,87 @@ def test_client_setup_handlers_use_resolvable_contexts():
         assert len(context_options) == 1
         context_name = context_options[0].removeprefix("--context=")
         assert SerenaAgentContext.from_name(context_name).name == context_name
+
+
+def test_devin_setup_handler_is_applicable_for_devin_cli(monkeypatch):
+    commands: list[str] = []
+
+    def fake_execute_shell_command(command: str, capture_stderr: bool = False) -> ShellCommandResult:
+        commands.append(command)
+        if command == "devin --version":
+            return _result(command, stdout="devin 3000.2.17 (2c489dfc)\n")
+        if command == "devin mcp add --help":
+            return _result(command, stdout="Add a new MCP server.\n")
+        return _result(command, return_code=1)
+
+    monkeypatch.setattr("serena.config.client_setup.execute_shell_command", fake_execute_shell_command)
+
+    assert ClientSetupHandlerDevin().is_applicable() is True
+    assert commands == ["devin --version", "devin mcp add --help"]
+
+
+def test_devin_setup_handler_rejects_binary_without_mcp_add(monkeypatch):
+    def fake_execute_shell_command(command: str, capture_stderr: bool = False) -> ShellCommandResult:
+        if command == "devin --version":
+            return _result(command, stdout="devin 3000.2.17 (2c489dfc)\n")
+        return _result(command, return_code=1, stdout="unknown command\n")
+
+    monkeypatch.setattr("serena.config.client_setup.execute_shell_command", fake_execute_shell_command)
+
+    assert ClientSetupHandlerDevin().is_applicable() is False
+
+
+def test_devin_setup_handler_apply_uses_devin_mcp_add(monkeypatch):
+    commands: list[str] = []
+
+    def fake_run_shell_command(self: ClientSetupHandlerDevin, command: str) -> bool:
+        commands.append(command)
+        return True
+
+    monkeypatch.setattr(ClientSetupHandlerDevin, "_run_shell_command", fake_run_shell_command)
+
+    assert ClientSetupHandlerDevin().apply() is True
+    assert commands == ["devin mcp add -s user serena -- serena start-mcp-server --context=devin --project-from-cwd"]
+
+
+@pytest.mark.parametrize(
+    ("return_code", "stdout"),
+    [
+        (1, ""),
+        (0, "0.0.34\n"),
+        (0, "my-devin wrapper 1.0\n"),
+        (0, "devin\n"),
+        (0, "  devin 3000.2.17"),
+    ],
+)
+def test_devin_setup_handler_short_circuits_when_version_probe_does_not_match(monkeypatch, return_code: int, stdout: str):
+    commands: list[str] = []
+
+    def fake_execute_shell_command(command: str, capture_stderr: bool = False) -> ShellCommandResult:
+        commands.append(command)
+        if command == "devin --version":
+            return _result(command, return_code=return_code, stdout=stdout)
+        return _result(command, stdout="Add a new MCP server.\n")
+
+    monkeypatch.setattr("serena.config.client_setup.execute_shell_command", fake_execute_shell_command)
+
+    assert ClientSetupHandlerDevin().is_applicable() is False
+    assert commands == ["devin --version"]
+
+
+@pytest.mark.parametrize("help_stdout", ["Usage: devin mcp add\n", "add a new mcp server\n"])
+def test_devin_setup_handler_rejects_mcp_add_help_without_expected_text(monkeypatch, help_stdout: str):
+    commands: list[str] = []
+
+    def fake_execute_shell_command(command: str, capture_stderr: bool = False) -> ShellCommandResult:
+        commands.append(command)
+        if command == "devin --version":
+            return _result(command, stdout="devin 3000.2.17 (2c489dfc)\n")
+        if command == "devin mcp add --help":
+            return _result(command, stdout=help_stdout)
+        return _result(command, return_code=1)
+
+    monkeypatch.setattr("serena.config.client_setup.execute_shell_command", fake_execute_shell_command)
+
+    assert ClientSetupHandlerDevin().is_applicable() is False
+    assert commands == ["devin --version", "devin mcp add --help"]

--- a/test/serena/config/test_grok_docs.py
+++ b/test/serena/config/test_grok_docs.py
@@ -80,8 +80,10 @@ def test_devin_docs_are_consistent():
     assert "serena-hooks remind --client=devin" in devin_section
     assert "serena-hooks cleanup --client=devin" in devin_section
     assert "serena-hooks activate --client=devin" in devin_section
-    assert "serena-hooks auto-approve --client=devin" in devin_section
-    assert "PermissionRequest" in devin_section
-    assert '"matcher": "mcp__serena__.*"' in devin_section
+
+    # Auto-approval uses Devin CLI's native permission allow-list, not a hook.
+    assert "mcp__serena__*" in devin_section
+    assert "serena-hooks auto-approve" not in devin_section
+    assert "PermissionRequest" not in devin_section
 
     assert "* `devin`: Optimized for use with Devin CLI" in config_doc

--- a/test/serena/config/test_grok_docs.py
+++ b/test/serena/config/test_grok_docs.py
@@ -5,7 +5,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
-from serena.config.client_setup import ClientSetupHandlerGrok
+from serena.config.client_setup import ClientSetupHandlerDevin, ClientSetupHandlerGrok
 from serena.hooks import HookClient, PreToolUseRemindAboutSymbolicToolsHook
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -43,7 +43,7 @@ def test_grok_docs_are_consistent():
     assert "serena-hooks cleanup --client=grok" in grok_section
 
     assert "* `grok`: Optimized for use with xAI's Grok Build CLI." in config_doc
-    assert "contexts `ide`, `claude-code`, and `grok` are **single-project contexts**" in config_doc
+    assert "contexts `ide`, `claude-code`, `devin`, and `grok` are **single-project contexts**" in config_doc
 
 
 def test_grok_hook_matcher_docs_match_code(tmp_path: Path):
@@ -65,3 +65,20 @@ def test_grok_hook_matcher_docs_match_code(tmp_path: Path):
             hook = PreToolUseRemindAboutSymbolicToolsHook(HookClient.GROK)
 
         assert hook.is_grep_call() or hook.is_read_call() or hook._is_shell_command_call()
+
+
+def test_devin_docs_are_consistent():
+    clients_doc = (PROJECT_ROOT / "docs/02-usage/030_clients.md").read_text()
+    config_doc = (PROJECT_ROOT / "docs/02-usage/050_configuration.md").read_text()
+    handler_source = inspect.getsource(ClientSetupHandlerDevin.apply)
+
+    assert "\n## Devin CLI\n" in clients_doc
+    devin_section = _extract_section(clients_doc, "Devin CLI")
+
+    assert "030_clients.html#devin-cli" in handler_source
+    assert "serena setup devin" in devin_section
+    assert "serena-hooks remind --client=devin" in devin_section
+    assert "serena-hooks cleanup --client=devin" in devin_section
+    assert "serena-hooks activate --client=devin" in devin_section
+
+    assert "* `devin`: Optimized for use with Devin CLI" in config_doc

--- a/test/serena/config/test_grok_docs.py
+++ b/test/serena/config/test_grok_docs.py
@@ -80,5 +80,8 @@ def test_devin_docs_are_consistent():
     assert "serena-hooks remind --client=devin" in devin_section
     assert "serena-hooks cleanup --client=devin" in devin_section
     assert "serena-hooks activate --client=devin" in devin_section
+    assert "serena-hooks auto-approve --client=devin" in devin_section
+    assert "PermissionRequest" in devin_section
+    assert '"matcher": "mcp__serena__.*"' in devin_section
 
     assert "* `devin`: Optimized for use with Devin CLI" in config_doc

--- a/test/serena/test_cli_project_commands.py
+++ b/test/serena/test_cli_project_commands.py
@@ -364,6 +364,27 @@ class TestFindProjectRoot:
         finally:
             os.chdir(original_cwd)
 
+    def test_start_directory_override(self, temp_project_dir):
+        """A custom start directory is used instead of CWD, respecting the root boundary."""
+        serena_dir = os.path.join(temp_project_dir, ".serena")
+        os.makedirs(serena_dir)
+        Path(os.path.join(serena_dir, "project.yml")).touch()
+        subdir = os.path.join(temp_project_dir, "src", "nested")
+        os.makedirs(subdir)
+        other_dir = os.path.join(temp_project_dir, "other")
+        os.makedirs(other_dir)
+
+        # Even though we are in an unrelated directory, starting the search from subdir
+        # and bounding it to temp_project_dir should find the project root.
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(other_dir)
+            result = find_project_root(start=subdir, root=temp_project_dir)
+            assert result is not None
+            assert os.path.samefile(result, temp_project_dir)
+        finally:
+            os.chdir(original_cwd)
+
 
 class TestProjectFromCwdMutualExclusivity:
     """Tests for --project-from-cwd mutual exclusivity."""

--- a/test/serena/test_cli_project_commands.py
+++ b/test/serena/test_cli_project_commands.py
@@ -365,6 +365,15 @@ class TestFindProjectRoot:
         finally:
             os.chdir(original_cwd)
 
+    def test_start_overrides_cwd_and_walks_up(self, temp_project_dir):
+        """``start`` searches upward from the given directory instead of CWD."""
+        os.makedirs(os.path.join(temp_project_dir, ".git"))
+        subdir = os.path.join(temp_project_dir, "a", "b")
+        os.makedirs(subdir)
+        # CWD is unrelated; searching from the subdir must still find the repo root.
+        result = find_project_root(start=subdir)
+        assert result is not None and os.path.samefile(result, temp_project_dir)
+
 
 class TestProjectFromCwd:
     """Tests for the --project-from-cwd flag (mutual exclusivity and project resolution)."""
@@ -378,25 +387,47 @@ class TestProjectFromCwd:
         assert result.exit_code != 0
         assert "cannot be used with" in result.output
 
-    def test_project_from_cwd_prefers_devin_project_dir(self, monkeypatch, temp_project_dir):
-        """--project-from-cwd honors DEVIN_PROJECT_DIR (Devin may spawn the server from another cwd)."""
-        monkeypatch.setenv("DEVIN_PROJECT_DIR", temp_project_dir)
+    @staticmethod
+    def _resolved_project() -> str:
+        """Invoke start_mcp_server --project-from-cwd with the MCP factory mocked; return the resolved project."""
         with patch("serena.mcp.SerenaMCPFactory") as factory_cls:
             factory_cls.return_value.create_mcp_server.return_value = MagicMock()
             result = CliRunner().invoke(TopLevelCommands.start_mcp_server, ["--project-from-cwd", "--transport", "stdio"])
         assert result.exit_code == 0, result.output
-        assert factory_cls.call_args.kwargs["project"] == temp_project_dir
+        return factory_cls.call_args.kwargs["project"]
 
-    def test_project_from_cwd_falls_back_to_cwd_detection(self, monkeypatch, temp_project_dir):
-        """Without DEVIN_PROJECT_DIR, --project-from-cwd detects the project by walking up from CWD."""
+    def test_uses_devin_project_dir_when_it_is_the_repo_root(self, monkeypatch, temp_project_dir):
+        """DEVIN_PROJECT_DIR pointing at a git root activates that root."""
+        os.makedirs(os.path.join(temp_project_dir, ".git"))
+        monkeypatch.setenv("DEVIN_PROJECT_DIR", temp_project_dir)
+        project = self._resolved_project()
+        assert project is not None and os.path.samefile(project, temp_project_dir)
+
+    def test_walks_up_from_devin_project_dir_subdirectory(self, monkeypatch, temp_project_dir):
+        """DEVIN_PROJECT_DIR pointing at a subdirectory still resolves to the real repo root."""
+        os.makedirs(os.path.join(temp_project_dir, ".git"))
+        subdir = os.path.join(temp_project_dir, "packages", "app")
+        os.makedirs(subdir)
+        monkeypatch.setenv("DEVIN_PROJECT_DIR", subdir)
+        project = self._resolved_project()
+        assert project is not None and os.path.samefile(project, temp_project_dir)
+
+    def test_honors_devin_project_dir_when_not_inside_a_repo(self, monkeypatch, tmp_path):
+        """When DEVIN_PROJECT_DIR is not inside any git/Serena project, it is honored directly."""
+        # stub detection to None so a stray ancestor .git cannot interfere with the assertion
+        plain = tmp_path / "workspace"
+        plain.mkdir()
+        monkeypatch.setenv("DEVIN_PROJECT_DIR", str(plain))
+        monkeypatch.setattr("serena.cli.find_project_root", lambda **kwargs: None)
+        project = self._resolved_project()
+        assert project == str(plain)
+
+    def test_falls_back_to_cwd_detection_without_devin_project_dir(self, monkeypatch, temp_project_dir):
+        """Without DEVIN_PROJECT_DIR, the project is detected by walking up from CWD."""
         monkeypatch.delenv("DEVIN_PROJECT_DIR", raising=False)
         os.makedirs(os.path.join(temp_project_dir, ".git"))
         monkeypatch.chdir(temp_project_dir)
-        with patch("serena.mcp.SerenaMCPFactory") as factory_cls:
-            factory_cls.return_value.create_mcp_server.return_value = MagicMock()
-            result = CliRunner().invoke(TopLevelCommands.start_mcp_server, ["--project-from-cwd", "--transport", "stdio"])
-        assert result.exit_code == 0, result.output
-        project = factory_cls.call_args.kwargs["project"]
+        project = self._resolved_project()
         assert project is not None and os.path.samefile(project, temp_project_dir)
 
 

--- a/test/serena/test_cli_project_commands.py
+++ b/test/serena/test_cli_project_commands.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click import Command, Option
@@ -364,30 +365,9 @@ class TestFindProjectRoot:
         finally:
             os.chdir(original_cwd)
 
-    def test_start_directory_override(self, temp_project_dir):
-        """A custom start directory is used instead of CWD, respecting the root boundary."""
-        serena_dir = os.path.join(temp_project_dir, ".serena")
-        os.makedirs(serena_dir)
-        Path(os.path.join(serena_dir, "project.yml")).touch()
-        subdir = os.path.join(temp_project_dir, "src", "nested")
-        os.makedirs(subdir)
-        other_dir = os.path.join(temp_project_dir, "other")
-        os.makedirs(other_dir)
 
-        # Even though we are in an unrelated directory, starting the search from subdir
-        # and bounding it to temp_project_dir should find the project root.
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(other_dir)
-            result = find_project_root(start=subdir, root=temp_project_dir)
-            assert result is not None
-            assert os.path.samefile(result, temp_project_dir)
-        finally:
-            os.chdir(original_cwd)
-
-
-class TestProjectFromCwdMutualExclusivity:
-    """Tests for --project-from-cwd mutual exclusivity."""
+class TestProjectFromCwd:
+    """Tests for the --project-from-cwd flag (mutual exclusivity and project resolution)."""
 
     def test_project_from_cwd_with_project_flag_fails(self, cli_runner):
         """Test that --project-from-cwd with --project raises error."""
@@ -397,6 +377,27 @@ class TestProjectFromCwdMutualExclusivity:
         )
         assert result.exit_code != 0
         assert "cannot be used with" in result.output
+
+    def test_project_from_cwd_prefers_devin_project_dir(self, monkeypatch, temp_project_dir):
+        """--project-from-cwd honors DEVIN_PROJECT_DIR (Devin may spawn the server from another cwd)."""
+        monkeypatch.setenv("DEVIN_PROJECT_DIR", temp_project_dir)
+        with patch("serena.mcp.SerenaMCPFactory") as factory_cls:
+            factory_cls.return_value.create_mcp_server.return_value = MagicMock()
+            result = CliRunner().invoke(TopLevelCommands.start_mcp_server, ["--project-from-cwd", "--transport", "stdio"])
+        assert result.exit_code == 0, result.output
+        assert factory_cls.call_args.kwargs["project"] == temp_project_dir
+
+    def test_project_from_cwd_falls_back_to_cwd_detection(self, monkeypatch, temp_project_dir):
+        """Without DEVIN_PROJECT_DIR, --project-from-cwd detects the project by walking up from CWD."""
+        monkeypatch.delenv("DEVIN_PROJECT_DIR", raising=False)
+        os.makedirs(os.path.join(temp_project_dir, ".git"))
+        monkeypatch.chdir(temp_project_dir)
+        with patch("serena.mcp.SerenaMCPFactory") as factory_cls:
+            factory_cls.return_value.create_mcp_server.return_value = MagicMock()
+            result = CliRunner().invoke(TopLevelCommands.start_mcp_server, ["--project-from-cwd", "--transport", "stdio"])
+        assert result.exit_code == 0, result.output
+        project = factory_cls.call_args.kwargs["project"]
+        assert project is not None and os.path.samefile(project, temp_project_dir)
 
 
 if __name__ == "__main__":

--- a/test/serena/test_cli_setup.py
+++ b/test/serena/test_cli_setup.py
@@ -3,10 +3,11 @@ from types import SimpleNamespace
 from click.testing import CliRunner
 
 from serena.cli import TopLevelCommands
+from serena.config.client_setup import ClientSetupHandlerDevin
 from serena.util.shell import ShellCommandResult
 
 GROK_ADD_COMMAND = "grok mcp add --scope user serena -- serena start-mcp-server --context=grok --project-from-cwd"
-DEVIN_ADD_COMMAND = "devin mcp add -s user serena -- serena start-mcp-server --context=devin --project-from-cwd"
+DEVIN_ADD_COMMAND = "devin mcp add -s user serena -- serena start-mcp-server --context=devin --enable-web-dashboard false --open-web-dashboard false --add-mode query-projects --project-from-cwd"
 
 
 def _result(command: str, return_code: int = 0, stdout: str = "", stderr: str = "") -> ShellCommandResult:
@@ -106,13 +107,12 @@ def test_setup_devin_success(monkeypatch):
         return _result(command, return_code=1)
 
     monkeypatch.setattr("serena.config.client_setup.execute_shell_command", fake_execute_shell_command)
+    monkeypatch.setattr(ClientSetupHandlerDevin, "_configure_devin_config", lambda self, scope: True)
 
     result = CliRunner().invoke(TopLevelCommands.setup, ["devin"])
 
     assert result.exit_code == 0, result.output
     assert "successfully set up for devin" in result.output
-    assert "recommend" in result.output.lower()
-    assert "030_clients.html#devin-cli" in result.output
     assert commands == ["devin --version", "devin mcp add --help", DEVIN_ADD_COMMAND]
 
 

--- a/test/serena/test_cli_setup.py
+++ b/test/serena/test_cli_setup.py
@@ -6,6 +6,7 @@ from serena.cli import TopLevelCommands
 from serena.util.shell import ShellCommandResult
 
 GROK_ADD_COMMAND = "grok mcp add --scope user serena -- serena start-mcp-server --context=grok --project-from-cwd"
+DEVIN_ADD_COMMAND = "devin mcp add -s user serena -- serena start-mcp-server --context=devin --project-from-cwd"
 
 
 def _result(command: str, return_code: int = 0, stdout: str = "", stderr: str = "") -> ShellCommandResult:
@@ -89,3 +90,81 @@ def test_init_suggests_grok_when_detected(monkeypatch):
     assert result.exit_code == 0, result.output
     assert "serena setup grok" in result.output
     assert "serena setup claude-code" not in result.output
+
+
+def test_setup_devin_success(monkeypatch):
+    commands: list[str] = []
+
+    def fake_execute_shell_command(command: str, capture_stderr: bool = False) -> ShellCommandResult:
+        commands.append(command)
+        if command == "devin --version":
+            return _result(command, stdout="devin 3000.2.17 (2c489dfc)\n")
+        if command == "devin mcp add --help":
+            return _result(command, stdout="Add a new MCP server.\n")
+        if command == DEVIN_ADD_COMMAND:
+            return _result(command)
+        return _result(command, return_code=1)
+
+    monkeypatch.setattr("serena.config.client_setup.execute_shell_command", fake_execute_shell_command)
+
+    result = CliRunner().invoke(TopLevelCommands.setup, ["devin"])
+
+    assert result.exit_code == 0, result.output
+    assert "successfully set up for devin" in result.output
+    assert "recommend" in result.output.lower()
+    assert "030_clients.html#devin-cli" in result.output
+    assert commands == ["devin --version", "devin mcp add --help", DEVIN_ADD_COMMAND]
+
+
+def test_setup_devin_not_applicable_exits_1(monkeypatch):
+    def fake_execute_shell_command(command: str, capture_stderr: bool = False) -> ShellCommandResult:
+        if command == "devin --version":
+            return _result(command, return_code=1)
+        return _result(command)
+
+    monkeypatch.setattr("serena.config.client_setup.execute_shell_command", fake_execute_shell_command)
+
+    result = CliRunner().invoke(TopLevelCommands.setup, ["devin"])
+
+    assert result.exit_code == 1
+    assert "Cannot apply setup for client 'devin'" in result.output
+
+
+def test_setup_devin_apply_failure_exits_1(monkeypatch):
+    def fake_execute_shell_command(command: str, capture_stderr: bool = False) -> ShellCommandResult:
+        if command == "devin --version":
+            return _result(command, stdout="devin 3000.2.17 (2c489dfc)\n")
+        if command == "devin mcp add --help":
+            return _result(command, stdout="Add a new MCP server.\n")
+        if command == DEVIN_ADD_COMMAND:
+            return _result(command, return_code=1, stderr="boom")
+        return _result(command, return_code=1)
+
+    monkeypatch.setattr("serena.config.client_setup.execute_shell_command", fake_execute_shell_command)
+
+    result = CliRunner().invoke(TopLevelCommands.setup, ["devin"])
+
+    assert result.exit_code == 1
+    assert "Failed to set up Serena for devin" in result.output
+    assert "recommend" not in result.output.lower()
+    assert "030_clients.html#devin-cli" not in result.output
+
+
+def test_init_suggests_devin_when_detected(monkeypatch):
+    def fake_execute_shell_command(command: str, capture_stderr: bool = False) -> ShellCommandResult:
+        if command == "devin --version":
+            return _result(command, stdout="devin 3000.2.17 (2c489dfc)\n")
+        if command == "devin mcp add --help":
+            return _result(command, stdout="Add a new MCP server.\n")
+        return _result(command, return_code=1)
+
+    def fake_init(**kwargs) -> SimpleNamespace:
+        return SimpleNamespace(config_file_path="/tmp/serena_config.yml")
+
+    monkeypatch.setattr("serena.config.client_setup.execute_shell_command", fake_execute_shell_command)
+    monkeypatch.setattr("serena.cli.SerenaConfig.init", fake_init)
+
+    result = CliRunner().invoke(TopLevelCommands.init, [])
+
+    assert result.exit_code == 0, result.output
+    assert "serena setup devin" in result.output

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 
 from serena.hooks import (
     HookClient,
+    PostToolUseRemindAboutSymbolicToolsHook,
     PreToolUseAutoApproveSerenaHook,
     PreToolUseHook,
     PreToolUseRemindAboutSymbolicToolsHook,
@@ -1295,7 +1296,9 @@ class TestDevinHookSupport:
     def test_claude_session_start_generic_index_reminder(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ):
-        """Claude Code SessionStart hook gives a generic index reminder when no project dir is known."""
+        """Claude Code SessionStart hook gives a generic index reminder when no
+        project dir is known.
+        """
         monkeypatch.delenv("DEVIN_PROJECT_DIR", raising=False)
         with patch("sys.stdin", _make_stdin({"session_id": "claude-session"})), patch("serena.hooks.serena_home_dir", str(tmp_path)):
             SessionStartActivateProjectHook(HookClient.CLAUDE_CODE).execute()
@@ -1304,3 +1307,47 @@ class TestDevinHookSupport:
         additional_context = result["hookSpecificOutput"]["additionalContext"]
         assert "remind the user to run" in additional_context
         assert "serena project index" in additional_context
+
+    def test_devin_post_remind_after_grep(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Devin CLI PostToolUse hook reminds after a raw grep call."""
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):
+                PostToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        assert result["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+        assert "symbolic tools" in result["hookSpecificOutput"]["additionalContext"]
+
+    def test_devin_post_remind_respects_cooldown(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Devin CLI PostToolUse hook only nudges once per cooldown window."""
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            with patch("sys.stdin", _make_stdin(_base_input(tool_name="read", tool_input={"file_path": "src/foo.py"}))):
+                PostToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
+            assert capsys.readouterr().out != ""
+
+            # second call within the same session should be silent
+            with patch("sys.stdin", _make_stdin(_base_input(tool_name="read", tool_input={"file_path": "src/bar.py"}))):
+                PostToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
+        assert capsys.readouterr().out == ""
+
+    def test_devin_post_compaction_includes_full_instructions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        """Devin CLI PostCompaction hook re-injects the full Serena system prompt."""
+
+        def fake_subprocess_run(cmd, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = "FULL SERENA INSTRUCTIONS\n"
+                stderr = ""
+
+            return Result()
+
+        monkeypatch.setattr("serena.hooks.subprocess.run", fake_subprocess_run)
+        with patch("sys.stdin", _make_stdin({"session_id": "devin-session"})), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            SessionStartActivateProjectHook(HookClient.DEVIN, include_instructions=True, event_name="PostCompaction").execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        assert result["hookSpecificOutput"]["hookEventName"] == "PostCompaction"
+        assert "FULL SERENA INSTRUCTIONS" in result["hookSpecificOutput"]["additionalContext"]
+        assert "activate it using Serena" in result["hookSpecificOutput"]["additionalContext"]

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pickle
 from datetime import datetime, timedelta
 from io import StringIO
@@ -1237,3 +1238,69 @@ class TestDevinHookSupport:
         result = json.loads(output)
         assert result["hookSpecificOutput"]["hookEventName"] == "SessionStart"
         assert "/tmp/devin-project" in result["hookSpecificOutput"]["additionalContext"]
+
+    def test_devin_session_start_reminds_to_index_when_cache_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        """Devin CLI SessionStart hook reminds the user to index when no cache exists."""
+        project_dir = tmp_path / "devin-project"
+        project_dir.mkdir()
+        monkeypatch.setenv("DEVIN_PROJECT_DIR", str(project_dir))
+        with patch("sys.stdin", _make_stdin({"session_id": "devin-session"})), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            SessionStartActivateProjectHook(HookClient.DEVIN).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        additional_context = result["hookSpecificOutput"]["additionalContext"]
+        assert "does not appear to be indexed" in additional_context
+        assert "serena project index" in additional_context
+
+    def test_devin_session_start_reminds_to_index_when_cache_stale(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        """Devin CLI SessionStart hook warns when the symbol cache is stale."""
+        project_dir = tmp_path / "devin-project"
+        cache_dir = project_dir / ".serena" / "cache" / "python"
+        cache_dir.mkdir(parents=True)
+        stale_file = cache_dir / "document_symbols_cache.pkl"
+        stale_file.write_text("stale", encoding="utf-8")
+        old_mtime = (datetime.now() - timedelta(days=10)).timestamp()
+        stale_file.touch(exist_ok=True)
+        os.utime(stale_file, (old_mtime, old_mtime))
+        monkeypatch.setenv("DEVIN_PROJECT_DIR", str(project_dir))
+        with patch("sys.stdin", _make_stdin({"session_id": "devin-session"})), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            SessionStartActivateProjectHook(HookClient.DEVIN).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        additional_context = result["hookSpecificOutput"]["additionalContext"]
+        assert "stale" in additional_context
+        assert "serena project index" in additional_context
+
+    def test_devin_session_start_confirms_index_when_cache_fresh(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        """Devin CLI SessionStart hook confirms indexing when the cache is fresh."""
+        project_dir = tmp_path / "devin-project"
+        cache_dir = project_dir / ".serena" / "cache" / "python"
+        cache_dir.mkdir(parents=True)
+        fresh_file = cache_dir / "document_symbols_cache.pkl"
+        fresh_file.write_text("fresh", encoding="utf-8")
+        monkeypatch.setenv("DEVIN_PROJECT_DIR", str(project_dir))
+        with patch("sys.stdin", _make_stdin({"session_id": "devin-session"})), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            SessionStartActivateProjectHook(HookClient.DEVIN).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        additional_context = result["hookSpecificOutput"]["additionalContext"]
+        assert "appears to be indexed" in additional_context
+
+    def test_claude_session_start_generic_index_reminder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        """Claude Code SessionStart hook gives a generic index reminder when no project dir is known."""
+        monkeypatch.delenv("DEVIN_PROJECT_DIR", raising=False)
+        with patch("sys.stdin", _make_stdin({"session_id": "claude-session"})), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            SessionStartActivateProjectHook(HookClient.CLAUDE_CODE).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        additional_context = result["hookSpecificOutput"]["additionalContext"]
+        assert "remind the user to run" in additional_context
+        assert "serena project index" in additional_context

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -1,5 +1,4 @@
 import json
-import os
 import pickle
 from datetime import datetime, timedelta
 from io import StringIO
@@ -1166,7 +1165,7 @@ class TestDevinHookSupport:
             assert hook.is_read_code_file_call() == expected_code_read, f"is_read_code_file_call wrong for {command} (devin)"
 
     def test_devin_remind_output_json_for_grep(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI remind hook rewrites a grep call to a harmless no-op instead of blocking."""
+        """Devin CLI remind hook rewrites a grep call to read the nudge file instead of searching."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):
@@ -1177,12 +1176,13 @@ class TestDevinHookSupport:
         assert result["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
         assert "decision" not in result
         updated_input = result["hookSpecificOutput"]["updatedInput"]
-        assert updated_input["pattern"] == "__SERENA_SUPPRESSED__"
-        assert updated_input.get("max_results") == 0
+        assert updated_input["pattern"] == ".*"
+        assert "devin_nudge.txt" in updated_input["path"]
+        assert updated_input.get("max_results") == 100
         assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
 
     def test_devin_remind_output_json_for_read(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI remind hook rewrites a read call to /dev/null instead of blocking."""
+        """Devin CLI remind hook rewrites a read call to the nudge file instead of the target."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="read", tool_input={"file_path": "src/foo.py"}))):
@@ -1190,7 +1190,10 @@ class TestDevinHookSupport:
         output = capsys.readouterr().out
         result = json.loads(output)
         assert "hookSpecificOutput" in result
-        assert result["hookSpecificOutput"]["updatedInput"]["file_path"] == os.devnull
+        file_path = result["hookSpecificOutput"]["updatedInput"]["file_path"]
+        assert "devin_nudge.txt" in file_path
+        nudge_content = Path(file_path).read_text(encoding="utf-8")
+        assert "Serena" in nudge_content
         assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
 
     def test_devin_remind_output_json_for_exec(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -11,7 +11,6 @@ from click.testing import CliRunner
 
 from serena.hooks import (
     HookClient,
-    PostToolUseRemindAboutSymbolicToolsHook,
     PreToolUseAutoApproveSerenaHook,
     PreToolUseHook,
     PreToolUseRemindAboutSymbolicToolsHook,
@@ -1179,46 +1178,39 @@ class TestDevinHookSupport:
         assert result["hookSpecificOutput"]["additionalContext"] == "use Serena"
         assert "updatedInput" not in result["hookSpecificOutput"]
 
-    def test_devin_remind_soft_enforces_grep_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """A grep burst is rewritten to a no-op that reads the nudge file (not a blocking decision)."""
+    def test_devin_remind_emits_context_on_grep_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """A grep burst emits a short reminder via additionalContext (no rewrite, no decision)."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
         result = json.loads(capsys.readouterr().out)
-        # soft-enforce (updatedInput), never a top-level block that would cancel the agent turn
         assert "decision" not in result
         assert result["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
-        updated_input = result["hookSpecificOutput"]["updatedInput"]
-        assert updated_input["pattern"] == ".*"
-        assert "devin_nudge.txt" in updated_input["path"]
-        assert updated_input["output_mode"] == "content"
+        assert "updatedInput" not in result["hookSpecificOutput"]
         assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
 
-    def test_devin_remind_soft_enforces_code_read_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """A code-file ``read`` burst is redirected to the nudge file, which contains the reminder."""
+    def test_devin_remind_emits_context_on_code_read_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """A code-file ``read`` burst emits a short reminder via additionalContext (no rewrite)."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="read", tool_input={"file_path": "src/foo.py"}))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
         result = json.loads(capsys.readouterr().out)
         assert "decision" not in result
-        file_path = result["hookSpecificOutput"]["updatedInput"]["file_path"]
-        assert "devin_nudge.txt" in file_path
-        assert "Serena" in Path(file_path).read_text(encoding="utf-8")
+        assert "updatedInput" not in result["hookSpecificOutput"]
         assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
 
-    def test_devin_remind_soft_enforces_exec_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """An ``exec`` code-read burst is rewritten to a printf of the reminder (not blocked)."""
+    def test_devin_remind_emits_context_on_exec_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """An ``exec`` code-read burst emits a short reminder via additionalContext (no rewrite)."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="exec", tool_input={"command": "cat src/foo.py"}))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
         result = json.loads(capsys.readouterr().out)
         assert "decision" not in result
-        command = result["hookSpecificOutput"]["updatedInput"]["command"]
-        assert command.startswith("printf")
-        assert "Serena" in command
+        assert "updatedInput" not in result["hookSpecificOutput"]
+        assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
 
     def test_devin_remind_silent_below_threshold(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
         """Below the burst threshold the remind hook stays silent (tool runs unchanged)."""
@@ -1307,28 +1299,6 @@ class TestDevinHookSupport:
         additional_context = result["hookSpecificOutput"]["additionalContext"]
         assert "remind the user to run" in additional_context
         assert "serena project index" in additional_context
-
-    def test_devin_post_remind_after_grep(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI PostToolUse hook reminds after a raw grep call."""
-        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
-            with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):
-                PostToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
-        output = capsys.readouterr().out
-        result = json.loads(output)
-        assert result["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
-        assert "symbolic tools" in result["hookSpecificOutput"]["additionalContext"]
-
-    def test_devin_post_remind_respects_cooldown(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI PostToolUse hook only nudges once per cooldown window."""
-        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
-            with patch("sys.stdin", _make_stdin(_base_input(tool_name="read", tool_input={"file_path": "src/foo.py"}))):
-                PostToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
-            assert capsys.readouterr().out != ""
-
-            # second call within the same session should be silent
-            with patch("sys.stdin", _make_stdin(_base_input(tool_name="read", tool_input={"file_path": "src/bar.py"}))):
-                PostToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
-        assert capsys.readouterr().out == ""
 
     def test_devin_post_compaction_includes_full_instructions(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -1165,66 +1165,58 @@ class TestDevinHookSupport:
             assert hook.is_read_call() == expected_read, f"is_read_call wrong for {command} (devin)"
             assert hook.is_read_code_file_call() == expected_code_read, f"is_read_code_file_call wrong for {command} (devin)"
 
-    def test_devin_remind_output_json_for_grep(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI remind hook rewrites a grep call to read the nudge file instead of searching."""
+    def test_devin_output_maps_decision_to_approve_or_block(self):
+        """OutputData renders the top-level ``decision`` (approve/block) + reason Devin CLI expects."""
+        allow = PreToolUseHook.OutputData(permission_decision="allow", permission_decision_reason="ok").to_json_string(HookClient.DEVIN)
+        assert json.loads(allow) == {"decision": "approve", "reason": "ok"}
+
+        # the reason prefers additional_context (the richer, agent-facing nudge) over the terse reason
+        deny = PreToolUseHook.OutputData(
+            permission_decision="deny", permission_decision_reason="terse", additional_context="use Serena"
+        ).to_json_string(HookClient.DEVIN)
+        assert json.loads(deny) == {"decision": "block", "reason": "use Serena"}
+
+    def test_devin_remind_blocks_grep_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """A grep burst is blocked with a reason shown to the agent (Claude Code deny parity)."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
-        output = capsys.readouterr().out
-        result = json.loads(output)
-        assert "hookSpecificOutput" in result
-        assert result["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
-        assert "decision" not in result
-        updated_input = result["hookSpecificOutput"]["updatedInput"]
-        assert updated_input["pattern"] == ".*"
-        assert "devin_nudge.txt" in updated_input["path"]
-        assert updated_input.get("max_results") == 100
-        assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
+        result = json.loads(capsys.readouterr().out)
+        # top-level decision, not a hookSpecificOutput/updatedInput no-op
+        assert result["decision"] == "block"
+        assert "hookSpecificOutput" not in result
+        assert "updatedInput" not in json.dumps(result)
+        assert "Serena" in result["reason"]
+        assert "grep" in result["reason"].lower()
 
-    def test_devin_remind_output_json_for_read(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI remind hook rewrites a read call to the nudge file instead of the target."""
+    def test_devin_remind_blocks_code_read_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """A code-file ``read`` burst is blocked with a reason mentioning Serena."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="read", tool_input={"file_path": "src/foo.py"}))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
-        output = capsys.readouterr().out
-        result = json.loads(output)
-        assert "hookSpecificOutput" in result
-        file_path = result["hookSpecificOutput"]["updatedInput"]["file_path"]
-        assert "devin_nudge.txt" in file_path
-        nudge_content = Path(file_path).read_text(encoding="utf-8")
-        assert "Serena" in nudge_content
-        assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
+        result = json.loads(capsys.readouterr().out)
+        assert result["decision"] == "block"
+        assert "Serena" in result["reason"]
+        assert "read" in result["reason"].lower()
 
-    def test_devin_remind_output_json_for_exec(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI remind hook rewrites an exec read/grep call to a printf reminder."""
+    def test_devin_remind_blocks_exec_code_read_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """An ``exec`` burst reading code files (``cat src/foo.py``) is blocked with a reason."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="exec", tool_input={"command": "cat src/foo.py"}))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
-        output = capsys.readouterr().out
-        result = json.loads(output)
-        assert "hookSpecificOutput" in result
-        command = result["hookSpecificOutput"]["updatedInput"]["command"]
-        assert command.startswith("printf")
-        assert "Serena" in command
+        result = json.loads(capsys.readouterr().out)
+        assert result["decision"] == "block"
+        assert "Serena" in result["reason"]
 
-    def test_devin_auto_approve_emits_approve_for_symbolic_serena_tool(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI auto-approve unconditionally approves Serena symbolic tools."""
-        payload = _base_input(tool_name="mcp__serena__find_symbol")
-        with patch("sys.stdin", _make_stdin(payload)), patch("serena.hooks.serena_home_dir", str(tmp_path)):
-            PreToolUseAutoApproveSerenaHook(HookClient.DEVIN).execute()
-        output = capsys.readouterr().out
-        result = json.loads(output)
-        assert result["decision"] == "approve"
-        assert "Devin CLI" in result["reason"]
-
-    def test_devin_auto_approve_is_silent_for_non_symbolic_serena_tool(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI auto-approve stays silent for non-symbolic Serena tools (e.g. read_file)."""
-        payload = _base_input(tool_name="mcp__serena__read_file")
-        with patch("sys.stdin", _make_stdin(payload)), patch("serena.hooks.serena_home_dir", str(tmp_path)):
-            PreToolUseAutoApproveSerenaHook(HookClient.DEVIN).execute()
+    def test_devin_remind_silent_below_threshold(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Below the burst threshold the remind hook stays silent (does not block)."""
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            for _ in range(2):
+                with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):
+                    PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
         assert capsys.readouterr().out == ""
 
     def test_devin_session_start_includes_project_dir(

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pickle
 from datetime import datetime, timedelta
 from io import StringIO
@@ -1164,17 +1165,46 @@ class TestDevinHookSupport:
             assert hook.is_read_call() == expected_read, f"is_read_call wrong for {command} (devin)"
             assert hook.is_read_code_file_call() == expected_code_read, f"is_read_code_file_call wrong for {command} (devin)"
 
-    def test_devin_remind_output_json(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Devin CLI remind hook emits a top-level decision block with the nudge reason."""
+    def test_devin_remind_output_json_for_grep(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Devin CLI remind hook rewrites a grep call to a harmless no-op instead of blocking."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
         output = capsys.readouterr().out
         result = json.loads(output)
-        assert result["decision"] == "block"
-        assert "reason" in result
-        assert "Serena" in result["reason"]
+        assert "hookSpecificOutput" in result
+        assert result["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert "decision" not in result
+        updated_input = result["hookSpecificOutput"]["updatedInput"]
+        assert updated_input["pattern"] == "__SERENA_SUPPRESSED__"
+        assert updated_input.get("max_results") == 0
+        assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
+
+    def test_devin_remind_output_json_for_read(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Devin CLI remind hook rewrites a read call to /dev/null instead of blocking."""
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            for _ in range(3):
+                with patch("sys.stdin", _make_stdin(_base_input(tool_name="read", tool_input={"file_path": "src/foo.py"}))):
+                    PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        assert "hookSpecificOutput" in result
+        assert result["hookSpecificOutput"]["updatedInput"]["file_path"] == os.devnull
+        assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
+
+    def test_devin_remind_output_json_for_exec(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Devin CLI remind hook rewrites an exec read/grep call to a printf reminder."""
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            for _ in range(3):
+                with patch("sys.stdin", _make_stdin(_base_input(tool_name="exec", tool_input={"command": "cat src/foo.py"}))):
+                    PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        assert "hookSpecificOutput" in result
+        command = result["hookSpecificOutput"]["updatedInput"]["command"]
+        assert command.startswith("printf")
+        assert "Serena" in command
 
     def test_devin_auto_approve_emits_approve_for_symbolic_serena_tool(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
         """Devin CLI auto-approve unconditionally approves Serena symbolic tools."""

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -1130,3 +1130,65 @@ class TestHookCli:
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             result = runner.invoke(hook_commands, ["activate", "--client", "claude-code"], input="not json")
         assert result.exit_code != 0
+
+
+class TestDevinHookSupport:
+    """Tests for Devin CLI hook integration."""
+
+    def test_devin_read_grep_tool_detection(self, tmp_path: Path):
+        """Devin CLI uses lowercase ``read`` and ``grep`` tool names."""
+        for tool_name, expected_grep, expected_read in [
+            ("read", False, True),
+            ("grep", True, False),
+            ("edit", False, False),
+            ("glob", False, False),
+            ("exec", False, False),
+        ]:
+            with patch("sys.stdin", _make_stdin(_base_input(tool_name=tool_name))), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+                hook = PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN)
+            assert hook.is_grep_call() == expected_grep, f"is_grep_call wrong for {tool_name} (devin)"
+            assert hook.is_read_call() == expected_read, f"is_read_call wrong for {tool_name} (devin)"
+
+    def test_devin_exec_shell_read_and_grep(self, tmp_path: Path):
+        """Devin CLI ``exec`` tool embeds the shell command; classify by basename and code-file extension."""
+        for command, expected_grep, expected_read, expected_code_read in [
+            ("rg foo", True, False, False),
+            ("cat src/foo.py", False, True, True),
+            ("cat README.md", False, True, False),
+            ("git status", False, False, False),
+        ]:
+            stdin_data = _base_input(tool_name="exec", tool_input={"command": command})
+            with patch("sys.stdin", _make_stdin(stdin_data)), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+                hook = PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN)
+            assert hook.is_grep_call() == expected_grep, f"is_grep_call wrong for {command} (devin)"
+            assert hook.is_read_call() == expected_read, f"is_read_call wrong for {command} (devin)"
+            assert hook.is_read_code_file_call() == expected_code_read, f"is_read_code_file_call wrong for {command} (devin)"
+
+    def test_devin_remind_output_json(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Devin CLI remind hook emits a top-level decision block with the nudge reason."""
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            for _ in range(3):
+                with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):
+                    PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        assert result["decision"] == "block"
+        assert "reason" in result
+        assert "Serena" in result["reason"]
+
+    def test_devin_auto_approve_emits_approve_for_symbolic_serena_tool(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Devin CLI auto-approve unconditionally approves Serena symbolic tools."""
+        payload = _base_input(tool_name="mcp__serena__find_symbol")
+        with patch("sys.stdin", _make_stdin(payload)), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            PreToolUseAutoApproveSerenaHook(HookClient.DEVIN).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        assert result["decision"] == "approve"
+        assert "Devin CLI" in result["reason"]
+
+    def test_devin_auto_approve_is_silent_for_non_symbolic_serena_tool(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Devin CLI auto-approve stays silent for non-symbolic Serena tools (e.g. read_file)."""
+        payload = _base_input(tool_name="mcp__serena__read_file")
+        with patch("sys.stdin", _make_stdin(payload)), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            PreToolUseAutoApproveSerenaHook(HookClient.DEVIN).execute()
+        assert capsys.readouterr().out == ""

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -1190,7 +1190,7 @@ class TestDevinHookSupport:
         updated_input = result["hookSpecificOutput"]["updatedInput"]
         assert updated_input["pattern"] == ".*"
         assert "devin_nudge.txt" in updated_input["path"]
-        assert updated_input.get("max_results") == 100
+        assert updated_input["output_mode"] == "content"
         assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
 
     def test_devin_remind_soft_enforces_code_read_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -1165,54 +1165,61 @@ class TestDevinHookSupport:
             assert hook.is_read_call() == expected_read, f"is_read_call wrong for {command} (devin)"
             assert hook.is_read_code_file_call() == expected_code_read, f"is_read_code_file_call wrong for {command} (devin)"
 
-    def test_devin_output_maps_decision_to_approve_or_block(self):
-        """OutputData renders the top-level ``decision`` (approve/block) + reason Devin CLI expects."""
-        allow = PreToolUseHook.OutputData(permission_decision="allow", permission_decision_reason="ok").to_json_string(HookClient.DEVIN)
-        assert json.loads(allow) == {"decision": "approve", "reason": "ok"}
-
-        # the reason prefers additional_context (the richer, agent-facing nudge) over the terse reason
-        deny = PreToolUseHook.OutputData(
+    def test_devin_remind_never_emits_a_blocking_decision(self):
+        """A remind never emits a top-level ``decision`` for Devin (that would cancel the turn)."""
+        # even with an unmapped tool (updated_input stays None) the output is context-only, no decision
+        out = PreToolUseHook.OutputData(
             permission_decision="deny", permission_decision_reason="terse", additional_context="use Serena"
         ).to_json_string(HookClient.DEVIN)
-        assert json.loads(deny) == {"decision": "block", "reason": "use Serena"}
+        result = json.loads(out)
+        assert "decision" not in result
+        assert result["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert result["hookSpecificOutput"]["additionalContext"] == "use Serena"
+        assert "updatedInput" not in result["hookSpecificOutput"]
 
-    def test_devin_remind_blocks_grep_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """A grep burst is blocked with a reason shown to the agent (Claude Code deny parity)."""
+    def test_devin_remind_soft_enforces_grep_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """A grep burst is rewritten to a no-op that reads the nudge file (not a blocking decision)."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
         result = json.loads(capsys.readouterr().out)
-        # top-level decision, not a hookSpecificOutput/updatedInput no-op
-        assert result["decision"] == "block"
-        assert "hookSpecificOutput" not in result
-        assert "updatedInput" not in json.dumps(result)
-        assert "Serena" in result["reason"]
-        assert "grep" in result["reason"].lower()
+        # soft-enforce (updatedInput), never a top-level block that would cancel the agent turn
+        assert "decision" not in result
+        assert result["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        updated_input = result["hookSpecificOutput"]["updatedInput"]
+        assert updated_input["pattern"] == ".*"
+        assert "devin_nudge.txt" in updated_input["path"]
+        assert updated_input.get("max_results") == 100
+        assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
 
-    def test_devin_remind_blocks_code_read_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """A code-file ``read`` burst is blocked with a reason mentioning Serena."""
+    def test_devin_remind_soft_enforces_code_read_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """A code-file ``read`` burst is redirected to the nudge file, which contains the reminder."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="read", tool_input={"file_path": "src/foo.py"}))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
         result = json.loads(capsys.readouterr().out)
-        assert result["decision"] == "block"
-        assert "Serena" in result["reason"]
-        assert "read" in result["reason"].lower()
+        assert "decision" not in result
+        file_path = result["hookSpecificOutput"]["updatedInput"]["file_path"]
+        assert "devin_nudge.txt" in file_path
+        assert "Serena" in Path(file_path).read_text(encoding="utf-8")
+        assert "Serena" in result["hookSpecificOutput"]["additionalContext"]
 
-    def test_devin_remind_blocks_exec_code_read_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """An ``exec`` burst reading code files (``cat src/foo.py``) is blocked with a reason."""
+    def test_devin_remind_soft_enforces_exec_burst(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """An ``exec`` code-read burst is rewritten to a printf of the reminder (not blocked)."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(3):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="exec", tool_input={"command": "cat src/foo.py"}))):
                     PreToolUseRemindAboutSymbolicToolsHook(HookClient.DEVIN).execute()
         result = json.loads(capsys.readouterr().out)
-        assert result["decision"] == "block"
-        assert "Serena" in result["reason"]
+        assert "decision" not in result
+        command = result["hookSpecificOutput"]["updatedInput"]["command"]
+        assert command.startswith("printf")
+        assert "Serena" in command
 
     def test_devin_remind_silent_below_threshold(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-        """Below the burst threshold the remind hook stays silent (does not block)."""
+        """Below the burst threshold the remind hook stays silent (tool runs unchanged)."""
         with patch("serena.hooks.serena_home_dir", str(tmp_path)):
             for _ in range(2):
                 with patch("sys.stdin", _make_stdin(_base_input(tool_name="grep"))):

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -14,6 +14,7 @@ from serena.hooks import (
     PreToolUseHook,
     PreToolUseRemindAboutSymbolicToolsHook,
     SessionEndCleanupHook,
+    SessionStartActivateProjectHook,
     hook_commands,
 )
 
@@ -1225,3 +1226,15 @@ class TestDevinHookSupport:
         with patch("sys.stdin", _make_stdin(payload)), patch("serena.hooks.serena_home_dir", str(tmp_path)):
             PreToolUseAutoApproveSerenaHook(HookClient.DEVIN).execute()
         assert capsys.readouterr().out == ""
+
+    def test_devin_session_start_includes_project_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        """Devin CLI SessionStart hook includes DEVIN_PROJECT_DIR in the activation prompt."""
+        monkeypatch.setenv("DEVIN_PROJECT_DIR", "/tmp/devin-project")
+        with patch("sys.stdin", _make_stdin({"session_id": "devin-session"})), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            SessionStartActivateProjectHook(HookClient.DEVIN).execute()
+        output = capsys.readouterr().out
+        result = json.loads(output)
+        assert result["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+        assert "/tmp/devin-project" in result["hookSpecificOutput"]["additionalContext"]


### PR DESCRIPTION
## Summary

Closes #1757.

Adds first-class **Devin CLI** support for Serena. A single command sets up the full integration:

    serena setup devin

For a per-project setup instead of a global one:

    serena setup devin --project

## What `serena setup devin` configures automatically

1. **MCP server** `serena` with the `devin` context:
   - Excludes Devin CLI's built-in tools (`read`, `edit`, `grep`, `glob`, `exec`) so only Serena's symbolic/code-intelligence tools are exposed.
   - Disables the web dashboard (`--enable-web-dashboard false --open-web-dashboard false`).
   - Enables cross-project querying (`--add-mode query-projects`).
   - Project resolution via `--project-from-cwd` (or `--project <cwd>` for per-project installs), walking up from `DEVIN_PROJECT_DIR` to the real repo root.
2. **Auto-approval** via Devin CLI's native `permissions.allow: ["mcp__serena__*"]`.
3. **Lifecycle hooks**:
   - `SessionStart` → `serena-hooks activate --client=devin --include-instructions` (re-inject full Serena system prompt + activate project).
   - `PreToolUse` → `serena-hooks remind --client=devin` (short reminder via `additionalContext` after a burst of raw `read`/`grep`/`exec` calls; no rewrite, no `decision`, no `block`).
   - `PostCompaction` → `serena-hooks activate --client=devin --include-instructions --event PostCompaction` (re-inject full instructions after context compaction).
   - `SessionEnd` → `serena-hooks cleanup --client=devin`.

## Anti-crutch design

- **No `updatedInput` rewrite for Devin.** The previous iteration rewrote raw `read`/`grep`/`exec` calls into harmless no-ops. That was fragile because Devin CLI treats `deny` and `block` as turn-cancelling and the semantics may change. The `remind` hook now only adds `additionalContext`.
- **No `post-remind` PostToolUse hook.** It duplicated the PreToolUse reminder; removed to keep the surface minimal.
- **Full instructions at SessionStart and PostCompaction.** The `activate` hook uses `serena print-system-prompt --only-instructions --context=devin` with a 1-hour on-disk cache, so the model keeps Serena's capabilities in context without depending on tool-rewrite tricks.
- **Auto-approval remains native** (`permissions.allow`), not a hook.

## Test plan

- [x] `uv run pytest test/serena/test_hooks.py test/serena/config/test_grok_docs.py test/serena/config/test_client_setup.py test/serena/test_cli_setup.py test/serena/test_cli_project_commands.py` → **161 passed**
- [x] `uv run poe lint` → passed
- [x] `uv run poe type-check` → passed
- [x] Real `serena setup devin` verified against `devin 3000.2.17` (`devin --version`, `devin mcp add --help`, `-s user`/`-s project` scope).

## Note

A full interactive `devin -p` end-to-end run could not be exercised in the CI/sandbox environment, so the end-to-end verification drives Serena's half with the binary-confirmed payload schema and the real MCP server. Happy to adjust the hook wording or cache TTL if the maintainers prefer.
