### PR TITLE
fix: make ErlangLanguageServer instantiable (implement _create_base_initialize_params)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Status of the `main` branch. Changes prior to the next official version change w
     coverage-report output, but matched by bare dirname and so also hid legitimate source directories named
     `coverage` (e.g. `src/routes/coverage/`) from symbol tools. Generated report dirs are already covered by
     gitignore. Fixes #1523.
+  - Fix: Restore `erlang` support (broken since v1.6.0 due to an implementation error) 
 
 * Tools:
   - Fix: `search_for_pattern` marked one line too many as matched whenever a match ended with a line

--- a/src/solidlsp/language_servers/erlang_language_server.py
+++ b/src/solidlsp/language_servers/erlang_language_server.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import pathlib
 import shutil
 import subprocess
 import threading
@@ -76,6 +75,25 @@ class ErlangLanguageServer(SolidLanguageServer):
         except (subprocess.SubprocessError, FileNotFoundError):
             return False
 
+    def _create_base_initialize_params(self) -> dict:
+        """
+        Returns the base initialize params for Erlang LS.
+
+        processId, rootPath, rootUri, clientInfo and workspaceFolders are added by the builder.
+        """
+        return {
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {"didSave": True},
+                    "completion": {"dynamicRegistration": True},
+                    "definition": {"dynamicRegistration": True},
+                    "references": {"dynamicRegistration": True},
+                    "documentSymbol": {"dynamicRegistration": True},
+                    "hover": {"dynamicRegistration": True},
+                }
+            },
+        }
+
     def _start_server(self) -> None:
         """Start Erlang LS server process with proper initialization waiting."""
 
@@ -132,25 +150,8 @@ class ErlangLanguageServer(SolidLanguageServer):
         log.info("Starting Erlang LS server process")
         self.server.start()
 
-        # Send initialize request
-        initialize_params = {
-            "processId": None,
-            "rootPath": self.repository_root_path,
-            "rootUri": pathlib.Path(self.repository_root_path).as_uri(),
-            "capabilities": {
-                "textDocument": {
-                    "synchronization": {"didSave": True},
-                    "completion": {"dynamicRegistration": True},
-                    "definition": {"dynamicRegistration": True},
-                    "references": {"dynamicRegistration": True},
-                    "documentSymbol": {"dynamicRegistration": True},
-                    "hover": {"dynamicRegistration": True},
-                }
-            },
-        }
-
         log.info("Sending initialize request to Erlang LS")
-        init_response = self.server.send.initialize(initialize_params)  # type: ignore[arg-type]
+        init_response = self.server.send.initialize(self._create_initialize_params())
 
         # Verify server capabilities
         if "capabilities" in init_response:


### PR DESCRIPTION
## Problem

`ErlangLanguageServer` cannot be instantiated at all. Every Serena tool fails on an Erlang project during project initialisation:

```
The language server manager is not initialized, indicating a problem during project initialisation.
Failed to start 1 language server(s):
erlang: Can't instantiate abstract class ErlangLanguageServer without an implementation
for abstract method '_create_base_initialize_params'
```

Because the failure is at initialisation, it takes down every tool, not just the one called — `get_symbols_overview`, `find_symbol`, `find_referencing_symbols` and the editing tools all fail identically.

## Cause

When server-specific initialize params were moved behind the abstract `_create_base_initialize_params` hook on `SolidLanguageServer` (`ls.py`), the Erlang backend was not converted with the others. It still builds its initialize dict inline inside `_start_server` and passes it straight to `self.server.send.initialize(...)`, so it never implements the abstract method and the class is left abstract.

This is not environment-specific: it reproduces with `erlang_ls` correctly installed and on `PATH`, on current `main`.

## Fix

Convert the backend to the same pattern the other language servers use (compare `ocaml_lsp_server.py`):

- Move the `capabilities` block out of `_start_server` into `_create_base_initialize_params`.
- Drop `processId` / `rootPath` / `rootUri` from the literal — `DefaultInitializeParamsBuilder` supplies those, and the method's docstring explicitly says implementations should not set them.
- Have `_start_server` build its params via `self._create_initialize_params()`.
- Remove the now-unused `pathlib` import.

No behavioural change beyond making the class instantiable; the capabilities advertised to `erlang_ls` are the same ones the inline dict sent. The `# type: ignore[arg-type]` on the `initialize` call is no longer needed, since `_create_initialize_params()` returns a properly typed `InitializeParams`.

## Verification

Against a real rebar3 umbrella project (~12 OTP applications), with `erlang_ls` on `PATH`:

- `ErlangLanguageServer.__abstractmethods__` is now empty — the class instantiates.
- `get_symbols_overview` on a 700-line module returns its functions, records and macros.
- `find_referencing_symbols` on a record returns 26 cross-references with correct locations and snippets.

## Note on erlang_ls vs ELP

`erlang_ls` was archived on 2025-08-15, and #771 tracks moving to ELP; #1149 attempted that and was closed over a branch/CI problem rather than on the merits. This PR takes no position on that migration — it only makes the Erlang backend that currently ships actually usable. If ELP support lands later, this file is likely replaced wholesale, but until then the shipped backend is 100% non-functional and this is a small fix.
