### PR TITLE
fix(solidlsp): gracefully degrade when a language server lacks textDocument/documentSymbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Status of the `main` branch. Changes prior to the next official version change w
     project creation) 
   - Add `python_basedpyright` as an alternative Python language server
   - Nix/nixd: support custom `ls_path` launchers and external JSON settings through `config_path` #1737
+  - Fix: `get_diagnostics_for_file` crashed with `SolidLSPException` for any Ansible file with at least
+    one lint finding, because `ansible-language-server` doesn't implement `textDocument/documentSymbol`
+    and the request used to map diagnostics onto owning symbols just threw. `AnsibleLanguageServer` now
+    overrides that request to return `None` directly, so diagnostics fall back to being grouped under
+    the file-level path as already documented #1758
 
 * JetBrains:
   - `jet_brains_find_symbol`: Disallow wildcard-only search, delegating to overview tool if request is for file

--- a/src/solidlsp/language_servers/ansible_language_server.py
+++ b/src/solidlsp/language_servers/ansible_language_server.py
@@ -12,8 +12,9 @@ from typing import Any, ClassVar
 from overrides import override
 
 from solidlsp.language_servers.common import RuntimeDependency, RuntimeDependencyCollection, build_npm_install_command
-from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
+from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, LSPFileBuffer, SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.lsp_protocol_handler.lsp_types import DocumentSymbol, SymbolInformation
 from solidlsp.settings import SolidLSPSettings
 
 log = logging.getLogger(__name__)
@@ -124,6 +125,15 @@ class AnsibleLanguageServer(SolidLanguageServer):
                 return True
 
         return False
+
+    @override
+    def _request_document_symbols(
+        self, relative_file_path: str, file_data: LSPFileBuffer | None
+    ) -> list[SymbolInformation] | list[DocumentSymbol] | None:
+        # ansible-language-server does not implement textDocument/documentSymbol and the
+        # maintainers have declined to add it (see ansible/vscode-ansible#601, closed NOT_PLANNED).
+        # Skip the request entirely rather than sending a request we know will fail.
+        return None
 
     @staticmethod
     def _determine_log_level(line: str) -> int:

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -1845,7 +1845,14 @@ class SolidLanguageServer(ABC):
 
             # no cached result, query language server
             log.debug(f"Requesting document symbols for {relative_file_path} from the Language Server")
-            response = self.server.send.document_symbol({"textDocument": {"uri": self._resolve_file_uri(relative_file_path)}})
+            try:
+                response = self.server.send.document_symbol({"textDocument": {"uri": self._resolve_file_uri(relative_file_path)}})
+            except SolidLSPException as ex:
+                # some servers (e.g. ansible-language-server, see
+                # https://github.com/ansible/vscode-ansible/issues/601) don't implement
+                # textDocument/documentSymbol at all; degrade to "no symbols" instead of crashing
+                log.debug("Failed to retrieve document symbols for %s: %s", relative_file_path, ex)
+                return None
 
             # Only cache non-empty results. An empty or None response can occur when the language server
             # has not yet finished indexing or building the project (e.g. Lean 4 before `lake build`),

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -1845,14 +1845,7 @@ class SolidLanguageServer(ABC):
 
             # no cached result, query language server
             log.debug(f"Requesting document symbols for {relative_file_path} from the Language Server")
-            try:
-                response = self.server.send.document_symbol({"textDocument": {"uri": self._resolve_file_uri(relative_file_path)}})
-            except SolidLSPException as ex:
-                # some servers (e.g. ansible-language-server, see
-                # https://github.com/ansible/vscode-ansible/issues/601) don't implement
-                # textDocument/documentSymbol at all; degrade to "no symbols" instead of crashing
-                log.debug("Failed to retrieve document symbols for %s: %s", relative_file_path, ex)
-                return None
+            response = self.server.send.document_symbol({"textDocument": {"uri": self._resolve_file_uri(relative_file_path)}})
 
             # Only cache non-empty results. An empty or None response can occur when the language server
             # has not yet finished indexing or building the project (e.g. Lean 4 before `lake build`),

--- a/test/solidlsp/ansible/test_ansible_basic.py
+++ b/test/solidlsp/ansible/test_ansible_basic.py
@@ -11,9 +11,19 @@ from pathlib import Path
 import pytest
 
 from solidlsp import SolidLanguageServer
+from solidlsp.language_servers.ansible_language_server import AnsibleLanguageServer
 from solidlsp.ls_config import LanguageServerId
 from test.conftest import language_server_tests_enabled
 from test.solidlsp.conftest import format_symbol_for_assert, has_malformed_name, request_all_symbols
+
+
+def test_request_document_symbols_returns_none_without_contacting_server() -> None:
+    """ansible-language-server has no textDocument/documentSymbol support (see
+    ansible/vscode-ansible#601, closed NOT_PLANNED), so the override must short-circuit
+    to None instead of sending a request that is guaranteed to fail. Runs with no
+    language server process, node, or npm required.
+    """
+    assert AnsibleLanguageServer._request_document_symbols(None, "playbook.yml", None) is None
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Problem

`get_diagnostics_for_file` crashes outright (`ToolCallError` / `SolidLSPException: Unhandled method textDocument/documentSymbol (-32601)`) for any Ansible YAML file that has at least one real `ansible-lint` diagnostic to report.

The tool groups each diagnostic under the symbol that owns it via `find_diagnostic_owner_symbol`, which requests `textDocument/documentSymbol` from the language server. Its docstring already promises graceful degradation for this: "If a diagnostic cannot be mapped to a symbol, it is grouped under the special name path `<file>`." But that fallback was never implemented for the case where the server doesn't support `documentSymbol` at all — the request just throws, and the exception propagates all the way up through `symbol.py`'s `find_diagnostic_owner_symbol` and `symbol_tools.py`'s diagnostics grouping, failing the whole tool call.

This isn't a one-off or a config issue: `ansible-language-server` (the standard, actively-maintained Ansible LSP, now folded into `vscode-ansible`) does not implement `textDocument/documentSymbol` and the maintainers have explicitly declined to add it — see [ansible/vscode-ansible#601](https://github.com/ansible/vscode-ansible/issues/601), closed `NOT_PLANNED` in Jan 2024. So this reliably breaks `get_diagnostics_for_file` for every Ansible role/task/playbook file that has lint findings.

Example from a real session, before the fix:

```
ERROR ... SolidLSPException: Error processing request textDocument/documentSymbol with params:
{'textDocument': {'uri': 'file:///.../roles/columnstore_setup/tasks/multi_node.yml'}}
(caused by Unhandled method textDocument/documentSymbol (-32601))
...
serena.tools.tools_base.ToolCallError: SolidLSPException: Error processing request textDocument/documentSymbol...
```

## Fix

**Updated approach (per review):** the fix is scoped to `AnsibleLanguageServer` rather than the shared base class. `src/solidlsp/language_servers/ansible_language_server.py` now overrides `_request_document_symbols` to unconditionally `return None`, since `ansible-language-server` never implements `textDocument/documentSymbol` — there's no point sending a request known to always fail. This matches the existing per-server override pattern already used by `eclipse_jdtls.py` and `angular_language_server.py` for other server-specific quirks.

`src/solidlsp/ls.py` is unchanged from `main`: the original version of this PR added a general `try/except SolidLSPException` around the `document_symbol` call in the shared `get_raw_document_symbols`, but review (see discussion below) pointed out this widened the blast radius to every language server and risked masking `LanguageServerTerminatedException` — the exception `tools_base.py` relies on to trigger language-server restart-and-retry — for three tools beyond just diagnostics (`GetSymbolsOverviewTool`, `FindReferencingSymbolsTool`). Scoping the fix to Ansible avoids all of that: no exception is ever thrown or caught, because the request is never sent.

I traced the full call chain before picking this spot:

- `request_document_symbols` (the caller of `_request_document_symbols`) already tolerates a `None` return — it logs a warning and returns an empty `DocumentSymbols([])`.
- `_get_document_symbols_with_locations` and `_request_symbol_at_location` iterate over that (now-empty) result without special-casing.
- `find_diagnostic_owner_symbol` (`serena/symbol.py`) already handles `None` from `request_symbol_at_location`.

So every layer above `_request_document_symbols` was already `None`/empty-safe; the only gap was that Ansible had no override telling it to skip the doomed request in the first place.

## Verification

Confirmed against a real ce-tools repo with Ansible + Terraform files, before/after:

**Before:** `get_diagnostics_for_file` on `roles/columnstore_setup/tasks/multi_node.yml` threw `ToolCallError`, failing the task after ~2s.

**After:** same file, same request — the log now shows `WARNING ... Received None response from the Language Server for document symbols in .../multi_node.yml ... Returning empty list`, and the tool call completes normally with the diagnostics grouped under `<file>`:

```json
{"multi_node.yml": {"Error": {"<file>": [{"message": "Trailing spaces", "code": "yaml[trailing-spaces]", "source": "ansible-lint"}, ...]}}}
```

Added `test/solidlsp/ansible/test_ansible_basic.py::test_request_document_symbols_returns_none_without_contacting_server`, a fast unit test asserting the override short-circuits without needing a running language server, node, or npm — closing the gap that the original fix only had manual verification for the crash itself.

Also ran the existing test suite (`uv run pytest`) against:
- `test/serena/test_serena_agent.py -k test_get_diagnostics_for_file`
- `test/solidlsp/ansible/`
- `test/solidlsp/python/test_symbol_retrieval.py`
- `test/solidlsp/toml/test_toml_symbol_retrieval.py`

94 passed, 1 pre-existing xfail (`test_bare_symbol_names`, ansible), 1 skipped, 1 failed due to a missing Go binary in the test environment (unrelated to this change, not a regression).
