### PR TITLE
fix(kotlin,svelte): handle workspace refresh requests to prevent language server shutdown

### DIFF
--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -475,6 +475,16 @@ class KotlinLanguageServer(SolidLanguageServer):
                         self._indexing_complete.set()
 
         self.server.on_request("client/registerCapability", do_nothing)
+        # We advertise `refreshSupport` for these features in the client
+        # capabilities above, so the server is entitled to send the matching
+        # refresh requests. Without a handler the client answers
+        # `MethodNotFound`, which the Kotlin LSP treats as fatal and shuts
+        # itself down, taking any in-flight request with it.
+        self.server.on_request("workspace/diagnostic/refresh", do_nothing)
+        self.server.on_request("workspace/inlayHint/refresh", do_nothing)
+        self.server.on_request("workspace/inlineValue/refresh", do_nothing)
+        self.server.on_request("workspace/semanticTokens/refresh", do_nothing)
+        self.server.on_request("workspace/codeLens/refresh", do_nothing)
         self.server.on_notification("language/status", do_nothing)
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)

--- a/src/solidlsp/language_servers/svelte_language_server.py
+++ b/src/solidlsp/language_servers/svelte_language_server.py
@@ -592,7 +592,9 @@ class SvelteLanguageServer(SolidLanguageServer):
         self.server.on_request("workspace/applyEdit", workspace_apply_edit_handler)
         self.server.on_request("workspace/configuration", configuration_handler)
         self.server.on_request("workspace/diagnostic/refresh", do_nothing)
-        self.server.on_request("workspace/inlayHints/refresh", do_nothing)
+        # `inlayHint` is singular per the LSP spec; the previous `inlayHints`
+        # spelling matched no real request and was therefore never invoked.
+        self.server.on_request("workspace/inlayHint/refresh", do_nothing)
         self.server.on_request("workspace/semanticTokens/refresh", do_nothing)
         self._wrap_notify_send_for_ts_js_mirror()
         self.server.start()


### PR DESCRIPTION
## Problem

`KotlinLanguageServer` advertises `refreshSupport` for five features in its client capabilities:

https://github.com/oraios/serena/blob/main/src/solidlsp/language_servers/kotlin_language_server.py#L211-L227

```python
"codeLens":       {"refreshSupport": True},
"semanticTokens": {"refreshSupport": True},
"inlineValue":    {"refreshSupport": True},
"inlayHint":      {"refreshSupport": True},
"diagnostics":    {"refreshSupport": True},
```

but registers no handler for any of the corresponding `workspace/*/refresh` requests — only `client/registerCapability`, `workspace/executeClientCommand` and `window/workDoneProgress/create` are registered.

Because we advertised support, the server is entitled to send those requests. When it does, `LanguageServerProcess._request_handler` finds no handler and answers with `MethodNotFound`:

```python
handler = self.on_request_handlers.get(method)
if not handler:
    self.send_error_response(
        request_id,
        LSPError(ErrorCodes.MethodNotFound, f"method '{method}' not handled on client."),
    )
    return
```

The Kotlin LSP (`com.jetbrains.lsp.implementation`) treats that error as fatal and shuts itself down, taking any in-flight request with it.

## Evidence

Observed repeatedly in production against a Kotlin project. From the Serena log — the language server dies 0.4 s after the unhandled request, and the in-flight tool call fails:

```
ERROR [LSP-stderr-reader:kotlin] solidlsp.ls_process:_read_ls_process_stderr:660 -
  com.jetbrains.lsp.implementation.LspException: method 'workspace/diagnostic/refresh' not handled on client.
INFO  [LSP-stdout-reader:kotlin] solidlsp.ls_process:_read_ls_process_stdout:639 -
  Language server stdout reader thread has terminated
ERROR [LSP-stdout-reader:kotlin] solidlsp.ls_process:_read_ls_process_stdout:643 -
  LanguageServerTerminatedException: Language server stdout read process terminated unexpectedly
INFO  [LSP-stdout-reader:kotlin] solidlsp.ls_process:_cancel_pending_requests:326 -
  Cancelling 1 pending language server requests
ERROR [Task-4:FindSymbolTool] serena.tools.tools_base:task:386 -
  Language server terminated while executing tool
```

This reproduced on every occurrence in our logs (three separate crashes across two days), always triggered by `workspace/diagnostic/refresh`.

Serena usually recovers via the `SolidLSPException` retry in `tools_base.py`, so the user often only sees a delay. But when the affected language cannot be determined, the retry is skipped (`affected language is unknown. Not retrying.`) and the raw `LanguageServerTerminatedException` reaches the caller. In our case the agent using Serena drew two incorrect conclusions from it — that concurrent tool calls were unsafe, and that absolute paths / broad searches had to be avoided — neither of which was true.

## Fix

Register no-op handlers for all five advertised refresh capabilities, mirroring what `svelte_language_server.py` already does:

https://github.com/oraios/serena/blob/main/src/solidlsp/language_servers/svelte_language_server.py#L594-L596

```python
self.server.on_request("workspace/diagnostic/refresh", do_nothing)
self.server.on_request("workspace/inlayHint/refresh", do_nothing)
self.server.on_request("workspace/inlineValue/refresh", do_nothing)
self.server.on_request("workspace/semanticTokens/refresh", do_nothing)
self.server.on_request("workspace/codeLens/refresh", do_nothing)
```

A no-op is the correct response here: these requests only ask the client to invalidate cached results, and Serena keeps no such client-side cache. Answering them keeps the session alive, which is the whole point.

The method names follow the LSP 3.17 spec (`workspace/inlayHint/refresh`, singular).

### Second commit: `svelte`, same class of bug

While checking the spelling I noticed that `svelte_language_server.py` registers `workspace/inlayHints/refresh` with a plural `Hints`. That method does not exist in the LSP specification, so the handler could never be invoked and the request it was meant to absorb would still be answered with `MethodNotFound` — the same failure mode this PR fixes for Kotlin, just latent. Corrected to the spec name in a separate commit.

## Verification

Every advertised `refreshSupport` capability in `kotlin_language_server.py` now has a matching handler:

```
advertised refreshSupport: ['codeLens', 'semanticTokens', 'inlineValue', 'inlayHint', 'diagnostics']
registered handlers      : ['diagnostic', 'inlayHint', 'inlineValue', 'semanticTokens', 'codeLens']
MISSING: none
```

And no `workspace/*/refresh` handler anywhere in `src/solidlsp/language_servers/` names a method that is absent from the LSP 3.17 spec — checked against the official `metaModel.json`, which lists exactly:

```
workspace/codeLens/refresh      workspace/diagnostic/refresh
workspace/foldingRange/refresh  workspace/inlayHint/refresh
workspace/inlineValue/refresh   workspace/semanticTokens/refresh
```

## Scope

Two files, 13 added / 1 removed lines, split into two focused commits. No behaviour change beyond answering the refresh requests. No public API, capability declaration or configuration is touched.
