### PR TITLE
Docs: add the language servers missing from the supported-language lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Status of the `main` branch. Changes prior to the next official version change will appear here.
 
 * General:
+  - Fix: the README, the Language Support docs page and the project template omitted several already-supported language servers
   - Fix: a tool call exceeding the timeout blocked the task executor indefinitely; the executor now
     recovers without user-induced cancellation
   - Add Grok Build support (context `grok`, setup CLI, hooks)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Serena incorporates a powerful abstraction layer for the integration of language
 The underlying language servers are typically open-source projects or at least freely available for use.
 
 When using Serena's language server backend, we provide **support for over 40 programming languages**, including
-Ada / SPARK, AL, Angular, Ansible, Bash, BSL, C#, C/C++, Clojure, Crystal, CUE, Dart, Elixir, Elm, Erlang, Fortran, F#, GDScript, GLSL, Go, Groovy, Haskell, Haxe, HLSL, HTML, Java, JavaScript, JSON, Julia, Kotlin, LaTeX, Lean 4, Lua, Luau, Markdown, MATLAB, mSL, Nix, OCaml, Perl, PHP, PowerShell, Python, R, Ruby, Rust, Scala, SCSS / Sass / CSS, Solidity, Svelte, Swift, TOML, TypeScript, WGSL, YAML, and Zig.
+Ada / SPARK, AL, Angular, Ansible, Bash, BSL, C#, C/C++, Clojure, Crystal, CUE, Dart, Elixir, Elm, Erlang, Fortran, F#, GDScript, GLSL, Go, Groovy, Haskell, Haxe, HLSL, HTML, Java, JavaScript, JSON, Julia, Kotlin, LaTeX, Lean 4, Lua, Luau, Markdown, MATLAB, mSL, Nix, OCaml, Pascal, Perl, PHP, PowerShell, Python, QML, R, Rego, Ruby, Rust, Scala, SCSS / Sass / CSS, Solidity, Svelte, Swift, SystemVerilog, Terraform, TOML, TypeScript, Vue, WGSL, YAML, and Zig.
 
 ### The Serena JetBrains Plugin
 

--- a/docs/01-about/020_programming-languages.md
+++ b/docs/01-about/020_programming-languages.md
@@ -109,6 +109,8 @@ Some languages require additional installations or setup steps, as noted.
 * **Luau**
 * **Markdown**  
   (must explicitly enable language `markdown`, primarily useful for documentation-heavy projects)
+* **MATLAB**  
+  (requires Node.js and a licensed local MATLAB installation, R2021b or later; Serena automatically downloads version 1.3.9 of the VS Code MATLAB extension, which bundles the language server)
 * **mSL** (mIRC Scripting Language)  
   (auto-installed; no external dependencies required — uses a custom pygls-based LSP server shipped with Serena;
   supports document symbols, workspace symbols, references, and go-to-definition for aliases, events, menus, dialogs, and CTCP handlers in `.mrc` files)
@@ -124,6 +126,8 @@ Some languages require additional installations or setup steps, as noted.
   (by default, uses the Intelephense language server (language `php`), set `INTELEPHENSE_LICENSE_KEY` environment variable for premium features;
   we also support [Phpactor](https://github.com/phpactor/phpactor) (language `php_phpactor`), which requires PHP 8.1+;
   and the experimental [PHPantom](https://github.com/PHPantom-dev/phpantom_lsp) backend (language `php_phpantom`)
+* **PowerShell**  
+  (requires PowerShell 7+ (`pwsh`) on PATH or in a standard install location; Serena automatically downloads PowerShell Editor Services 4.4.0 and installs PSScriptAnalyzer 1.25.0 via `Save-Module` from your configured PowerShell repository)
 * **Python**
   (by default, uses [Pyright](https://github.com/microsoft/pyright) (language `python`);
   alternatives: [BasedPyright](https://github.com/DetachHead/basedpyright) (language `python_basedpyright`),
@@ -135,6 +139,8 @@ Some languages require additional installations or setup steps, as noted.
   (requires Qt 6, provides `qmlls` or `qmlls6` on PATH; see the [Qt qmlls documentation](https://doc.qt.io/qt-6/qtqml-tool-qmlls.html))
 * **R**  
   (requires installation of the `languageserver` R package)
+* **Rego**  
+  (requires the [Regal](https://github.com/open-policy-agent/regal) language server on PATH)
 * **Ruby**  
   (by default, uses [ruby-lsp](https://github.com/Shopify/ruby-lsp) (language `ruby`); use language `ruby_solargraph` to use Solargraph instead.)
 * **Rust**  
@@ -150,6 +156,12 @@ Some languages require additional installations or setup steps, as noted.
 * **Svelte**
   (requires Node.js v18+ and npm; supports `.svelte` Single File Components plus TypeScript/JavaScript files via `svelte-language-server`; a companion `typescript-language-server` + `typescript-svelte-plugin` is spawned automatically for cross-file rename, go-to-definition, and references across `.ts`/`.js` and `.svelte` files; use language `svelte` for Svelte projects instead of also enabling `typescript`)
 * **Swift**
+* **SystemVerilog**  
+  (uses `verible-verilog-ls`, taken from PATH if present, otherwise version `v0.0-4051-g9fdb4057` is downloaded automatically)
+* **Terraform**  
+  (uses `terraform-ls` 0.36.5, which Serena downloads automatically; requires Terraform on PATH)
+* **TOML**  
+  (experimental; uses Taplo 0.10.0, taken from PATH if present, otherwise downloaded automatically)
 * **TypeScript**
 * **Vue**    
   (3.x with TypeScript; requires Node.js v18+ and npm; supports .vue Single File Components with monorepo detection)

--- a/src/serena/resources/project.template.yml
+++ b/src/serena/resources/project.template.yml
@@ -2,22 +2,22 @@
 project_name: "project_name"
 
 # list of language servers to start when using the LSP backend; choose from:
-#   ada                 al                  angular             ansible             bash
-#   bsl                 clojure             cpp                 cpp_ccls            crystal
-#   csharp              csharp_omnisharp    cue                 dart                elixir
-#   elm                 erlang              fortran             fsharp              gdscript
-#   go                  groovy              haskell             haxe                hlsl
-#   html                java                json                julia               kotlin
-#   latex               lean4               lua                 luau                markdown
-#   matlab              msl                 nix                 ocaml               pascal
-#   perl                php                 php_phpactor        php_phpantom        powershell
-#   python              python_jedi         python_pyrefly      python_ty           r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   scss                solidity            svelte              swift               systemverilog
-#   terraform           toml                typescript          typescript_vts      vue
-#   yaml                zig
+#   ada                    al                     angular                ansible                bash
+#   bsl                    clojure                cpp                    cpp_ccls               crystal
+#   csharp                 csharp_omnisharp       cue                    dart                   elixir
+#   elm                    erlang                 fortran                fsharp                 gdscript
+#   go                     groovy                 haskell                haxe                   hlsl
+#   html                   java                   json                   julia                  kotlin
+#   latex                  lean4                  lua                    luau                   markdown
+#   matlab                 msl                    nix                    ocaml                  pascal
+#   perl                   php                    php_phpactor           php_phpantom           powershell
+#   python                 python_basedpyright    python_jedi            python_pyrefly         python_ty
+#   qml                    r                      rego                   ruby                   ruby_solargraph
+#   rust                   scala                  scss                   solidity               svelte
+#   swift                  systemverilog          terraform              toml                   typescript
+#   typescript_vts         vue                    yaml                   zig
 #   (This list may be outdated; generated with scripts/print_language_list.py;
-#   For the current list, see values of Language enum here:
+#   For the current list, see values of the LanguageServerId enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
 # For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:


### PR DESCRIPTION
Several backends that are registered and tested were absent from the user-facing lists: six from the README (pascal, qml, rego, systemverilog, terraform, vue), six from the Language Support docs page (matlab, powershell, rego, systemverilog, terraform, toml), and two from the commented language-server list in the project template (python_basedpyright, qml).

The drift is long-standing and runs in both directions: matlab, powershell and toml reached the README but never the docs page; pascal, vue and qml reached the docs page but never the README; terraform, rego and systemverilog reached neither, the oldest of them since 2025-07-06. The two template omissions are the most recent, from #1705 and #1635. The guide's Documentation step does ask for the README and the docs page, so most of this was missed rather than unspecified; it does not mention the project template at all.

The setup notes on the new docs-page entries name the versions Serena actually pins, taken from the corresponding language-server modules: MATLAB extension 1.3.9, PowerShell Editor Services 4.4.0 and PSScriptAnalyzer 1.25.0, Verible v0.0-4051-g9fdb4057, terraform-ls 0.36.5, and Taplo 0.10.0. The PowerShell entry mentions both automatic installations, since enabling that backend also runs Save-Module against the user's configured PowerShell repository.

The new Regal link points at open-policy-agent/regal, the current canonical repository; StyraInc/regal still redirects there, and the adapter and the CI workflow have not been changed.

The template block is refreshed from scripts/print_language_list.py, which is why its column widths change: python_basedpyright is longer than any identifier the previous list contained. The pointer directly below it still named the Language enum, renamed to LanguageServerId in d2cf18dd.

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.
