### PR TITLE
fix(hooks): accept raw control characters in payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Add `serena-hooks --client=grok`, including Grok-native PreToolUse allow/deny output.
   - PreToolUse remind hook: coerce non-string shell command values instead of failing, and recognize
     `target_file`/`targetFile` file-path keys (shared payload parsing, applies to all hook clients).
+  - Fix hook input parsing for clients that emit raw control characters in JSON string values #1743.
 
 
 # v1.6.1 (2026-07-21)

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -31,7 +31,7 @@ class HookClient(Enum):
 class Hook(ABC):
     def __init__(self, client: HookClient):
         raw = sys.stdin.read()
-        input_data = json.loads(raw)
+        input_data = json.loads(raw, strict=False)
         self._input_data = input_data
         self._client = client
 

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -992,6 +992,20 @@ class TestHookCli:
         output = json.loads(result.output)
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
+    def test_remind_command_accepts_raw_control_characters_in_tool_input(self, tmp_path: Path):
+        """CodeBuddy freeform tool input may contain unescaped control characters."""
+        stdin_json = (
+            '{"hook_event_name":"PreToolUse","session_id":"cli-codebuddy-raw-input",'
+            '"tool_name":"Edit","tool_input":"*** Begin Patch\n*** Add File: /tmp/x.txt\n+hi\n",'
+            '"permission_mode":"default"}'
+        )
+        runner = CliRunner()
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            result = runner.invoke(hook_commands, ["remind", "--client", "codebuddy"], input=stdin_json)
+
+        assert result.exit_code == 0
+        assert result.output == ""
+
     def test_remind_command_grok_emits_native_deny(self, tmp_path: Path):
         """The documented Grok remind CLI emits Grok-native deny JSON."""
         runner = CliRunner()


### PR DESCRIPTION
## Summary

- accept raw control characters in hook JSON string values while keeping malformed JSON rejected
- cover the reported CodeBuddy freeform `Edit` payload at the `serena-hooks` CLI boundary
- document the fix in the Hooks changelog

## Root cause

`Hook` used Python's default strict JSON decoder, so unescaped newlines inside CodeBuddy's string-valued `tool_input` failed before the existing non-dict input normalization could run.

## User impact

`serena-hooks remind` and `serena-hooks auto-approve` no longer crash on these payloads. Freeform string inputs remain ignored by hook heuristics, matching the existing behavior.

## Testing

- `uv run pytest test/serena/test_hooks.py -q --basetemp <isolated-temp-dir>` — 83 passed
- `uv run poe lint`
- `uv run poe type-check`

Closes #1743.
