### PR TITLE
ci: use Node 24 for Node-backed test batches

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,7 +81,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.11"]
         # 5 batches, each installs ONLY the toolchains its languages need (steps gated by matrix.batch).
-        # Node/Python/uv stay in every batch (cheap, needed for the venv + auto-installed LSes).
+        # Python/uv stay in every batch; Node is limited to other-langs and catch-all.
         # catch-all = web + python + the core framework.
         batch: [jvm, native, other-langs, niche, catch-all]
         # --- OS gating: which batch runs on which OS -----------------------------------------
@@ -106,9 +106,10 @@ jobs:
         with:
           go-version: ">=1.17.0"
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        if: matrix.batch == 'other-langs' || matrix.batch == 'catch-all'
+        uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
       - name: Ensure cached directory exist before calling cache-related actions
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- update `actions/setup-node` from `v4` to `v7`
- update the installed CI toolchain from Node `20.x` to `24.x`
- run Node setup only for `other-langs` and `catch-all`
- correct the matrix documentation

## Why

[GitHub began defaulting JavaScript actions to Node 24](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on June 16, 2026 and recommends updating workflows to action releases that use Node 24. [`setup-node@v7`](https://github.com/actions/setup-node/releases/tag/v7.0.0) is the current release and uses the Node 24 action runtime.

The separately configured Node toolchain is needed by Node-backed language servers and npm fixtures in `other-langs` and `catch-all`. The `jvm`, `native`, and `niche` batches do not consume it, so installing Node there is unnecessary.

`package-manager-cache: false` is intentionally omitted. [`setup-node@v7`](https://github.com/actions/setup-node/blob/v7/action.yml) only enables automatic npm caching when a repository-root `package.json` declares npm through `packageManager` or `devEngines.packageManager`; Serena has no root `package.json`.

This is independent CI maintenance. It removes unused Node setup from the Windows/JVM job, but does not fix or mask the pytest/JDTLS hang.

Other outdated action pins are intentionally outside this PR's scope.

## Validation

Local compatibility audit using Node `24.15.0` and npm `11.12.1`:

- cold installation succeeded for Serena's pinned Node-backed language-server stacks
- no `EBADENGINE` incompatibilities occurred
- LSP initialize/shutdown completed for Angular, TypeScript, vtsls, Vue, Svelte, Intelephense, Bash, Ansible, YAML, HTML, JSON, Sass, Solidity, Elm, Haxe, and MATLAB

Workflow validation:

- YAML parse
- `actionlint` with existing unrelated action-version and shellcheck findings filtered
- `git diff --check`

The Actions matrix will provide OS-specific validation.
