### PR TITLE
fix(ls): re-raise LS termination from pull-diagnostics fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Status of the `main` branch. Changes prior to the next official version change w
     and the request used to map diagnostics onto owning symbols just threw. `AnsibleLanguageServer` now
     overrides that request to return `None` directly, so diagnostics fall back to being grouped under
     the file-level path as already documented #1758
+  - Fix: pull-diagnostics fallback in `request_text_document_diagnostics` no longer swallows
+    `LanguageServerTerminatedException`, so a crash during a diagnostics pull triggers the existing
+    language-server restart path instead of silently returning no diagnostics #1770
   - Fix: F#'s `module <Name>` declarations reported a `selectionRange` pointing at the `module`
     keyword instead of at `<Name>`, so looking up hover/references from a module symbol's position
     returned the keyword's own docs instead of the module's #925

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -966,6 +966,11 @@ class SolidLanguageServer(ABC):
                         }
                     )
                 except SolidLSPException as ex:
+                    # Termination must propagate so tools_base can restart the LS and retry.
+                    # Other pull-diagnostics failures (e.g. unsupported method without crash)
+                    # still fall back to published diagnostics.
+                    if ex.is_language_server_terminated():
+                        raise
                     log.debug("Falling back to published diagnostics for %s due to pull-diagnostics error: %s", relative_file_path, ex)
                     response = None
                     pull_diagnostics_failed = True


### PR DESCRIPTION
## Summary

`request_text_document_diagnostics` caught every `SolidLSPException` from `textDocument/diagnostic` and fell back to published diagnostics. When the language server process had already terminated (`ex.is_language_server_terminated()`), that swallowed the failure locally instead of letting it reach `tools_base._apply()`, which restarts the language server and retries the tool call.

Result before this change: a crash during a diagnostics pull could silently degrade to “no diagnostics” instead of triggering the existing auto-restart path.

### Changes

- Re-raise `SolidLSPException` when `is_language_server_terminated()` is true.
- Keep the published-diagnostics fallback for other pull-diagnostics failures (e.g. servers that hard-error on an unsupported pull request without crashing).
- Unit tests for re-raise vs fallback.
- `CHANGELOG.md` entry under Language Servers.

Fixes #1770

## Test plan

- [x] `pytest test/solidlsp/test_pull_diagnostics_terminated.py` (2 passed)
- [x] Confirmed no open prior PR for #1770 before opening