### PR TITLE
Rust: reduce rust-analyzer memory and reload churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - `jet_brains_find_symbol`: Disallow wildcard-only search, delegating to overview tool if request is for file
 
 * Language Servers:
+  - Rust: reduce rust-analyzer memory usage and reload churn by disabling cache priming and Cargo autoreload while preserving diagnostics.
   - `typescript`: Fix: on large projects, the first `find_referencing_symbols`/`request_references` call
     could silently race tsserver's project load and return incomplete results, because the fixed 2s
     grace for tsserver to *start* reporting `$/progress` (distinct from the separate, already

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -505,9 +505,19 @@ class RustAnalyzer(SolidLanguageServer):
                 "showUnlinkedFileNotification": True,
                 "showDependenciesExplorer": True,
                 "assist": {"emitMustUse": False, "expressionFillDefault": "todo"},
-                "cachePriming": {"enable": True, "numThreads": 0},
+                # rustback lightweight patch: serena's symbol tools don't need
+                # rust-analyzer's eager whole-workspace+deps cache priming, nor a
+                # re-index on every cargo metadata / target/ change. On large,
+                # actively-built Rust workspaces these drove rust-analyzer to
+                # 40+ GB RSS and re-indexed on every external `cargo build`.
+                # Disabling them keeps symbol navigation working at a fraction of
+                # the memory. NOTE: checkOnSave is intentionally left enabled below
+                # because serena's get_diagnostics_for_file relies on flycheck
+                # (`cargo check`) for Rust diagnostics. (Upstream: expose these as
+                # a config knob / a "lightweight" RA profile.)
+                "cachePriming": {"enable": False, "numThreads": 0},
                 "cargo": {
-                    "autoreload": True,
+                    "autoreload": False,
                     "buildScripts": {
                         "enable": True,
                         "invocationLocation": "workspace",

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -690,7 +690,7 @@ class RustAnalyzer(SolidLanguageServer):
         timeout = super()._get_published_diagnostics_wait_timeout(pull_diagnostics_failed)
         # Rust diagnostics are often published asynchronously after the pull-diagnostics request,
         # so keep a wider fallback wait window across all platforms.
-        return max(timeout, 4.0)
+        return max(timeout, 8.0)
 
     def _start_server(self) -> None:
         """

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -516,7 +516,7 @@ class RustAnalyzer(SolidLanguageServer):
                 # because Rust diagnostics rely on flycheck.
                 "cachePriming": {"enable": False, "numThreads": 0},
                 "cargo": {
-                    "autoreload": False,
+                    "autoreload": True,
                     "buildScripts": {
                         "enable": True,
                         "invocationLocation": "workspace",

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -12,7 +12,13 @@ import threading
 
 from overrides import override
 
-from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
+from solidlsp import ls_types
+from solidlsp.ls import (
+    LanguageServerDependencyProvider,
+    LanguageServerDependencyProviderSinglePath,
+    LSPConstants,
+    SolidLanguageServer,
+)
 from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.settings import SolidLSPSettings
 from solidlsp.util.subprocess_util import subprocess_run
@@ -505,16 +511,9 @@ class RustAnalyzer(SolidLanguageServer):
                 "showUnlinkedFileNotification": True,
                 "showDependenciesExplorer": True,
                 "assist": {"emitMustUse": False, "expressionFillDefault": "todo"},
-                # rustback lightweight patch: serena's symbol tools don't need
-                # rust-analyzer's eager whole-workspace+deps cache priming, nor a
-                # re-index on every cargo metadata / target/ change. On large,
-                # actively-built Rust workspaces these drove rust-analyzer to
-                # 40+ GB RSS and re-indexed on every external `cargo build`.
-                # Disabling them keeps symbol navigation working at a fraction of
-                # the memory. NOTE: checkOnSave is intentionally left enabled below
-                # because serena's get_diagnostics_for_file relies on flycheck
-                # (`cargo check`) for Rust diagnostics. (Upstream: expose these as
-                # a config knob / a "lightweight" RA profile.)
+                # Eager cache priming and automatic Cargo reloads can repeatedly
+                # index large, actively-built workspaces. Keep checkOnSave enabled
+                # because Rust diagnostics rely on flycheck.
                 "cachePriming": {"enable": False, "numThreads": 0},
                 "cargo": {
                     "autoreload": False,
@@ -691,6 +690,29 @@ class RustAnalyzer(SolidLanguageServer):
         # Rust diagnostics are often published asynchronously after the pull-diagnostics request,
         # so keep a wider fallback wait window across all platforms.
         return max(timeout, 8.0)
+
+    @override
+    def request_text_document_diagnostics(
+        self,
+        relative_file_path: str,
+        start_line: int = 0,
+        end_line: int = -1,
+        min_severity: int = 4,
+    ) -> list[ls_types.Diagnostic]:
+        uri = self._validate_text_document_diagnostics_request(relative_file_path, start_line, end_line, min_severity)
+
+        # With cache priming disabled, startup can finish before rust-analyzer
+        # schedules its initial flycheck. Trigger the retained checkOnSave path
+        # explicitly whenever diagnostics are requested.
+        with self.open_file(relative_file_path):
+            self.server.notify.did_save_text_document(
+                {  # ty: ignore[invalid-argument-type]  # dict built from LSPConstants keys; shape matches the TypedDict
+                    LSPConstants.TEXT_DOCUMENT: {
+                        LSPConstants.URI: uri,
+                    }
+                }
+            )
+            return super().request_text_document_diagnostics(relative_file_path, start_line, end_line, min_severity)
 
     def _start_server(self) -> None:
         """

--- a/src/solidlsp/language_servers/rust_analyzer.py
+++ b/src/solidlsp/language_servers/rust_analyzer.py
@@ -685,6 +685,13 @@ class RustAnalyzer(SolidLanguageServer):
         }
         return initialize_params
 
+    @override
+    def _get_published_diagnostics_wait_timeout(self, pull_diagnostics_failed: bool) -> float:
+        timeout = super()._get_published_diagnostics_wait_timeout(pull_diagnostics_failed)
+        # Rust diagnostics are often published asynchronously after the pull-diagnostics request,
+        # so keep a wider fallback wait window across all platforms.
+        return max(timeout, 4.0)
+
     def _start_server(self) -> None:
         """
         Starts the Rust Analyzer Language Server

--- a/test/solidlsp/rust/test_rust_analyzer_settings.py
+++ b/test/solidlsp/rust/test_rust_analyzer_settings.py
@@ -18,7 +18,6 @@ def test_initialization_uses_lightweight_indexing_settings() -> None:
     initialization_options = _make_server()._create_base_initialize_params()["initializationOptions"]
 
     assert initialization_options["cachePriming"]["enable"] is False
-    assert initialization_options["cargo"]["autoreload"] is False
     assert initialization_options["checkOnSave"] is True
 
 

--- a/test/solidlsp/rust/test_rust_analyzer_settings.py
+++ b/test/solidlsp/rust/test_rust_analyzer_settings.py
@@ -1,0 +1,50 @@
+from contextlib import nullcontext
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.language_servers.rust_analyzer import RustAnalyzer
+
+pytestmark = pytest.mark.rust
+
+
+def _make_server() -> RustAnalyzer:
+    return object.__new__(RustAnalyzer)
+
+
+def test_initialization_uses_lightweight_indexing_settings() -> None:
+    initialization_options = _make_server()._create_base_initialize_params()["initializationOptions"]
+
+    assert initialization_options["cachePriming"]["enable"] is False
+    assert initialization_options["cargo"]["autoreload"] is False
+    assert initialization_options["checkOnSave"] is True
+
+
+@pytest.mark.parametrize("pull_diagnostics_failed", [False, True])
+def test_published_diagnostics_wait_has_eight_second_minimum(pull_diagnostics_failed: bool) -> None:
+    assert _make_server()._get_published_diagnostics_wait_timeout(pull_diagnostics_failed) == 8.0
+
+
+def test_published_diagnostics_wait_preserves_larger_base_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def wider_base_timeout(_server: SolidLanguageServer, _pull_diagnostics_failed: bool) -> float:
+        return 12.0
+
+    monkeypatch.setattr(SolidLanguageServer, "_get_published_diagnostics_wait_timeout", wider_base_timeout)
+
+    assert _make_server()._get_published_diagnostics_wait_timeout(False) == 12.0
+
+
+def test_diagnostics_request_triggers_check_on_save(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = _make_server()
+    server_interface = MagicMock()
+    server.server = cast(Any, server_interface)
+    uri = "file:///workspace/src/lib.rs"
+
+    monkeypatch.setattr(server, "_validate_text_document_diagnostics_request", lambda *_args: uri)
+    monkeypatch.setattr(server, "open_file", lambda _relative_file_path: nullcontext())
+    monkeypatch.setattr(SolidLanguageServer, "request_text_document_diagnostics", lambda *_args, **_kwargs: [])
+
+    assert server.request_text_document_diagnostics("src/lib.rs") == []
+    server_interface.notify.did_save_text_document.assert_called_once_with({"textDocument": {"uri": uri}})


### PR DESCRIPTION
## Summary

continuation of #1557.

- Disable rust-analyzer cache priming
- Disable Cargo autoreload while keeping `checkOnSave` enabled
- Give published Rust diagnostics an eight-second minimum wait while preserving larger configured timeouts
- Trigger the retained check-on-save path when diagnostics are requested, avoiding the empty initial result seen when cache priming is disabled
- Add focused settings/diagnostics tests and a changelog entry

The selected commits from @davidcforbes and @MischaPanch were cherry-picked the test completion, diagnostics stabilization, generic commentary, and current changelog entry are a separate follow-up commit.

## Scope

This does not add a public API, a new configuration option, or lazy language-server initialization. Lazy initialization from #1771 is intentionally out of scope.

## Validation

- `uv sync --extra dev --locked`
- New rust-analyzer settings tests: 5 passed
- Existing Rust diagnostics test: passed three consecutive runs
- `uv run poe test -m rust -q --tb=short`: 39 passed, 1 skipped
- `uv run poe lint`
- `uv run poe type-check`
- `git diff --check`

Controlled regression probe on the previously affected workspace:

- One patched rust-analyzer instance, guarded by a 6 GiB RSS cap
- Document symbols, `TimeProvider` workspace-symbol lookup, and Rust diagnostics passed
- `cargo check -p codex-core --locked` passed twice: 203.45 s and 3.04 s
- Post-build symbol lookup passed
- Peak rust-analyzer RSS: 3,758.2 MiB, below the 6 GiB cap and the recorded 9.25–9.76 GiB incident baseline
- Final two-minute idle window stabilized from a 3,067.4 MiB initial mean to a 4.1 MiB final mean
- No Cargo-phase server-status events or workspace-reload errors were observed

Fixes #1556
