### PR TITLE
ci: exclude JDTLS workspaces from language-server cache

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -706,7 +706,11 @@ jobs:
         id: cache-language-servers
         uses: actions/cache@v3
         with:
-          path: ~/.serena/language_servers/static
+          # JDTLS workspaces contain mutable Eclipse/Buildship runtime state.
+          # Cache the installed servers, but create each JDTLS workspace locally.
+          path: |
+            ~/.serena/language_servers/static
+            !~/.serena/language_servers/static/EclipseJDTLS/workspaces/**
           key: language-servers-${{ runner.os }}-${{ matrix.batch }}-v1
           restore-keys: |
             language-servers-${{ runner.os }}-${{ matrix.batch }}-


### PR DESCRIPTION
## Summary

- keep caching downloaded language-server installations
- exclude JDTLS project workspaces from the shared GitHub Actions cache
- force each CI job to initialize its own Eclipse/Buildship runtime state

## Why

Serena currently caches all of `~/.serena/language_servers/static`, including
`EclipseJDTLS/workspaces`. Those directories contain mutable, project-specific
Eclipse and Buildship state. Restoring that state into another job can make Java
test behavior depend on an earlier job rather than only on the checked-out
revision and current runner.

This is an independent cache-correctness change. It does not claim that restored
workspace state caused the Windows JDTLS hang; the diagnostics work in #1786 is
still needed to classify that stall.

The cache action supports multiple glob paths and leading `!` exclusions. Its
cache version also incorporates the configured paths, so the new definition
does not match the old broad cache archive.

#1214 intentionally preserves JDTLS workspaces across local Serena restarts. #1576 established stale JDTLS workspace state as a real correctness risk. This change preserves that user behavior while preventing GitHub Actions from restoring project-derived workspace state across revisions that share the same runner checkout path.

## Validation

- workflow YAML parses successfully
- `git diff --check`
- `actionlint` reports only diagnostics already present on `main`
