### PR TITLE
fix(ls): resync open buffers and sync find_symbol/get_symbols_overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Status of the `main` branch. Changes prior to the next official version change w
 * Tools:
   - `find_symbol`, `jet_brains_find_symbol`: Change tool description to improve tool search results in clients that load tools dynamically
   - `get_current_config`: Result now includes language server status #1782
+  - Fix: `find_symbol` and `get_symbols_overview` could report a stale symbol position or miss a
+    new/deleted file when an already-open file was edited outside of Serena's own edit tools; both
+    tools are now included in the file system sync check every other symbolic tool already runs.
+    That check itself did not refresh an already-open buffer, only the file's watch registration,
+    so an open document could stay stale even where the check did run #1593
 
 * Language Servers: 
   - Allow language server priorities to be configured in `serena_config.yml` (for auto-detection during 

--- a/src/serena/ls_manager.py
+++ b/src/serena/ls_manager.py
@@ -347,6 +347,7 @@ class LanguageServerFileChangeNotifier:
         ]
         params: DidChangeWatchedFilesParams = {"changes": changes}
         created_paths = [rel_path for rel_path, change_type in events if change_type == FileChangeType.Created]
+        changed_paths = [rel_path for rel_path, change_type in events if change_type == FileChangeType.Changed]
 
         for ls in self._language_server_manager.iter_language_servers():
             # send the didChangeWatchedFiles notification to the language server
@@ -367,5 +368,13 @@ class LanguageServerFileChangeNotifier:
                         pass
                 except Exception as e:
                     log.error(f"Failed to refresh newly created file {rel_path!r} in language server", exc_info=e)
+
+            # A server may ignore didChangeWatchedFiles for a document it already has open
+            # (observed with pyright), so push fresh content directly to any open buffer too.
+            for rel_path in changed_paths:
+                try:
+                    ls.resync_open_buffer(rel_path)
+                except Exception as e:
+                    log.error(f"Failed to resync open buffer for changed file {rel_path!r}", exc_info=e)
 
         return len(events)

--- a/src/serena/tools/symbol_tools.py
+++ b/src/serena/tools/symbol_tools.py
@@ -54,7 +54,7 @@ class GetSymbolsOverviewTool(Tool, ToolMarkerSymbolicRead):
             Don't adjust unless there is really no other way to get the content required for the task.
         :return: a JSON object containing symbols grouped by kind in a compact format.
         """
-        # Note: file system sync not required (relevant file is opened in the language server explicitly)
+        self.project.ls_sync_file_system_changes()
 
         if depth == -1:
             if relative_path.endswith((".java", ".kt")):
@@ -191,7 +191,7 @@ class FindSymbolTool(Tool, ToolMarkerSymbolicRead):
         :param max_answer_chars: max result length; -1 for default
         :return: symbols (with locations) matching the name.
         """
-        # Note: file system sync not required; the symbol finder opens all relevant source files explicitly in the case of changes
+        self.project.ls_sync_file_system_changes()
 
         if include_body:
             depth = 0  # ignore user-specified depth if include_body is True

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -1395,6 +1395,37 @@ class SolidLanguageServer(ABC):
         )
         return deleted_text
 
+    def resync_open_buffer(self, relative_file_path: str) -> bool:
+        """
+        If the given file currently has an open buffer in this language server, re-reads its
+        contents from disk and pushes a full-content textDocument/didChange notification, so
+        that an edit made outside of this buffer's own insert_text_at_position/
+        delete_text_between_positions calls becomes visible to the server.
+
+        This is necessary in addition to workspace/didChangeWatchedFiles: once a document is
+        open, a server may treat the client (not the filesystem) as authoritative for its
+        content, so watched-file-change notifications alone can be silently ignored for an
+        already-open document.
+
+        :param relative_file_path: the relative path of the file to resync.
+        :return: True if a buffer was open and resynced, False if the file has no open buffer.
+        """
+        uri = self._resolve_file_uri(relative_file_path)
+        file_buffer = self.open_file_buffers.get(uri)
+        if file_buffer is None:
+            return False
+        file_buffer.version += 1
+        self.server.notify.did_change_text_document(
+            {  # ty: ignore[invalid-argument-type]  # dict built from LSPConstants keys; shape matches the TypedDict
+                LSPConstants.TEXT_DOCUMENT: {
+                    LSPConstants.VERSION: file_buffer.version,
+                    LSPConstants.URI: file_buffer.uri,
+                },
+                LSPConstants.CONTENT_CHANGES: [{"text": file_buffer.contents}],
+            }
+        )
+        return True
+
     def _send_definition_request(self, definition_params: DefinitionParams) -> Definition | list[LocationLink] | None:
         return self.server.send.definition(definition_params)
 

--- a/test/serena/test_ls_file_sync.py
+++ b/test/serena/test_ls_file_sync.py
@@ -13,7 +13,7 @@ import pytest
 
 from serena.agent import SerenaAgent
 from serena.project import Project
-from serena.tools import FindReferencingSymbolsTool
+from serena.tools import FindReferencingSymbolsTool, FindSymbolTool
 from solidlsp.ls_config import LanguageServerId
 from test.conftest import agent_for_project_context, get_repo_path
 
@@ -132,3 +132,60 @@ def test_ls_low_level_find_references_with_explicit_sync(tmp_path):
     Tests that requesting references directly from the LS works if synchronisation is explicitly requested after external file changes.
     """
     FileSystemSyncTestCase(use_serena_tool=False).run(tmp_path)
+
+
+class SymbolPositionStaleAfterExternalEditTestCase:
+    """
+    Tests that a Changed (not Created/Deleted) external edit to a file that already has an open
+    buffer in the language server session is reflected in symbol positions returned by
+    FindSymbolTool. This exercises SolidLanguageServer.resync_open_buffer, which is needed in
+    addition to workspace/didChangeWatchedFiles: once a document is open, a server may treat the
+    client (not the filesystem) as authoritative for its content and silently ignore watched-file
+    notifications for it (observed with pyright).
+    """
+
+    _TARGET_FILE = os.path.join("test_repo", "services.py")
+    _TARGET_SYMBOL = "create_user"
+    _PAD_LINES = 5
+
+    def _find(self, tool: FindSymbolTool) -> dict:
+        with tool.symbol_dict_grouper.disabled_context():
+            response = tool.apply(name_path_pattern=self._TARGET_SYMBOL, relative_path=self._TARGET_FILE)
+        symbols = json.loads(response)
+        assert len(symbols) == 1, f"expected exactly one match for {self._TARGET_SYMBOL}, got {symbols}"
+        return symbols[0]
+
+    def run(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        shutil.copytree(get_repo_path(LanguageServerId.PYTHON), repo_root)
+        target_abs = repo_root / self._TARGET_FILE
+
+        with agent_for_project_context(LanguageServerId.PYTHON, str(repo_root)) as agent:
+            project = agent.get_active_project_or_raise()
+            ls = next(iter(project.language_server_manager.iter_language_servers()))
+            tool = agent.get_tool(FindSymbolTool)
+
+            # Hold the file's buffer open across the external edit, mirroring the state left
+            # behind by a multi-step editing sequence that keeps a buffer open between calls.
+            with ls.open_file(self._TARGET_FILE):
+                baseline_start_line = self._find(tool)["body_location"]["start_line"]
+
+                original = target_abs.read_text(encoding="utf-8")
+                target_abs.write_text(("# pad\n" * self._PAD_LINES) + original, encoding="utf-8")
+
+                after_start_line = self._find(tool)["body_location"]["start_line"]
+
+        assert after_start_line == baseline_start_line + self._PAD_LINES, (
+            f"expected {self._TARGET_SYMBOL} to have shifted by {self._PAD_LINES} lines after the "
+            f"external edit ({baseline_start_line} -> {baseline_start_line + self._PAD_LINES}), "
+            f"but FindSymbolTool reported {after_start_line}"
+        )
+
+
+def test_find_symbol_tool_reflects_external_change_to_open_buffer(tmp_path):
+    """
+    Regression test for oraios/serena#1593: find_symbol returned a stale position for a symbol
+    in a file that was already open in the language server session and was then edited outside
+    of Serena's own edit tools.
+    """
+    SymbolPositionStaleAfterExternalEditTestCase().run(tmp_path)


### PR DESCRIPTION
## Root cause

`find_symbol` and `get_symbols_overview` carried a comment claiming that a file system sync is
not required because the symbol finder "opens all relevant source files explicitly in the case
of changes". That is true when a query opens and closes its own buffer, since a fresh
`didOpen` always carries the current disk content. It stops being true once a file's buffer is
already open (`ref_count > 0`) at query time: `SolidLanguageServer._open_in_ls` guards against
re-sending `didOpen` for a buffer that is already open, and neither tool called
`project.ls_sync_file_system_changes()`, unlike every other symbolic tool
(`find_referencing_symbols`, `find_implementations`, `find_declaration`,
`get_diagnostics_for_file`/`_symbol`, `rename_symbol`). A file already open when edited outside
of Serena's own edit tools (another editor, a second agent, a git checkout) then keeps
answering from the language server's stale view, exactly the "make-nested reported at the old
position" symptom in the issue.

Wiring the sync call in exposed a second gap in the sync mechanism itself
(`LanguageServerFileChangeNotifier.poll_and_notify`, added in #1591 20 days ago): it only sends
`workspace/didChangeWatchedFiles`. That notification is not guaranteed to refresh a document
the server already has open. A server is free to treat the client, not the filesystem, as
authoritative for an open document's content once `didOpen` has been sent, and pyright does
exactly that in a Docker repro: a `didChangeWatchedFiles(Changed)` for an open file is a no-op,
the next `documentSymbol` request still returns pre-edit positions.

## Fix

- `find_symbol`, `get_symbols_overview`: call `project.ls_sync_file_system_changes()`, matching
  the other symbolic tools.
- `SolidLanguageServer.resync_open_buffer()` (new): re-reads a file's current content and, if a
  buffer is open for it, pushes a full-content `textDocument/didChange`.
- `poll_and_notify()`: calls `resync_open_buffer()` for every changed path, in addition to the
  existing `didChangeWatchedFiles` notification.

## Verification

- New regression test (`test_find_symbol_tool_reflects_external_change_to_open_buffer`, pyright
  backend, Docker): holds a file's buffer open, edits it externally, and asserts `find_symbol`
  reports the shifted position. Fails on `main` (stale position), passes with this change.
- `test/serena/` python-marked suite (61 tests, incl. all of `test_ls_file_sync.py`,
  `test_serena_agent.py`, `test_symbol.py`, `test_symbol_editing.py`): green, no regressions.
- `ruff check`/`ruff format --check` and `ty check` on the full `src`/`test` tree: clean.
- Not checked: the effect on any language server other than pyright (no toolchain for
  clojure-lsp, the server named in the original report, in this environment), and the
  performance cost of running the sync's directory walk on every `find_symbol` call for very
  large repositories.

Fixes #1593
