### PR TITLE
ci: capture Windows JVM hang diagnostics

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -748,7 +748,7 @@ jobs:
             hang_diagnostics_seconds=600
             pytest_timeout_seconds=720
             # Repeatedly start the exact Java test that stalled in the original
-            # run, deleting its JDTLS workspace after every attempt.
+            # run while reusing the same JDTLS workspace between attempts.
             if [[ "$DIAGNOSTIC_HEAD_REF" == "agent/jdtls-hang-diagnostics" ]]; then
               diagnostic_serena_home="${runner_temp_path}/serena-jdtls-stress-home"
               mkdir -p "$diagnostic_serena_home/language_servers/static"
@@ -762,9 +762,8 @@ jobs:
                 *) echo "Refusing to clear unexpected JDTLS workspace path: $jdtls_workspaces_dir" >&2; exit 1 ;;
               esac
               rm -rf -- "$jdtls_workspaces_dir"
-              reset_jdtls_workspace=true
               stress_jdtls=true
-              export SERENA_CI_JDTLS_REPRO_MODE="exact-java-reference-fresh-workspace"
+              export SERENA_CI_JDTLS_REPRO_MODE="exact-java-reference-reused-workspace"
               test_runs=25
               hang_diagnostics_seconds=300
               pytest_timeout_seconds=420

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -730,6 +730,8 @@ jobs:
         run: |
           extra_pytest_args=()
           diagnostics_dir=""
+          jdtls_workspaces_dir=""
+          reset_jdtls_workspace=false
           stress_jdtls=false
           stress_failure_status=0
           test_runs=1
@@ -742,8 +744,21 @@ jobs:
             pytest_timeout_seconds=720
             # Repeatedly exercise the cross-language teardown/JDTLS-startup sequence that previously hung.
             if [[ "$DIAGNOSTIC_HEAD_REF" == "agent/jdtls-hang-diagnostics" ]]; then
+              diagnostic_serena_home="${RUNNER_TEMP}/serena-jdtls-stress-home"
+              mkdir -p "$diagnostic_serena_home/language_servers/static"
+              if [[ -d "$HOME/.serena/language_servers/static" ]]; then
+                cp -R "$HOME/.serena/language_servers/static/." "$diagnostic_serena_home/language_servers/static/"
+              fi
+              export SERENA_HOME="$diagnostic_serena_home"
+              jdtls_workspaces_dir="$diagnostic_serena_home/language_servers/static/EclipseJDTLS/workspaces"
+              case "$jdtls_workspaces_dir" in
+                "$RUNNER_TEMP"/serena-jdtls-stress-home/*) ;;
+                *) echo "Refusing to clear unexpected JDTLS workspace path: $jdtls_workspaces_dir" >&2; exit 1 ;;
+              esac
+              rm -rf -- "$jdtls_workspaces_dir"
+              reset_jdtls_workspace=true
               stress_jdtls=true
-              test_runs=50
+              test_runs=20
               hang_diagnostics_seconds=300
               pytest_timeout_seconds=420
               test_command=(
@@ -768,12 +783,29 @@ jobs:
                 --log-file-level=INFO
               )
             fi
+            pytest_status=0
             if "${test_command[@]}" -m "${{ steps.markers.outputs.expr }}" -q --tb=short "${attempt_pytest_args[@]}"; then
-              continue
+              pytest_status=0
             else
               pytest_status=$?
             fi
-            if [[ "$stress_jdtls" == true ]] && ! compgen -G "$diagnostics_dir/hang-*" > /dev/null; then
+            hang_captured=false
+            if [[ "$stress_jdtls" == true ]] && compgen -G "$diagnostics_dir/hang-*" > /dev/null; then
+              hang_captured=true
+            fi
+            if [[ "$hang_captured" == true ]]; then
+              if [[ "$pytest_status" -eq 0 ]]; then
+                exit 1
+              fi
+              exit "$pytest_status"
+            fi
+            if [[ "$reset_jdtls_workspace" == true ]]; then
+              rm -rf -- "$jdtls_workspaces_dir"
+            fi
+            if [[ "$pytest_status" -eq 0 ]]; then
+              continue
+            fi
+            if [[ "$stress_jdtls" == true ]]; then
               echo "::warning::pytest attempt $attempt failed without hang evidence (exit $pytest_status); continuing stress loop"
               stress_failure_status="$pytest_status"
               continue
@@ -782,6 +814,26 @@ jobs:
           done
           if [[ "$stress_failure_status" -ne 0 ]]; then
             exit "$stress_failure_status"
+          fi
+      - name: Print Windows JVM hang diagnostics
+        if: failure() && runner.os == 'Windows' && matrix.batch == 'jvm'
+        shell: bash
+        run: |
+          found_hang_capture=false
+          for capture_dir in "${RUNNER_TEMP}"/serena-ci-diagnostics/hang-*; do
+            if [[ ! -d "$capture_dir" ]]; then
+              continue
+            fi
+            found_hang_capture=true
+            while IFS= read -r -d '' file; do
+              echo "::group::${file#"${RUNNER_TEMP}/"}"
+              cat "$file"
+              echo
+              echo "::endgroup::"
+            done < <(find "$capture_dir" -type f -print0)
+          done
+          if [[ "$found_hang_capture" == false ]]; then
+            echo "No hang capture was produced."
           fi
       - name: Upload Windows JVM hang diagnostics
         if: failure() && runner.os == 'Windows' && matrix.batch == 'jvm'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -738,14 +738,19 @@ jobs:
           test_runs=1
           test_command=(uv run poe test)
           if [[ "${{ runner.os }}" == "Windows" && "${{ matrix.batch }}" == "jvm" ]]; then
-            diagnostics_dir="${RUNNER_TEMP}/serena-ci-diagnostics"
+            runner_temp_path="$RUNNER_TEMP"
+            if command -v cygpath > /dev/null 2>&1; then
+              runner_temp_path="$(cygpath -m "$RUNNER_TEMP")"
+            fi
+            diagnostics_dir="${runner_temp_path}/serena-ci-diagnostics"
             mkdir -p "$diagnostics_dir"
             export SERENA_CI_HANG_DIAGNOSTICS_DIR="$diagnostics_dir"
             hang_diagnostics_seconds=600
             pytest_timeout_seconds=720
-            # Prove the watchdog against a deliberate, branch-only stall in a live JDTLS process.
+            # Repeat the complete JVM batch from a clean JDTLS workspace, then
+            # reuse that workspace just as a normal CI job would.
             if [[ "$DIAGNOSTIC_HEAD_REF" == "agent/jdtls-hang-diagnostics" ]]; then
-              diagnostic_serena_home="${RUNNER_TEMP}/serena-jdtls-stress-home"
+              diagnostic_serena_home="${runner_temp_path}/serena-jdtls-stress-home"
               mkdir -p "$diagnostic_serena_home/language_servers/static"
               if [[ -d "$HOME/.serena/language_servers/static" ]]; then
                 cp -R "$HOME/.serena/language_servers/static/." "$diagnostic_serena_home/language_servers/static/"
@@ -753,23 +758,16 @@ jobs:
               export SERENA_HOME="$diagnostic_serena_home"
               jdtls_workspaces_dir="$diagnostic_serena_home/language_servers/static/EclipseJDTLS/workspaces"
               case "$jdtls_workspaces_dir" in
-                "$RUNNER_TEMP"/serena-jdtls-stress-home/*) ;;
+                "$runner_temp_path"/serena-jdtls-stress-home/*) ;;
                 *) echo "Refusing to clear unexpected JDTLS workspace path: $jdtls_workspaces_dir" >&2; exit 1 ;;
               esac
               rm -rf -- "$jdtls_workspaces_dir"
-              jdtls_canary=true
               stress_jdtls=true
-              export SERENA_CI_JDTLS_CANARY_PHASE="before_service_ready_wait"
-              export SERENA_CI_JDTLS_CANARY_STALL_SECONDS=150
-              hang_diagnostics_seconds=2
-              pytest_timeout_seconds=360
-              test_command=(
-                uv run pytest
-                "test/serena/test_serena_agent.py::TestSerenaAgent::test_find_symbol[java_model_class]"
-              )
+              export SERENA_CI_JDTLS_REPRO_MODE="full-jvm-batch-reused-workspace"
+              test_runs=3
+              hang_diagnostics_seconds=300
+              pytest_timeout_seconds=420
             fi
-            # In normal CI this is a per-test deadline. The canary interprets it as a
-            # short settling delay after the deliberate stall begins.
             export SERENA_CI_HANG_DIAGNOSTICS_SECONDS="$hang_diagnostics_seconds"
             extra_pytest_args+=(
               "--timeout=$pytest_timeout_seconds"
@@ -826,14 +824,18 @@ jobs:
         if: failure() && runner.os == 'Windows' && matrix.batch == 'jvm'
         shell: bash
         run: |
+          runner_temp_path="$RUNNER_TEMP"
+          if command -v cygpath > /dev/null 2>&1; then
+            runner_temp_path="$(cygpath -m "$RUNNER_TEMP")"
+          fi
           found_hang_capture=false
-          for capture_dir in "${RUNNER_TEMP}"/serena-ci-diagnostics/hang-*; do
+          for capture_dir in "${runner_temp_path}"/serena-ci-diagnostics/hang-*; do
             if [[ ! -d "$capture_dir" ]]; then
               continue
             fi
             found_hang_capture=true
             while IFS= read -r -d '' file; do
-              echo "::group::${file#"${RUNNER_TEMP}/"}"
+              echo "::group::${file#"${runner_temp_path}/"}"
               cat "$file"
               echo
               echo "::endgroup::"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -725,7 +725,30 @@ jobs:
           echo "expr=$expr" >> "$GITHUB_OUTPUT"
       - name: Test with pytest
         shell: bash
-        run: uv run poe test -m "${{ steps.markers.outputs.expr }}" -q --tb=short
+        run: |
+          extra_pytest_args=()
+          if [[ "${{ runner.os }}" == "Windows" && "${{ matrix.batch }}" == "jvm" ]]; then
+            diagnostics_dir="${RUNNER_TEMP}/serena-ci-diagnostics"
+            mkdir -p "$diagnostics_dir"
+            export SERENA_CI_HANG_DIAGNOSTICS_DIR="$diagnostics_dir"
+            # Capture live state first, then leave two minutes for jcmd/jstack before pytest-timeout exits.
+            export SERENA_CI_HANG_DIAGNOSTICS_SECONDS=600
+            extra_pytest_args+=(
+              --timeout=720
+              --timeout-method=thread
+              "--log-file=$diagnostics_dir/pytest.log"
+              --log-file-level=INFO
+            )
+          fi
+          uv run poe test -m "${{ steps.markers.outputs.expr }}" -q --tb=short "${extra_pytest_args[@]}"
+      - name: Upload Windows JVM hang diagnostics
+        if: failure() && runner.os == 'Windows' && matrix.batch == 'jvm'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-jvm-hang-diagnostics-attempt-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/serena-ci-diagnostics
+          if-no-files-found: warn
+          retention-days: 14
       - name: Type-checking with ty
         # Type-checking is batch-independent; run it only once per OS instead of in every batch.
         if: matrix.batch == 'catch-all'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -729,34 +729,60 @@ jobs:
           DIAGNOSTIC_HEAD_REF: ${{ github.head_ref }}
         run: |
           extra_pytest_args=()
+          diagnostics_dir=""
+          stress_jdtls=false
+          stress_failure_status=0
           test_runs=1
           test_command=(uv run poe test)
           if [[ "${{ runner.os }}" == "Windows" && "${{ matrix.batch }}" == "jvm" ]]; then
             diagnostics_dir="${RUNNER_TEMP}/serena-ci-diagnostics"
             mkdir -p "$diagnostics_dir"
             export SERENA_CI_HANG_DIAGNOSTICS_DIR="$diagnostics_dir"
-            # Capture live state first, then leave two minutes for jcmd/jstack before pytest-timeout exits.
-            export SERENA_CI_HANG_DIAGNOSTICS_SECONDS=600
-            extra_pytest_args+=(
-              --timeout=720
-              --timeout-method=thread
-              "--log-file=$diagnostics_dir/pytest.log"
-              --log-file-level=INFO
-            )
+            hang_diagnostics_seconds=600
+            pytest_timeout_seconds=720
             # Repeatedly exercise the cross-language teardown/JDTLS-startup sequence that previously hung.
             if [[ "$DIAGNOSTIC_HEAD_REF" == "agent/jdtls-hang-diagnostics" ]]; then
+              stress_jdtls=true
               test_runs=50
+              hang_diagnostics_seconds=300
+              pytest_timeout_seconds=420
               test_command=(
                 uv run pytest
                 "test/serena/test_serena_agent.py::TestSerenaAgent::test_find_symbol"
                 "test/serena/test_serena_agent.py::TestSerenaAgent::test_find_symbol_references"
               )
             fi
+            # Capture live state first, then leave two minutes for jcmd/jstack before pytest-timeout exits.
+            export SERENA_CI_HANG_DIAGNOSTICS_SECONDS="$hang_diagnostics_seconds"
+            extra_pytest_args+=(
+              "--timeout=$pytest_timeout_seconds"
+              --timeout-method=thread
+            )
           fi
           for ((attempt = 1; attempt <= test_runs; attempt++)); do
             echo "pytest attempt $attempt/$test_runs"
-            "${test_command[@]}" -m "${{ steps.markers.outputs.expr }}" -q --tb=short "${extra_pytest_args[@]}"
+            attempt_pytest_args=("${extra_pytest_args[@]}")
+            if [[ -n "$diagnostics_dir" ]]; then
+              attempt_pytest_args+=(
+                "--log-file=$diagnostics_dir/pytest-attempt-$attempt.log"
+                --log-file-level=INFO
+              )
+            fi
+            if "${test_command[@]}" -m "${{ steps.markers.outputs.expr }}" -q --tb=short "${attempt_pytest_args[@]}"; then
+              continue
+            else
+              pytest_status=$?
+            fi
+            if [[ "$stress_jdtls" == true ]] && ! compgen -G "$diagnostics_dir/hang-*" > /dev/null; then
+              echo "::warning::pytest attempt $attempt failed without hang evidence (exit $pytest_status); continuing stress loop"
+              stress_failure_status="$pytest_status"
+              continue
+            fi
+            exit "$pytest_status"
           done
+          if [[ "$stress_failure_status" -ne 0 ]]; then
+            exit "$stress_failure_status"
+          fi
       - name: Upload Windows JVM hang diagnostics
         if: failure() && runner.os == 'Windows' && matrix.batch == 'jvm'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -747,8 +747,8 @@ jobs:
             export SERENA_CI_HANG_DIAGNOSTICS_DIR="$diagnostics_dir"
             hang_diagnostics_seconds=600
             pytest_timeout_seconds=720
-            # Repeat the complete JVM batch from a clean JDTLS workspace, then
-            # reuse that workspace just as a normal CI job would.
+            # Repeatedly start the exact Java test that stalled in the original
+            # run, deleting its JDTLS workspace after every attempt.
             if [[ "$DIAGNOSTIC_HEAD_REF" == "agent/jdtls-hang-diagnostics" ]]; then
               diagnostic_serena_home="${runner_temp_path}/serena-jdtls-stress-home"
               mkdir -p "$diagnostic_serena_home/language_servers/static"
@@ -762,11 +762,16 @@ jobs:
                 *) echo "Refusing to clear unexpected JDTLS workspace path: $jdtls_workspaces_dir" >&2; exit 1 ;;
               esac
               rm -rf -- "$jdtls_workspaces_dir"
+              reset_jdtls_workspace=true
               stress_jdtls=true
-              export SERENA_CI_JDTLS_REPRO_MODE="full-jvm-batch-reused-workspace"
-              test_runs=3
+              export SERENA_CI_JDTLS_REPRO_MODE="exact-java-reference-fresh-workspace"
+              test_runs=25
               hang_diagnostics_seconds=300
               pytest_timeout_seconds=420
+              test_command=(
+                uv run pytest
+                "test/serena/test_serena_agent.py::TestSerenaAgent::test_find_symbol_references[java_model_refs]"
+              )
             fi
             export SERENA_CI_HANG_DIAGNOSTICS_SECONDS="$hang_diagnostics_seconds"
             extra_pytest_args+=(

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -725,8 +725,11 @@ jobs:
           echo "expr=$expr" >> "$GITHUB_OUTPUT"
       - name: Test with pytest
         shell: bash
+        env:
+          DIAGNOSTIC_HEAD_REF: ${{ github.head_ref }}
         run: |
           extra_pytest_args=()
+          test_runs=1
           if [[ "${{ runner.os }}" == "Windows" && "${{ matrix.batch }}" == "jvm" ]]; then
             diagnostics_dir="${RUNNER_TEMP}/serena-ci-diagnostics"
             mkdir -p "$diagnostics_dir"
@@ -739,8 +742,15 @@ jobs:
               "--log-file=$diagnostics_dir/pytest.log"
               --log-file-level=INFO
             )
+            # Exercise the flaky path repeatedly on this diagnostic PR without multiplying the full matrix.
+            if [[ "$DIAGNOSTIC_HEAD_REF" == "agent/jdtls-hang-diagnostics" ]]; then
+              test_runs=5
+            fi
           fi
-          uv run poe test -m "${{ steps.markers.outputs.expr }}" -q --tb=short "${extra_pytest_args[@]}"
+          for ((attempt = 1; attempt <= test_runs; attempt++)); do
+            echo "pytest attempt $attempt/$test_runs"
+            uv run poe test -m "${{ steps.markers.outputs.expr }}" -q --tb=short "${extra_pytest_args[@]}"
+          done
       - name: Upload Windows JVM hang diagnostics
         if: failure() && runner.os == 'Windows' && matrix.batch == 'jvm'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -742,7 +742,7 @@ jobs:
             export SERENA_CI_HANG_DIAGNOSTICS_DIR="$diagnostics_dir"
             hang_diagnostics_seconds=600
             pytest_timeout_seconds=720
-            # Repeatedly exercise the cross-language teardown/JDTLS-startup sequence that previously hung.
+            # Prove the watchdog against a deliberate, branch-only stall in a live JDTLS process.
             if [[ "$DIAGNOSTIC_HEAD_REF" == "agent/jdtls-hang-diagnostics" ]]; then
               diagnostic_serena_home="${RUNNER_TEMP}/serena-jdtls-stress-home"
               mkdir -p "$diagnostic_serena_home/language_servers/static"
@@ -756,18 +756,18 @@ jobs:
                 *) echo "Refusing to clear unexpected JDTLS workspace path: $jdtls_workspaces_dir" >&2; exit 1 ;;
               esac
               rm -rf -- "$jdtls_workspaces_dir"
-              reset_jdtls_workspace=true
               stress_jdtls=true
-              test_runs=20
-              hang_diagnostics_seconds=300
-              pytest_timeout_seconds=420
+              export SERENA_CI_JDTLS_CANARY_PHASE="before_service_ready_wait"
+              export SERENA_CI_JDTLS_CANARY_STALL_SECONDS=150
+              hang_diagnostics_seconds=2
+              pytest_timeout_seconds=360
               test_command=(
                 uv run pytest
-                "test/serena/test_serena_agent.py::TestSerenaAgent::test_find_symbol"
-                "test/serena/test_serena_agent.py::TestSerenaAgent::test_find_symbol_references"
+                "test/serena/test_serena_agent.py::TestSerenaAgent::test_find_symbol[java_model_class]"
               )
             fi
-            # Capture live state first, then leave two minutes for jcmd/jstack before pytest-timeout exits.
+            # In normal CI this is a per-test deadline. The canary interprets it as a
+            # short settling delay after the deliberate stall begins.
             export SERENA_CI_HANG_DIAGNOSTICS_SECONDS="$hang_diagnostics_seconds"
             extra_pytest_args+=(
               "--timeout=$pytest_timeout_seconds"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -732,6 +732,7 @@ jobs:
           diagnostics_dir=""
           jdtls_workspaces_dir=""
           reset_jdtls_workspace=false
+          jdtls_canary=false
           stress_jdtls=false
           stress_failure_status=0
           test_runs=1
@@ -756,6 +757,7 @@ jobs:
                 *) echo "Refusing to clear unexpected JDTLS workspace path: $jdtls_workspaces_dir" >&2; exit 1 ;;
               esac
               rm -rf -- "$jdtls_workspaces_dir"
+              jdtls_canary=true
               stress_jdtls=true
               export SERENA_CI_JDTLS_CANARY_PHASE="before_service_ready_wait"
               export SERENA_CI_JDTLS_CANARY_STALL_SECONDS=150
@@ -788,6 +790,11 @@ jobs:
               pytest_status=0
             else
               pytest_status=$?
+            fi
+            # A canary run must upload its result even when the deliberate stall
+            # finishes and pytest itself passes.
+            if [[ "$jdtls_canary" == true ]]; then
+              exit 1
             fi
             hang_captured=false
             if [[ "$stress_jdtls" == true ]] && compgen -G "$diagnostics_dir/hang-*" > /dev/null; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -730,6 +730,7 @@ jobs:
         run: |
           extra_pytest_args=()
           test_runs=1
+          test_command=(uv run poe test)
           if [[ "${{ runner.os }}" == "Windows" && "${{ matrix.batch }}" == "jvm" ]]; then
             diagnostics_dir="${RUNNER_TEMP}/serena-ci-diagnostics"
             mkdir -p "$diagnostics_dir"
@@ -742,14 +743,19 @@ jobs:
               "--log-file=$diagnostics_dir/pytest.log"
               --log-file-level=INFO
             )
-            # Exercise the flaky path repeatedly on this diagnostic PR without multiplying the full matrix.
+            # Repeatedly exercise the cross-language teardown/JDTLS-startup sequence that previously hung.
             if [[ "$DIAGNOSTIC_HEAD_REF" == "agent/jdtls-hang-diagnostics" ]]; then
-              test_runs=5
+              test_runs=50
+              test_command=(
+                uv run pytest
+                "test/serena/test_serena_agent.py::TestSerenaAgent::test_find_symbol"
+                "test/serena/test_serena_agent.py::TestSerenaAgent::test_find_symbol_references"
+              )
             fi
           fi
           for ((attempt = 1; attempt <= test_runs; attempt++)); do
             echo "pytest attempt $attempt/$test_runs"
-            uv run poe test -m "${{ steps.markers.outputs.expr }}" -q --tb=short "${extra_pytest_args[@]}"
+            "${test_command[@]}" -m "${{ steps.markers.outputs.expr }}" -q --tb=short "${extra_pytest_args[@]}"
           done
       - name: Upload Windows JVM hang diagnostics
         if: failure() && runner.os == 'Windows' && matrix.batch == 'jvm'

--- a/src/solidlsp/ci_hang_diagnostics.py
+++ b/src/solidlsp/ci_hang_diagnostics.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DIAGNOSTICS_DIR_ENV = "SERENA_CI_HANG_DIAGNOSTICS_DIR"
+JDTLS_CANARY_PHASE_ENV = "SERENA_CI_JDTLS_CANARY_PHASE"
+JDTLS_CANARY_STALL_SECONDS_ENV = "SERENA_CI_JDTLS_CANARY_STALL_SECONDS"
+
+JDTLS_LAST_PHASE_FILENAME = "jdtls-last-phase.json"
+JDTLS_PHASE_TAIL_FILENAME = "jdtls-phase-tail.json"
+JDTLS_LSP_TAIL_FILENAME = "jdtls-lsp-tail.json"
+
+_PHASE_TAIL_SIZE = 200
+_LSP_TAIL_SIZE = 400
+_STATE_LOCK = threading.RLock()
+_CANARY_STALL_STARTED = threading.Event()
+
+LSPTraceLogger = Callable[[str, str, dict[str, Any] | str], None]
+
+
+@dataclass
+class _RuntimeDiagnosticsState:
+    sequence: int = 0
+    phases: deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=_PHASE_TAIL_SIZE))
+    lsp_messages: deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=_LSP_TAIL_SIZE))
+
+
+_STATE_BY_ROOT: dict[Path, _RuntimeDiagnosticsState] = {}
+
+
+def _diagnostics_root() -> Path | None:
+    value = os.environ.get(DIAGNOSTICS_DIR_ENV)
+    if value is None or not value.strip():
+        return None
+    return Path(value)
+
+
+def _is_java_language_server(ls_id: object) -> bool:
+    value = getattr(ls_id, "value", ls_id)
+    return str(value).casefold() == "java"
+
+
+def _new_entry(state: _RuntimeDiagnosticsState, kind: str) -> dict[str, Any]:
+    state.sequence += 1
+    return {
+        "sequence": state.sequence,
+        "kind": kind,
+        "timestamp_utc": datetime.now(UTC).isoformat(),
+        "monotonic_seconds": time.monotonic(),
+        "process_id": os.getpid(),
+        "thread_id": threading.get_ident(),
+        "thread_name": threading.current_thread().name,
+    }
+
+
+def _write_json_atomic(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary_path.write_text(json.dumps(value, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+    os.replace(temporary_path, path)
+
+
+def record_jdtls_phase(phase: str, **details: object) -> None:
+    """Record a JDTLS lifecycle phase without relying on Python logging."""
+    root = _diagnostics_root()
+    if root is None:
+        return
+
+    try:
+        with _STATE_LOCK:
+            state = _STATE_BY_ROOT.setdefault(root, _RuntimeDiagnosticsState())
+            entry = _new_entry(state, "phase")
+            entry["phase"] = phase
+            if details:
+                entry["details"] = details
+            state.phases.append(entry)
+            _write_json_atomic(root / JDTLS_LAST_PHASE_FILENAME, entry)
+            _write_json_atomic(
+                root / JDTLS_PHASE_TAIL_FILENAME,
+                {
+                    "max_entries": _PHASE_TAIL_SIZE,
+                    "entries": list(state.phases),
+                },
+            )
+    except OSError:
+        # Diagnostics must never change language-server behavior.
+        return
+
+
+def record_jdtls_lifecycle(ls_id: object, phase: str, **details: object) -> None:
+    if _is_java_language_server(ls_id):
+        record_jdtls_phase(phase, **details)
+
+
+def _summarize_lsp_message(source: str, target: str, message: dict[str, Any] | str) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "source": source,
+        "target": target,
+    }
+    if isinstance(message, str):
+        summary.update({"message_kind": "text", "length": len(message)})
+        return summary
+
+    method = message.get("method")
+    request_id = message.get("id")
+    if method is not None:
+        summary["method"] = method
+    if request_id is not None:
+        summary["request_id"] = request_id
+
+    if method is not None and request_id is not None:
+        summary["message_kind"] = "request"
+    elif method is not None:
+        summary["message_kind"] = "notification"
+    elif request_id is not None:
+        summary["message_kind"] = "response"
+    else:
+        summary["message_kind"] = "other"
+
+    if "result" in message:
+        summary["has_result"] = True
+    error = message.get("error")
+    if isinstance(error, dict):
+        summary["error_code"] = error.get("code")
+
+    params = message.get("params")
+    if method == "language/status" and isinstance(params, dict):
+        summary["status_type"] = params.get("type")
+        summary["status_message"] = params.get("message")
+
+    return summary
+
+
+def _record_jdtls_lsp_message(source: str, target: str, message: dict[str, Any] | str) -> None:
+    root = _diagnostics_root()
+    if root is None:
+        return
+
+    try:
+        with _STATE_LOCK:
+            state = _STATE_BY_ROOT.setdefault(root, _RuntimeDiagnosticsState())
+            entry = _new_entry(state, "lsp")
+            entry.update(_summarize_lsp_message(source, target, message))
+            state.lsp_messages.append(entry)
+    except OSError:
+        return
+
+
+def snapshot_runtime_diagnostics(output_dir: Path) -> list[Path]:
+    """Persist a point-in-time copy of the in-memory JDTLS phase and LSP tails."""
+    root = _diagnostics_root()
+    if root is None:
+        return []
+
+    with _STATE_LOCK:
+        state = _STATE_BY_ROOT.get(root)
+        if state is None:
+            return []
+
+        written_paths: list[Path] = []
+        if state.phases:
+            last_phase_path = output_dir / JDTLS_LAST_PHASE_FILENAME
+            _write_json_atomic(last_phase_path, state.phases[-1])
+            written_paths.append(last_phase_path)
+
+            phase_tail_path = output_dir / JDTLS_PHASE_TAIL_FILENAME
+            _write_json_atomic(
+                phase_tail_path,
+                {
+                    "max_entries": _PHASE_TAIL_SIZE,
+                    "entries": list(state.phases),
+                },
+            )
+            written_paths.append(phase_tail_path)
+
+        if state.lsp_messages:
+            lsp_tail_path = output_dir / JDTLS_LSP_TAIL_FILENAME
+            _write_json_atomic(
+                lsp_tail_path,
+                {
+                    "max_entries": _LSP_TAIL_SIZE,
+                    "entries": list(state.lsp_messages),
+                },
+            )
+            written_paths.append(lsp_tail_path)
+
+        return written_paths
+
+
+def wrap_jdtls_lsp_trace_logger(ls_id: object, delegate: LSPTraceLogger | None) -> LSPTraceLogger | None:
+    """
+    Add a bounded, payload-free JDTLS trace to an existing LSP trace logger.
+
+    Only method names, request IDs, directions, response/error presence, and
+    ``language/status`` values are persisted. Request parameters and response
+    bodies are deliberately omitted.
+    """
+    if not _is_java_language_server(ls_id) or _diagnostics_root() is None:
+        return delegate
+
+    def trace(source: str, target: str, message: dict[str, Any] | str) -> None:
+        if delegate is not None:
+            delegate(source, target, message)
+        _record_jdtls_lsp_message(source, target, message)
+
+    return trace
+
+
+def jdtls_canary_is_enabled() -> bool:
+    value = os.environ.get(JDTLS_CANARY_PHASE_ENV)
+    return value is not None and bool(value.strip())
+
+
+def wait_for_jdtls_canary_stall(cancel_event: threading.Event) -> bool:
+    """Wait until the test-only JDTLS canary enters its deliberate stall."""
+    while not cancel_event.is_set():
+        if _CANARY_STALL_STARTED.wait(timeout=0.1):
+            return True
+    return False
+
+
+def maybe_stall_jdtls_canary(phase: str) -> None:
+    """Deliberately stall at a named phase when the branch-only CI canary requests it."""
+    configured_phase = os.environ.get(JDTLS_CANARY_PHASE_ENV)
+    if configured_phase != phase:
+        return
+
+    duration_value = os.environ.get(JDTLS_CANARY_STALL_SECONDS_ENV, "150")
+    duration_seconds = float(duration_value)
+    if duration_seconds <= 0:
+        raise ValueError(f"{JDTLS_CANARY_STALL_SECONDS_ENV} must be positive")
+
+    record_jdtls_phase(
+        "canary_stall_started",
+        target_phase=phase,
+        duration_seconds=duration_seconds,
+    )
+    _CANARY_STALL_STARTED.set()
+    time.sleep(duration_seconds)
+    record_jdtls_phase("canary_stall_completed", target_phase=phase)
+
+
+def _reset_runtime_diagnostics_for_tests() -> None:
+    with _STATE_LOCK:
+        _STATE_BY_ROOT.clear()
+        _CANARY_STALL_STARTED.clear()

--- a/src/solidlsp/ci_hang_diagnostics.py
+++ b/src/solidlsp/ci_hang_diagnostics.py
@@ -23,6 +23,7 @@ _PHASE_TAIL_SIZE = 200
 _LSP_TAIL_SIZE = 400
 _STATE_LOCK = threading.RLock()
 _CANARY_STALL_STARTED = threading.Event()
+_CANARY_DIAGNOSTICS_CAPTURED = threading.Event()
 
 LSPTraceLogger = Callable[[str, str, dict[str, Any] | str], None]
 
@@ -228,6 +229,11 @@ def wait_for_jdtls_canary_stall(cancel_event: threading.Event) -> bool:
     return False
 
 
+def notify_jdtls_canary_diagnostics_captured() -> None:
+    """Release a deliberate JDTLS stall after its live diagnostics are complete."""
+    _CANARY_DIAGNOSTICS_CAPTURED.set()
+
+
 def maybe_stall_jdtls_canary(phase: str) -> None:
     """Deliberately stall at a named phase when the branch-only CI canary requests it."""
     configured_phase = os.environ.get(JDTLS_CANARY_PHASE_ENV)
@@ -245,11 +251,16 @@ def maybe_stall_jdtls_canary(phase: str) -> None:
         duration_seconds=duration_seconds,
     )
     _CANARY_STALL_STARTED.set()
-    time.sleep(duration_seconds)
-    record_jdtls_phase("canary_stall_completed", target_phase=phase)
+    diagnostics_captured = _CANARY_DIAGNOSTICS_CAPTURED.wait(timeout=duration_seconds)
+    record_jdtls_phase(
+        "canary_stall_completed",
+        target_phase=phase,
+        diagnostics_captured=diagnostics_captured,
+    )
 
 
 def _reset_runtime_diagnostics_for_tests() -> None:
     with _STATE_LOCK:
         _STATE_BY_ROOT.clear()
         _CANARY_STALL_STARTED.clear()
+        _CANARY_DIAGNOSTICS_CAPTURED.clear()

--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -19,7 +19,7 @@ from typing import Any, cast
 
 from overrides import override
 
-from solidlsp import ls_types
+from solidlsp import ci_hang_diagnostics, ls_types
 from solidlsp.ls import LanguageServerDependencyProvider, LSPFileBuffer, SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_exceptions import SolidLSPException
@@ -826,6 +826,11 @@ class EclipseJDTLS(SolidLanguageServer):
                     project_hash,
                 )
             )
+            ci_hang_diagnostics.record_jdtls_phase(
+                "workspace_selected",
+                workspace=ws_dir,
+                repository_root=self._repository_root_path,
+            )
 
             # shared_cache_location is the global cache used by Eclipse JDTLS across all workspaces
             shared_cache_location = str(PurePath(self._solidlsp_settings.ls_resources_dir, "lsp", "EclipseJDTLS", "sharedIndex"))
@@ -1398,6 +1403,7 @@ class EclipseJDTLS(SolidLanguageServer):
         """
         Starts the Eclipse JDTLS Language Server
         """
+        ci_hang_diagnostics.record_jdtls_phase("jdtls_start_server_entered")
 
         def register_capability_handler(params: dict) -> None:
             assert "registrations" in params
@@ -1413,11 +1419,17 @@ class EclipseJDTLS(SolidLanguageServer):
                     ]
                 if registration["method"] == "workspace/executeCommand":
                     if "java.intellicode.enable" in registration["registerOptions"]["commands"]:
+                        ci_hang_diagnostics.record_jdtls_phase("intellicode_command_registered")
                         self._intellicode_enable_command_available.set()
             return
 
         def lang_status_handler(params: dict) -> None:
             log.info("Language status update: %s", params)
+            ci_hang_diagnostics.record_jdtls_phase(
+                "language_status_received",
+                status_type=params.get("type"),
+                status_message=params.get("message"),
+            )
             if params["type"] == "ServiceReady" and params["message"] == "ServiceReady":
                 self._service_ready_event.set()
             if params["type"] == "ProjectStatus":
@@ -1442,54 +1454,82 @@ class EclipseJDTLS(SolidLanguageServer):
         self.server.on_notification("$/progress", do_nothing)
         self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
         self.server.on_notification("language/actionableNotification", do_nothing)
+        ci_hang_diagnostics.record_jdtls_phase("jdtls_handlers_registered")
 
         log.info("Starting EclipseJDTLS server process")
+        ci_hang_diagnostics.record_jdtls_phase("jdtls_process_starting")
         self.server.start()
+        ci_hang_diagnostics.record_jdtls_phase("jdtls_process_started")
         initialize_params = self._create_initialize_params()
 
         log.info("Sending initialize request from LSP client to LSP server and awaiting response")
+        ci_hang_diagnostics.record_jdtls_phase("initialize_request_sending")
         init_response = self.server.send.initialize(initialize_params)
+        ci_hang_diagnostics.record_jdtls_phase("initialize_response_received")
         assert init_response["capabilities"]["textDocumentSync"]["change"] == 2  # type: ignore
         assert "completionProvider" not in init_response["capabilities"]
         assert "executeCommandProvider" not in init_response["capabilities"]
 
         self.server.notify.initialized({})
+        ci_hang_diagnostics.record_jdtls_phase("initialized_notification_sent")
 
         self.server.notify.workspace_did_change_configuration({"settings": initialize_params["initializationOptions"]["settings"]})  # type: ignore
+        ci_hang_diagnostics.record_jdtls_phase("configuration_notification_sent")
 
         # IntelliCode enablement is only relevant in the default vscode-java VSIX mode where the
         # IntelliCode bundle is shipped. In upstream-jdtls mode it's absent and the
         # 'java.intellicode.enable' command will never be registered, so we skip the wait/call.
         if self.runtime_dependency_paths.intellicode_jar_path is not None:
+            ci_hang_diagnostics.record_jdtls_phase("intellicode_registration_wait_started")
             self._intellicode_enable_command_available.wait()
+            ci_hang_diagnostics.record_jdtls_phase("intellicode_registration_wait_completed")
 
             java_intellisense_members_path = self.runtime_dependency_paths.intellisense_members_path
             assert java_intellisense_members_path is not None
             assert os.path.exists(java_intellisense_members_path)
+            ci_hang_diagnostics.record_jdtls_phase("intellicode_enable_request_sending")
             intellicode_enable_result = self.server.send.execute_command(
                 {
                     "command": "java.intellicode.enable",
                     "arguments": [True, java_intellisense_members_path],
                 }
             )
+            ci_hang_diagnostics.record_jdtls_phase("intellicode_enable_response_received")
             assert intellicode_enable_result
 
+        ci_hang_diagnostics.record_jdtls_phase(
+            "service_ready_checkpoint",
+            event_is_set=self._service_ready_event.is_set(),
+        )
+        ci_hang_diagnostics.maybe_stall_jdtls_canary("before_service_ready_wait")
         if not self._service_ready_event.is_set():
             log.info("Waiting for service to be ready ...")
+            ci_hang_diagnostics.record_jdtls_phase("service_ready_wait_started")
             self._service_ready_event.wait()
+            ci_hang_diagnostics.record_jdtls_phase("service_ready_wait_completed")
+        else:
+            ci_hang_diagnostics.record_jdtls_phase("service_ready_already_set")
         log.info("Service is ready")
 
         if not self._project_ready_event.is_set():
             log.info("Waiting for project to be ready ...")
             project_ready_timeout = 20  # Hotfix: Using timeout until we figure out why sometimes we don't get the project ready event
+            ci_hang_diagnostics.record_jdtls_phase(
+                "project_ready_wait_started",
+                timeout_seconds=project_ready_timeout,
+            )
             if self._project_ready_event.wait(timeout=project_ready_timeout):
                 log.info("Project is ready")
+                ci_hang_diagnostics.record_jdtls_phase("project_ready_wait_completed")
             else:
                 log.warning("Did not receive project ready status within %d seconds; proceeding anyway", project_ready_timeout)
+                ci_hang_diagnostics.record_jdtls_phase("project_ready_wait_timed_out")
         else:
             log.info("Project is ready")
+            ci_hang_diagnostics.record_jdtls_phase("project_ready_already_set")
 
         log.info("Startup complete")
+        ci_hang_diagnostics.record_jdtls_phase("jdtls_startup_complete")
 
     @override
     def _request_hover(self, file_buffer: LSPFileBuffer, line: int, column: int) -> ls_types.Hover | None:

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -23,7 +23,7 @@ from sensai.util.string import ToStringMixin
 
 from serena.util.file_system import match_path
 from serena.util.text_utils import MatchedConsecutiveLines
-from solidlsp import ls_types
+from solidlsp import ci_hang_diagnostics, ls_types
 from solidlsp.dependency_provider import (
     LanguageServerDependencyProvider,
     LanguageServerDependencyProviderBaseCommand,
@@ -530,13 +530,16 @@ class SolidLanguageServer(ABC):
         self._load_document_symbols_cache()
 
         self.server_started = False
+        logging_fn: Callable[[str, str, StringDict | str], None] | None
         if config.trace_lsp_communication:
 
-            def logging_fn(source: str, target: str, msg: StringDict | str) -> None:
+            def default_logging_fn(source: str, target: str, msg: StringDict | str) -> None:
                 log.debug(f"LSP: {source} -> {target}: {msg!s}")
 
+            logging_fn = default_logging_fn
         else:
             logging_fn = None
+        logging_fn = ci_hang_diagnostics.wrap_jdtls_lsp_trace_logger(self.ls_id, logging_fn)
 
         # create the low-level server interface, potentially installing dependencies and launching a subprocess
         self._process_launch_info: ProcessLaunchInfo | None = process_launch_info
@@ -3132,8 +3135,22 @@ class SolidLanguageServer(ABC):
         :return: self for method chaining
         """
         log.info(f"Starting language server {self.language_server.ls_id} for {self.language_server.repository_root_path}")
+        ci_hang_diagnostics.record_jdtls_lifecycle(
+            self.ls_id,
+            "language_server_start_entered",
+            repository_root=self.repository_root_path,
+        )
         self.server_started = True
-        self._start_server()
+        try:
+            self._start_server()
+        except BaseException as exception:
+            ci_hang_diagnostics.record_jdtls_lifecycle(
+                self.ls_id,
+                "language_server_start_failed",
+                exception_type=type(exception).__name__,
+            )
+            raise
+        ci_hang_diagnostics.record_jdtls_lifecycle(self.ls_id, "language_server_start_completed")
         return self
 
     def stop(self, shutdown_timeout: float = 2.0) -> None:
@@ -3143,12 +3160,23 @@ class SolidLanguageServer(ABC):
 
         :param shutdown_timeout: time, in seconds, to wait for the server to shutdown gracefully before killing it
         """
+        ci_hang_diagnostics.record_jdtls_lifecycle(
+            self.ls_id,
+            "language_server_stop_entered",
+            shutdown_timeout=shutdown_timeout,
+        )
         try:
             self.server.stop(timeout=shutdown_timeout)
         except Exception as e:
             log.warning(f"Exception while shutting down language server: {e}")
+            ci_hang_diagnostics.record_jdtls_lifecycle(
+                self.ls_id,
+                "language_server_stop_failed",
+                exception_type=type(e).__name__,
+            )
         finally:
             self.server_started = False
+            ci_hang_diagnostics.record_jdtls_lifecycle(self.ls_id, "language_server_stop_completed")
 
     @property
     def language_server(self) -> Self:

--- a/test/ci_hang_diagnostics.py
+++ b/test/ci_hang_diagnostics.py
@@ -478,7 +478,10 @@ class HangDiagnosticsWatchdog:
             return
         if self._cancel_event.wait(timeout=self.delay_seconds):
             return
-        self._collect()
+        try:
+            self._collect()
+        finally:
+            runtime_diagnostics.notify_jdtls_canary_diagnostics_captured()
 
     def _collect(self) -> None:
         self.collector.collect(self.nodeid)

--- a/test/ci_hang_diagnostics.py
+++ b/test/ci_hang_diagnostics.py
@@ -16,7 +16,9 @@ from typing import Any
 
 import psutil
 
-DIAGNOSTICS_DIR_ENV = "SERENA_CI_HANG_DIAGNOSTICS_DIR"
+from solidlsp import ci_hang_diagnostics as runtime_diagnostics
+
+DIAGNOSTICS_DIR_ENV = runtime_diagnostics.DIAGNOSTICS_DIR_ENV
 DIAGNOSTICS_DELAY_ENV = "SERENA_CI_HANG_DIAGNOSTICS_SECONDS"
 
 _COMMAND_TIMEOUT_SECONDS = 30.0
@@ -30,6 +32,8 @@ _METADATA_ENVIRONMENT_VARIABLES = (
     "RUNNER_ARCH",
     "RUNNER_NAME",
     "RUNNER_OS",
+    runtime_diagnostics.JDTLS_CANARY_PHASE_ENV,
+    runtime_diagnostics.JDTLS_CANARY_STALL_SECONDS_ENV,
 )
 
 
@@ -205,6 +209,12 @@ class HangDiagnosticsCollector:
         except Exception as exception:
             errors.append(self._format_error("metadata", exception))
 
+        # snapshot phase markers and the bounded LSP trace...
+        try:
+            self._capture_runtime_diagnostics(capture_dir)
+        except Exception as exception:
+            errors.append(self._format_error("runtime diagnostics", exception))
+
         # dump all Python threads...
         try:
             self._capture_python_threads(capture_dir)
@@ -253,6 +263,22 @@ class HangDiagnosticsCollector:
             "environment": environment,
         }
         self._write_json(capture_dir / "metadata.json", metadata)
+
+    def _capture_runtime_diagnostics(self, capture_dir: Path) -> None:
+        output_dir = capture_dir / "jdtls-runtime-diagnostics"
+        output_dir.mkdir()
+        manifest: list[dict[str, str | int]] = []
+
+        for destination_path in runtime_diagnostics.snapshot_runtime_diagnostics(output_dir):
+            manifest.append(
+                {
+                    "source": "in-memory-runtime-snapshot",
+                    "destination": destination_path.name,
+                    "size_bytes": destination_path.stat().st_size,
+                }
+            )
+
+        self._write_json(output_dir / "manifest.json", manifest)
 
     @staticmethod
     def _capture_python_threads(capture_dir: Path) -> None:
@@ -388,6 +414,8 @@ class HangDiagnosticsWatchdog:
     delay_seconds: float
     collector: HangDiagnosticsCollector
     _timer: threading.Timer | None = field(default=None, init=False, repr=False)
+    _worker: threading.Thread | None = field(default=None, init=False, repr=False)
+    _cancel_event: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
 
     @classmethod
     def from_environment(cls, nodeid: str) -> HangDiagnosticsWatchdog | None:
@@ -418,8 +446,20 @@ class HangDiagnosticsWatchdog:
         return cls(nodeid=nodeid, delay_seconds=delay_seconds, collector=collector)
 
     def start(self) -> None:
-        if self._timer is not None:
+        if self._timer is not None or self._worker is not None:
             raise RuntimeError("hang diagnostics watchdog has already been started")
+
+        # The deliberate Windows canary arms collection only after JDTLS reaches the
+        # requested stall. Normal CI continues to use a fixed per-test deadline.
+        if runtime_diagnostics.jdtls_canary_is_enabled():
+            worker = threading.Thread(
+                target=self._collect_after_canary_stall,
+                name="serena-ci-jdtls-canary-diagnostics",
+                daemon=True,
+            )
+            self._worker = worker
+            worker.start()
+            return
 
         # schedule capture...
         timer = threading.Timer(self.delay_seconds, self._collect)
@@ -429,8 +469,16 @@ class HangDiagnosticsWatchdog:
         timer.start()
 
     def cancel(self) -> None:
+        self._cancel_event.set()
         if self._timer is not None:
             self._timer.cancel()
+
+    def _collect_after_canary_stall(self) -> None:
+        if not runtime_diagnostics.wait_for_jdtls_canary_stall(self._cancel_event):
+            return
+        if self._cancel_event.wait(timeout=self.delay_seconds):
+            return
+        self._collect()
 
     def _collect(self) -> None:
         self.collector.collect(self.nodeid)

--- a/test/ci_hang_diagnostics.py
+++ b/test/ci_hang_diagnostics.py
@@ -34,6 +34,7 @@ _METADATA_ENVIRONMENT_VARIABLES = (
     "RUNNER_OS",
     runtime_diagnostics.JDTLS_CANARY_PHASE_ENV,
     runtime_diagnostics.JDTLS_CANARY_STALL_SECONDS_ENV,
+    "SERENA_CI_JDTLS_REPRO_MODE",
 )
 
 

--- a/test/ci_hang_diagnostics.py
+++ b/test/ci_hang_diagnostics.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import faulthandler
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+DIAGNOSTICS_DIR_ENV = "SERENA_CI_HANG_DIAGNOSTICS_DIR"
+DIAGNOSTICS_DELAY_ENV = "SERENA_CI_HANG_DIAGNOSTICS_SECONDS"
+
+_COMMAND_TIMEOUT_SECONDS = 30.0
+_JDTLS_PROCESS_MARKERS = ("org.eclipse.equinox.launcher", "org.eclipse.jdt.ls.core")
+_METADATA_ENVIRONMENT_VARIABLES = (
+    "CI",
+    "GITHUB_ACTIONS",
+    "GITHUB_JOB",
+    "GITHUB_RUN_ATTEMPT",
+    "GITHUB_RUN_ID",
+    "RUNNER_ARCH",
+    "RUNNER_NAME",
+    "RUNNER_OS",
+)
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Result of a best-effort diagnostics command."""
+
+    command: list[str]
+    returncode: int | None
+    stdout: str
+    stderr: str
+    error: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.returncode == 0 and self.error is None
+
+    def render(self) -> str:
+        sections = [
+            f"command: {subprocess.list2cmdline(self.command)}",
+            f"returncode: {self.returncode}",
+        ]
+        if self.error is not None:
+            sections.append(f"error: {self.error}")
+        sections.extend(
+            (
+                "\nstdout:",
+                self.stdout,
+                "\nstderr:",
+                self.stderr,
+            )
+        )
+        return "\n".join(sections).rstrip() + "\n"
+
+
+@dataclass(frozen=True)
+class ProcessSnapshot:
+    """Process-tree state captured from the running pytest process."""
+
+    records: list[dict[str, Any]]
+    jdtls_pids: set[int]
+    jdtls_data_dirs: set[Path] = field(default_factory=set)
+
+
+def parse_jdtls_pids(jcmd_output: str) -> set[int]:
+    """
+    Extract JDTLS process IDs from ``jcmd -l`` output.
+
+    :param jcmd_output: output emitted by ``jcmd -l``
+    :return: process IDs whose main command identifies Eclipse JDTLS
+    """
+    result: set[int] = set()
+
+    # inspect JVM descriptions...
+    for line in jcmd_output.splitlines():
+        pid_text, separator, description = line.strip().partition(" ")
+        if not separator or not pid_text.isdigit():
+            continue
+        if _is_jdtls_process(description):
+            result.add(int(pid_text))
+
+    return result
+
+
+def _is_jdtls_process(description: str) -> bool:
+    normalized_description = description.casefold()
+    return any(marker.casefold() in normalized_description for marker in _JDTLS_PROCESS_MARKERS)
+
+
+def _coerce_subprocess_output(output: str | bytes | None) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace")
+    return output
+
+
+def _run_command(command: list[str], timeout_seconds: float) -> CommandResult:
+    # execute command...
+    try:
+        completed_process = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_seconds,
+            check=False,
+        )
+        return CommandResult(
+            command=command,
+            returncode=completed_process.returncode,
+            stdout=completed_process.stdout,
+            stderr=completed_process.stderr,
+        )
+    except subprocess.TimeoutExpired as exception:
+        return CommandResult(
+            command=command,
+            returncode=None,
+            stdout=_coerce_subprocess_output(exception.stdout),
+            stderr=_coerce_subprocess_output(exception.stderr),
+            error=f"timed out after {timeout_seconds:g} seconds",
+        )
+    except OSError as exception:
+        return CommandResult(
+            command=command,
+            returncode=None,
+            stdout="",
+            stderr="",
+            error=f"{type(exception).__name__}: {exception}",
+        )
+
+
+def _collect_process_snapshot() -> ProcessSnapshot:
+    records: list[dict[str, Any]] = []
+    jdtls_pids: set[int] = set()
+    jdtls_data_dirs: set[Path] = set()
+
+    # limit collection to pytest and its descendants...
+    pytest_process = psutil.Process(os.getpid())
+    try:
+        processes = [pytest_process, *pytest_process.children(recursive=True)]
+    except (psutil.Error, OSError):
+        processes = [pytest_process]
+
+    # inspect process metadata...
+    for process in processes:
+        try:
+            record = process.as_dict(attrs=["pid", "ppid", "name", "cmdline", "status", "create_time"])
+            records.append(record)
+
+            command_line = [str(argument) for argument in record.get("cmdline") or []]
+            if _is_jdtls_process(" ".join(command_line)):
+                jdtls_pids.add(int(record["pid"]))
+                if (data_dir := _extract_jdtls_data_dir(command_line)) is not None:
+                    jdtls_data_dirs.add(data_dir)
+        except (psutil.Error, OSError) as exception:
+            records.append({"pid": process.pid, "error": f"{type(exception).__name__}: {exception}"})
+
+    return ProcessSnapshot(records=records, jdtls_pids=jdtls_pids, jdtls_data_dirs=jdtls_data_dirs)
+
+
+def _extract_jdtls_data_dir(command_line: list[str]) -> Path | None:
+    for index, argument in enumerate(command_line[:-1]):
+        if argument == "-data":
+            return Path(command_line[index + 1])
+    return None
+
+
+@dataclass(frozen=True)
+class HangDiagnosticsCollector:
+    """Best-effort collector for a pytest stall involving Eclipse JDTLS."""
+
+    output_root: Path
+    serena_home: Path
+    command_timeout_seconds: float = _COMMAND_TIMEOUT_SECONDS
+
+    def collect(self, nodeid: str) -> Path:
+        """
+        Capture Python and JVM state without terminating either process.
+
+        :param nodeid: pytest node ID active when the watchdog fired
+        :return: directory containing the captured evidence
+        """
+        captured_at = datetime.now(UTC)
+        capture_dir = self.output_root / f"hang-{captured_at.strftime('%Y%m%dT%H%M%SZ')}-pid-{os.getpid()}"
+        capture_dir.mkdir(parents=True, exist_ok=False)
+        errors: list[str] = []
+
+        # record test metadata...
+        try:
+            self._write_metadata(capture_dir, nodeid, captured_at)
+        except Exception as exception:
+            errors.append(self._format_error("metadata", exception))
+
+        # dump all Python threads...
+        try:
+            self._capture_python_threads(capture_dir)
+        except Exception as exception:
+            errors.append(self._format_error("Python thread dump", exception))
+
+        # inspect pytest descendants...
+        process_snapshot = ProcessSnapshot(records=[], jdtls_pids=set())
+        try:
+            process_snapshot = _collect_process_snapshot()
+            self._write_json(capture_dir / "pytest-process-tree.json", process_snapshot.records)
+        except Exception as exception:
+            errors.append(self._format_error("process tree", exception))
+
+        # dump live JDTLS JVMs...
+        try:
+            self._capture_jdtls_threads(capture_dir, process_snapshot.jdtls_pids)
+        except Exception as exception:
+            errors.append(self._format_error("JDTLS thread dump", exception))
+
+        # preserve Eclipse workspace logs...
+        try:
+            self._capture_jdtls_logs(capture_dir, process_snapshot.jdtls_data_dirs)
+        except Exception as exception:
+            errors.append(self._format_error("JDTLS logs", exception))
+
+        # mark capture outcome...
+        if errors:
+            (capture_dir / "capture-errors.txt").write_text("\n".join(errors) + "\n", encoding="utf-8")
+        (capture_dir / "capture-complete.txt").write_text(
+            f"Diagnostics collection completed at {datetime.now(UTC).isoformat()}.\n",
+            encoding="utf-8",
+        )
+
+        return capture_dir
+
+    def _write_metadata(self, capture_dir: Path, nodeid: str, captured_at: datetime) -> None:
+        environment = {name: value for name in _METADATA_ENVIRONMENT_VARIABLES if (value := os.environ.get(name)) is not None}
+        metadata = {
+            "captured_at": captured_at.isoformat(),
+            "pytest_nodeid": nodeid,
+            "python_executable": sys.executable,
+            "python_pid": os.getpid(),
+            "python_version": sys.version,
+            "platform": platform.platform(),
+            "environment": environment,
+        }
+        self._write_json(capture_dir / "metadata.json", metadata)
+
+    @staticmethod
+    def _capture_python_threads(capture_dir: Path) -> None:
+        with (capture_dir / "python-threads.txt").open("w", encoding="utf-8") as stream:
+            stream.write("All Python threads captured by faulthandler:\n\n")
+            stream.flush()
+            faulthandler.dump_traceback(file=stream, all_threads=True)
+
+    def _capture_jdtls_threads(self, capture_dir: Path, process_tree_pids: set[int]) -> None:
+        jcmd_executable = shutil.which("jcmd")
+        jstack_executable = shutil.which("jstack")
+
+        # enumerate visible JVMs...
+        if jcmd_executable is None:
+            jcmd_list_result = CommandResult(
+                command=["jcmd", "-l"],
+                returncode=None,
+                stdout="",
+                stderr="",
+                error="jcmd was not found on PATH",
+            )
+        else:
+            jcmd_list_result = _run_command([jcmd_executable, "-l"], self.command_timeout_seconds)
+        (capture_dir / "jcmd-list.txt").write_text(jcmd_list_result.render(), encoding="utf-8")
+
+        # combine both discovery methods...
+        jdtls_pids = set(process_tree_pids)
+        jdtls_pids.update(parse_jdtls_pids(jcmd_list_result.stdout))
+        if not jdtls_pids:
+            (capture_dir / "jdtls-process-not-found.txt").write_text(
+                "No live JVM matched the Eclipse Equinox launcher or JDTLS main class.\n",
+                encoding="utf-8",
+            )
+            return
+
+        # attach to each JDTLS process...
+        for pid in sorted(jdtls_pids):
+            jcmd_thread_result: CommandResult | None = None
+            if jcmd_executable is not None:
+                jcmd_thread_result = _run_command(
+                    [jcmd_executable, str(pid), "Thread.print", "-l"],
+                    self.command_timeout_seconds,
+                )
+                (capture_dir / f"jvm-{pid}-jcmd-thread-print.txt").write_text(jcmd_thread_result.render(), encoding="utf-8")
+
+            if jcmd_thread_result is not None and jcmd_thread_result.succeeded and jcmd_thread_result.stdout.strip():
+                continue
+
+            if jstack_executable is None:
+                (capture_dir / f"jvm-{pid}-jstack-unavailable.txt").write_text(
+                    "jstack was not found on PATH, so no fallback dump could be attempted.\n",
+                    encoding="utf-8",
+                )
+                continue
+
+            jstack_result = _run_command(
+                [jstack_executable, "-l", str(pid)],
+                self.command_timeout_seconds,
+            )
+            (capture_dir / f"jvm-{pid}-jstack.txt").write_text(jstack_result.render(), encoding="utf-8")
+
+    def _capture_jdtls_logs(self, capture_dir: Path, active_data_dirs: set[Path]) -> None:
+        workspace_root = self.serena_home / "language_servers" / "static" / "EclipseJDTLS" / "workspaces"
+        output_dir = capture_dir / "jdtls-workspace-logs"
+        output_dir.mkdir()
+        manifest: list[dict[str, str | int]] = []
+
+        # prefer logs named by active JDTLS command lines...
+        active_logs = sorted((data_dir / ".metadata" / ".log" for data_dir in active_data_dirs), key=str)
+        selected_logs = [(path, "active-process") for path in active_logs if path.is_file()]
+
+        # fall back to logs updated near the current test...
+        if not selected_logs:
+            workspace_logs = sorted(
+                workspace_root.glob("*/data_dir/.metadata/.log"),
+                key=self._safe_mtime,
+                reverse=True,
+            )
+            recent_cutoff = time.time() - 2 * 60 * 60
+            recent_logs = [path for path in workspace_logs if self._safe_mtime(path) >= recent_cutoff]
+            fallback_logs = recent_logs[:3] if recent_logs else workspace_logs[:1]
+            selected_logs = [(path, "recent-fallback") for path in fallback_logs]
+
+        # copy selected workspace error logs...
+        for index, (source_path, selection) in enumerate(selected_logs):
+            try:
+                workspace_id = source_path.relative_to(workspace_root).parts[0]
+            except ValueError:
+                workspace_id = source_path.parents[2].name
+            destination_path = output_dir / f"{index:02d}-{workspace_id}.log"
+            try:
+                shutil.copy2(source_path, destination_path)
+                manifest.append(
+                    {
+                        "source": str(source_path),
+                        "destination": destination_path.name,
+                        "selection": selection,
+                        "size_bytes": destination_path.stat().st_size,
+                    }
+                )
+            except OSError as exception:
+                manifest.append(
+                    {
+                        "source": str(source_path),
+                        "selection": selection,
+                        "error": f"{type(exception).__name__}: {exception}",
+                    }
+                )
+
+        self._write_json(output_dir / "manifest.json", manifest)
+
+    @staticmethod
+    def _safe_mtime(path: Path) -> float:
+        try:
+            return path.stat().st_mtime
+        except OSError:
+            return 0
+
+    @staticmethod
+    def _write_json(path: Path, value: object) -> None:
+        path.write_text(json.dumps(value, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _format_error(phase: str, exception: Exception) -> str:
+        return f"{phase}: {type(exception).__name__}: {exception}"
+
+
+@dataclass
+class HangDiagnosticsWatchdog:
+    """Per-test timer that captures diagnostics before pytest-timeout aborts."""
+
+    nodeid: str
+    delay_seconds: float
+    collector: HangDiagnosticsCollector
+    _timer: threading.Timer | None = field(default=None, init=False, repr=False)
+
+    @classmethod
+    def from_environment(cls, nodeid: str) -> HangDiagnosticsWatchdog | None:
+        """
+        Create an enabled watchdog from CI environment variables.
+
+        :param nodeid: pytest node ID about to run
+        :return: configured watchdog, or None when diagnostics are disabled
+        :raises ValueError: if the configured delay is not positive
+        """
+        output_root_value = os.environ.get(DIAGNOSTICS_DIR_ENV)
+        delay_value = os.environ.get(DIAGNOSTICS_DELAY_ENV)
+        if not output_root_value or not delay_value:
+            return None
+
+        # validate timing...
+        delay_seconds = float(delay_value)
+        if delay_seconds <= 0:
+            raise ValueError(f"{DIAGNOSTICS_DELAY_ENV} must be positive")
+
+        # resolve Serena storage...
+        serena_home_value = os.environ.get("SERENA_HOME")
+        serena_home = Path(serena_home_value) if serena_home_value and serena_home_value.strip() else Path.home() / ".serena"
+        collector = HangDiagnosticsCollector(
+            output_root=Path(output_root_value),
+            serena_home=serena_home,
+        )
+        return cls(nodeid=nodeid, delay_seconds=delay_seconds, collector=collector)
+
+    def start(self) -> None:
+        if self._timer is not None:
+            raise RuntimeError("hang diagnostics watchdog has already been started")
+
+        # schedule capture...
+        timer = threading.Timer(self.delay_seconds, self._collect)
+        timer.name = "serena-ci-hang-diagnostics"
+        timer.daemon = True
+        self._timer = timer
+        timer.start()
+
+    def cancel(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+
+    def _collect(self) -> None:
+        self.collector.collect(self.nodeid)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,7 @@ from serena.util.file_system import GitignoreParser
 from solidlsp.ls import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig, LanguageServerId
 from solidlsp.settings import SolidLSPSettings
+from test.ci_hang_diagnostics import HangDiagnosticsWatchdog
 
 from .solidlsp.clojure import is_clojure_cli_available
 from .solidlsp.elixir import EXPERT_UNAVAILABLE
@@ -29,6 +30,21 @@ from .solidlsp.erlang import ERLANG_LS_UNAVAILABLE
 configure(level=logging.INFO)
 
 log = logging.getLogger(__name__)
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_protocol(item: pytest.Item) -> Iterator[None]:
+    """Run a CI diagnostics watchdog across each test's setup, call, and teardown phases."""
+    watchdog = HangDiagnosticsWatchdog.from_environment(item.nodeid)
+    if watchdog is not None:
+        watchdog.start()
+
+    # run the complete test protocol...
+    try:
+        yield
+    finally:
+        if watchdog is not None:
+            watchdog.cancel()
 
 
 @pytest.fixture(scope="session")

--- a/test/test_ci_hang_diagnostics.py
+++ b/test/test_ci_hang_diagnostics.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+from typing import TextIO
+
+import pytest
+
+import test.ci_hang_diagnostics as diagnostics
+from test.ci_hang_diagnostics import (
+    CommandResult,
+    HangDiagnosticsCollector,
+    HangDiagnosticsWatchdog,
+    ProcessSnapshot,
+    parse_jdtls_pids,
+)
+
+
+def test_parse_jdtls_pids() -> None:
+    output = """
+    111 C:\\tools\\plugins\\org.eclipse.equinox.launcher_1.6.900.jar -data C:\\workspace
+    222 org.eclipse.jdt.ls.core.id1
+    333 org.gradle.launcher.daemon.bootstrap.GradleDaemon
+    malformed
+    """
+
+    assert parse_jdtls_pids(output) == {111, 222}
+
+
+def test_watchdog_reads_configuration_from_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    serena_home = tmp_path / "serena-home"
+    monkeypatch.setenv(diagnostics.DIAGNOSTICS_DIR_ENV, str(tmp_path / "diagnostics"))
+    monkeypatch.setenv(diagnostics.DIAGNOSTICS_DELAY_ENV, "12.5")
+    monkeypatch.setenv("SERENA_HOME", str(serena_home))
+
+    watchdog = HangDiagnosticsWatchdog.from_environment("test/example.py::test_stall")
+
+    assert watchdog is not None
+    assert watchdog.delay_seconds == 12.5
+    assert watchdog.collector.serena_home == serena_home
+
+
+def test_collector_captures_python_jvm_and_workspace_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    serena_home = tmp_path / "serena-home"
+    workspace_log = (
+        serena_home / "language_servers" / "static" / "EclipseJDTLS" / "workspaces" / "workspace-hash" / "data_dir" / ".metadata" / ".log"
+    )
+    workspace_log.parent.mkdir(parents=True)
+    workspace_log.write_text("JDTLS workspace error log\n", encoding="utf-8")
+
+    # replace live process inspection...
+    monkeypatch.setattr(
+        diagnostics,
+        "_collect_process_snapshot",
+        lambda: ProcessSnapshot(
+            records=[{"pid": 4321, "name": "java.exe", "cmdline": ["org.eclipse.equinox.launcher"]}],
+            jdtls_pids={4321},
+            jdtls_data_dirs={workspace_log.parents[1]},
+        ),
+    )
+    monkeypatch.setattr(diagnostics.shutil, "which", lambda name: f"/fake/{name}" if name == "jcmd" else None)
+
+    # replace external diagnostics commands...
+    def run_command(command: list[str], timeout_seconds: float) -> CommandResult:
+        assert timeout_seconds == 30
+        if command[-1] == "-l" and len(command) == 2:
+            return CommandResult(command, 0, "4321 org.eclipse.jdt.ls.core.id1\n", "")
+        return CommandResult(command, 0, '"JDT Main Thread" #1 WAITING\n', "")
+
+    monkeypatch.setattr(diagnostics, "_run_command", run_command)
+
+    # replace faulthandler's direct file-descriptor write...
+    def dump_traceback(*, file: TextIO, all_threads: bool) -> None:
+        assert all_threads
+        file.write("Python worker thread waiting in Event.wait\n")
+
+    monkeypatch.setattr(diagnostics.faulthandler, "dump_traceback", dump_traceback)
+
+    collector = HangDiagnosticsCollector(output_root=tmp_path / "diagnostics", serena_home=serena_home)
+    capture_dir = collector.collect("test/solidlsp/java/test_java.py::test_stall")
+
+    assert "test_stall" in (capture_dir / "metadata.json").read_text(encoding="utf-8")
+    assert "Event.wait" in (capture_dir / "python-threads.txt").read_text(encoding="utf-8")
+    assert "WAITING" in (capture_dir / "jvm-4321-jcmd-thread-print.txt").read_text(encoding="utf-8")
+    copied_logs = list((capture_dir / "jdtls-workspace-logs").glob("*.log"))
+    assert len(copied_logs) == 1
+    assert copied_logs[0].read_text(encoding="utf-8") == "JDTLS workspace error log\n"
+    assert (capture_dir / "capture-complete.txt").is_file()
+
+
+def test_collector_falls_back_to_jstack(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        diagnostics,
+        "_collect_process_snapshot",
+        lambda: ProcessSnapshot(records=[], jdtls_pids={9876}),
+    )
+    monkeypatch.setattr(diagnostics.shutil, "which", lambda name: f"/fake/{name}")
+
+    def run_command(command: list[str], timeout_seconds: float) -> CommandResult:
+        if command[-1] == "-l" and len(command) == 2:
+            return CommandResult(command, 0, "9876 org.eclipse.jdt.ls.core.id1\n", "")
+        if "Thread.print" in command:
+            return CommandResult(command, 1, "", "AttachNotSupportedException")
+        return CommandResult(command, 0, '"Worker" WAITING on PlexusContainerManager\n', "")
+
+    monkeypatch.setattr(diagnostics, "_run_command", run_command)
+    monkeypatch.setattr(diagnostics.faulthandler, "dump_traceback", lambda **kwargs: None)
+
+    collector = HangDiagnosticsCollector(
+        output_root=tmp_path / "diagnostics",
+        serena_home=tmp_path / "serena-home",
+    )
+    capture_dir = collector.collect("test/example.py::test_stall")
+
+    assert "PlexusContainerManager" in (capture_dir / "jvm-9876-jstack.txt").read_text(encoding="utf-8")

--- a/test/test_ci_hang_diagnostics.py
+++ b/test/test_ci_hang_diagnostics.py
@@ -1,9 +1,12 @@
+import json
+import threading
 from pathlib import Path
 from typing import TextIO
 
 import pytest
 
 import test.ci_hang_diagnostics as diagnostics
+from solidlsp import ci_hang_diagnostics as runtime_diagnostics
 from test.ci_hang_diagnostics import (
     CommandResult,
     HangDiagnosticsCollector,
@@ -41,12 +44,19 @@ def test_collector_captures_python_jvm_and_workspace_logs(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    diagnostics_root = tmp_path / "diagnostics"
     serena_home = tmp_path / "serena-home"
     workspace_log = (
         serena_home / "language_servers" / "static" / "EclipseJDTLS" / "workspaces" / "workspace-hash" / "data_dir" / ".metadata" / ".log"
     )
     workspace_log.parent.mkdir(parents=True)
     workspace_log.write_text("JDTLS workspace error log\n", encoding="utf-8")
+    monkeypatch.setenv(runtime_diagnostics.DIAGNOSTICS_DIR_ENV, str(diagnostics_root))
+    runtime_diagnostics._reset_runtime_diagnostics_for_tests()
+    runtime_diagnostics.record_jdtls_phase("service_ready_wait_started")
+    trace_logger = runtime_diagnostics.wrap_jdtls_lsp_trace_logger("java", None)
+    assert trace_logger is not None
+    trace_logger("solidlsp", "ls", {"jsonrpc": "2.0", "id": 7, "method": "initialize", "params": {"secret": "omitted"}})
 
     # replace live process inspection...
     monkeypatch.setattr(
@@ -76,10 +86,16 @@ def test_collector_captures_python_jvm_and_workspace_logs(
 
     monkeypatch.setattr(diagnostics.faulthandler, "dump_traceback", dump_traceback)
 
-    collector = HangDiagnosticsCollector(output_root=tmp_path / "diagnostics", serena_home=serena_home)
+    collector = HangDiagnosticsCollector(output_root=diagnostics_root, serena_home=serena_home)
     capture_dir = collector.collect("test/solidlsp/java/test_java.py::test_stall")
 
     assert "test_stall" in (capture_dir / "metadata.json").read_text(encoding="utf-8")
+    assert "service_ready_wait_started" in (
+        capture_dir / "jdtls-runtime-diagnostics" / runtime_diagnostics.JDTLS_LAST_PHASE_FILENAME
+    ).read_text(encoding="utf-8")
+    copied_lsp_trace = (capture_dir / "jdtls-runtime-diagnostics" / runtime_diagnostics.JDTLS_LSP_TAIL_FILENAME).read_text(encoding="utf-8")
+    assert '"method": "initialize"' in copied_lsp_trace
+    assert "secret" not in copied_lsp_trace
     assert "Event.wait" in (capture_dir / "python-threads.txt").read_text(encoding="utf-8")
     assert "WAITING" in (capture_dir / "jvm-4321-jcmd-thread-print.txt").read_text(encoding="utf-8")
     copied_logs = list((capture_dir / "jdtls-workspace-logs").glob("*.log"))
@@ -113,3 +129,93 @@ def test_collector_falls_back_to_jstack(monkeypatch: pytest.MonkeyPatch, tmp_pat
     capture_dir = collector.collect("test/example.py::test_stall")
 
     assert "PlexusContainerManager" in (capture_dir / "jvm-9876-jstack.txt").read_text(encoding="utf-8")
+
+
+def test_runtime_diagnostics_keep_bounded_payload_free_lsp_tail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    diagnostics_root = tmp_path / "runtime"
+    monkeypatch.setenv(runtime_diagnostics.DIAGNOSTICS_DIR_ENV, str(diagnostics_root))
+    runtime_diagnostics._reset_runtime_diagnostics_for_tests()
+
+    runtime_diagnostics.record_jdtls_phase("initialize_request_sending", workspace=tmp_path / "workspace")
+    delegate_messages: list[object] = []
+    trace_logger = runtime_diagnostics.wrap_jdtls_lsp_trace_logger(
+        "java",
+        lambda source, target, message: delegate_messages.append(message),
+    )
+    assert trace_logger is not None
+    for request_id in range(405):
+        trace_logger(
+            "solidlsp",
+            "ls",
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "textDocument/references",
+                "params": {"secret_file_contents": "must not be persisted"},
+            },
+        )
+
+    runtime_diagnostics.snapshot_runtime_diagnostics(diagnostics_root)
+    phase = json.loads((diagnostics_root / runtime_diagnostics.JDTLS_LAST_PHASE_FILENAME).read_text(encoding="utf-8"))
+    trace = json.loads((diagnostics_root / runtime_diagnostics.JDTLS_LSP_TAIL_FILENAME).read_text(encoding="utf-8"))
+    serialized_trace = json.dumps(trace)
+
+    assert phase["phase"] == "initialize_request_sending"
+    assert len(delegate_messages) == 405
+    assert len(trace["entries"]) == trace["max_entries"] == 400
+    assert trace["entries"][0]["request_id"] == 5
+    assert trace["entries"][-1]["request_id"] == 404
+    assert "secret_file_contents" not in serialized_trace
+    assert "must not be persisted" not in serialized_trace
+
+
+def test_canary_stall_arms_diagnostics_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(runtime_diagnostics.DIAGNOSTICS_DIR_ENV, str(tmp_path))
+    monkeypatch.setenv(runtime_diagnostics.JDTLS_CANARY_PHASE_ENV, "before_service_ready_wait")
+    monkeypatch.setenv(runtime_diagnostics.JDTLS_CANARY_STALL_SECONDS_ENV, "1")
+    monkeypatch.setattr(runtime_diagnostics.time, "sleep", lambda seconds: None)
+    runtime_diagnostics._reset_runtime_diagnostics_for_tests()
+
+    runtime_diagnostics.maybe_stall_jdtls_canary("before_service_ready_wait")
+
+    assert runtime_diagnostics.wait_for_jdtls_canary_stall(threading.Event())
+    phase_tail = json.loads((tmp_path / runtime_diagnostics.JDTLS_PHASE_TAIL_FILENAME).read_text(encoding="utf-8"))
+    assert [entry["phase"] for entry in phase_tail["entries"][-2:]] == [
+        "canary_stall_started",
+        "canary_stall_completed",
+    ]
+
+
+def test_watchdog_collects_after_canary_stall_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(runtime_diagnostics.DIAGNOSTICS_DIR_ENV, str(tmp_path))
+    monkeypatch.setenv(runtime_diagnostics.JDTLS_CANARY_PHASE_ENV, "before_service_ready_wait")
+    monkeypatch.setenv(runtime_diagnostics.JDTLS_CANARY_STALL_SECONDS_ENV, "1")
+    monkeypatch.setattr(runtime_diagnostics.time, "sleep", lambda seconds: None)
+    runtime_diagnostics._reset_runtime_diagnostics_for_tests()
+    collected = threading.Event()
+
+    def collect(collector: HangDiagnosticsCollector, nodeid: str) -> Path:
+        collected.set()
+        return tmp_path / "capture"
+
+    monkeypatch.setattr(HangDiagnosticsCollector, "collect", collect)
+    watchdog = HangDiagnosticsWatchdog(
+        nodeid="test/example.py::test_canary",
+        delay_seconds=0,
+        collector=HangDiagnosticsCollector(output_root=tmp_path, serena_home=tmp_path / "serena-home"),
+    )
+
+    watchdog.start()
+    runtime_diagnostics.maybe_stall_jdtls_canary("before_service_ready_wait")
+
+    assert collected.wait(timeout=1)
+    watchdog.cancel()

--- a/test/test_ci_hang_diagnostics.py
+++ b/test/test_ci_hang_diagnostics.py
@@ -179,8 +179,8 @@ def test_canary_stall_arms_diagnostics_worker(
     monkeypatch.setenv(runtime_diagnostics.DIAGNOSTICS_DIR_ENV, str(tmp_path))
     monkeypatch.setenv(runtime_diagnostics.JDTLS_CANARY_PHASE_ENV, "before_service_ready_wait")
     monkeypatch.setenv(runtime_diagnostics.JDTLS_CANARY_STALL_SECONDS_ENV, "1")
-    monkeypatch.setattr(runtime_diagnostics.time, "sleep", lambda seconds: None)
     runtime_diagnostics._reset_runtime_diagnostics_for_tests()
+    runtime_diagnostics.notify_jdtls_canary_diagnostics_captured()
 
     runtime_diagnostics.maybe_stall_jdtls_canary("before_service_ready_wait")
 
@@ -199,7 +199,6 @@ def test_watchdog_collects_after_canary_stall_signal(
     monkeypatch.setenv(runtime_diagnostics.DIAGNOSTICS_DIR_ENV, str(tmp_path))
     monkeypatch.setenv(runtime_diagnostics.JDTLS_CANARY_PHASE_ENV, "before_service_ready_wait")
     monkeypatch.setenv(runtime_diagnostics.JDTLS_CANARY_STALL_SECONDS_ENV, "1")
-    monkeypatch.setattr(runtime_diagnostics.time, "sleep", lambda seconds: None)
     runtime_diagnostics._reset_runtime_diagnostics_for_tests()
     collected = threading.Event()
 


### PR DESCRIPTION
## Summary

- add a per-test watchdog for the Windows JVM pytest batch
- capture all Python threads, the pytest process tree, JDTLS JVM thread dumps, and active JDTLS workspace logs
- fall back from `jcmd Thread.print -l` to `jstack -l` when JVM attachment fails
- capture after 10 minutes and terminate after 12 minutes in normal runs
- repeat the cross-language sequence surrounding the failed Java startup on this diagnostic branch
- shorten branch-only capture/termination to 5/7 minutes, preserve each attempt log, and continue past fast assertion failures until a hang is captured or all repetitions finish
- run 20 cold JDTLS workspaces after a 50-warm-start run completed without a hang
- print any Python/JVM dump into the Actions job log before artifact upload

## Why

The Windows JVM job in [run 30496140622](https://github.com/oraios/serena/actions/runs/30496140622/job/90725317302?pr=1761) stalled in a Java test until the 60-minute job timeout. The existing log does not show whether Python was waiting for IntelliCode or `ServiceReady`, or whether JDTLS was blocked inside Maven/m2e initialization.

The first 50-repetition run did not hang. [Attempt 26 failed quickly](https://github.com/oraios/serena/actions/runs/30588744848/job/91026120690) because Java hover information omitted the expected Javadoc. Its artifact correctly contained only `pytest.log`; the watchdog had not fired.

A second 50-repetition run also completed without a hang. Eight attempts failed with the same missing-Javadoc result. A third run cleared only the isolated JDTLS workspace between attempts; all 20 repetitions passed without a hang or missing-Javadoc failure.

This draft PR remains diagnostic instrumentation. It is intended to capture the evidence needed to distinguish a Serena/SolidLSP wait or event-ordering problem from an upstream JDTLS/m2e deadlock.

## Validation

- `uv run pytest test/test_ci_hang_diagnostics.py -q`
- `uv run poe lint`
- `uv run poe type-check`
- forced-hang smoke test confirming the artifact completes before pytest-timeout exits the process
- workflow YAML parsed successfully; actionlint reported no diagnostics on the changed lines
