### PR TITLE
fix(gitignore): escape directory names before interpolating into pattern position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * General:
   - Fix: Race conditions in ProjectServer when used by multiple clients in parallel   
+  - Fix: `GitignoreParser` interpolated a directory's name unescaped into gitignore pattern position;
+    a directory named with pattern metacharacters (e.g. a stray `***`) could turn a scoped pattern
+    into one matching far more than intended, silently excluding most or all of the project from
+    indexing #1806
+  - Fix: the README, the Language Support docs page and the project template omitted several already-supported language servers
   - Fix: a tool call exceeding the timeout blocked the task executor indefinitely; the executor now
     recovers without user-induced cancellation
   - Add Grok Build support (context `grok`, setup CLI, hooks)

--- a/src/serena/util/file_system.py
+++ b/src/serena/util/file_system.py
@@ -236,15 +236,20 @@ class GitignoreParser:
         """
         patterns = []
 
-        # Get the relative path from repo root to the gitignore directory
-        rel_dir = os.path.relpath(gitignore_dir, self.repo_root)
+        # Get the relative path from repo root to the gitignore directory. Normalize to
+        # forward slashes immediately: os.path.relpath returns native separators, but
+        # gitignore/pathspec patterns are always POSIX-style, and on Windows os.sep is
+        # backslash -- the same character pathspec uses as its escape character. Building
+        # the pattern with any raw os.sep would make a later blanket backslash->slash
+        # normalization indistinguishable from the escape backslashes below.
+        rel_dir = os.path.relpath(gitignore_dir, self.repo_root).replace(os.sep, "/")
         if rel_dir == ".":
             rel_dir = ""
 
         # rel_dir is a filesystem path, but the code below interpolates it into pattern
         # position; escape each of its components so a directory name containing pattern
         # metacharacters (e.g. "***") is matched literally instead of as glob syntax.
-        rel_dir_pattern = os.sep.join(_escape_gitignore_path_component(part) for part in rel_dir.split(os.sep)) if rel_dir else rel_dir
+        rel_dir_pattern = "/".join(_escape_gitignore_path_component(part) for part in rel_dir.split("/")) if rel_dir else rel_dir
 
         for line in content.splitlines():
             # Strip trailing whitespace (but preserve leading whitespace for now)
@@ -274,20 +279,23 @@ class GitignoreParser:
             if is_anchored:
                 line = line[1:]
 
-            # Adjust pattern based on gitignore file location
+            # Adjust pattern based on gitignore file location. Joined with a literal "/",
+            # never os.path.join/os.sep: gitignore patterns are always POSIX-style, and on
+            # Windows os.sep is backslash, indistinguishable from the escape backslashes
+            # rel_dir_pattern may already contain.
             if rel_dir:
                 if is_anchored:
                     # Anchored patterns are relative to the gitignore directory
-                    adjusted_pattern = os.path.join(rel_dir_pattern, line)
+                    adjusted_pattern = f"{rel_dir_pattern}/{line}"
                 else:
                     # Non-anchored patterns can match anywhere below the gitignore directory
                     # We need to preserve this behavior
                     if line.startswith("**/"):
                         # Even if pattern starts with **, it should still be scoped to the subdirectory
-                        adjusted_pattern = os.path.join(rel_dir_pattern, line)
+                        adjusted_pattern = f"{rel_dir_pattern}/{line}"
                     else:
                         # Add the directory prefix but also allow matching in subdirectories
-                        adjusted_pattern = os.path.join(rel_dir_pattern, "**", line)
+                        adjusted_pattern = f"{rel_dir_pattern}/**/{line}"
             else:
                 if is_anchored:
                     # Anchored patterns in root should only match at root level
@@ -300,9 +308,6 @@ class GitignoreParser:
             # Re-add negation if needed
             if is_negation:
                 adjusted_pattern = "!" + adjusted_pattern
-
-            # Normalize path separators to forward slashes (gitignore uses forward slashes)
-            adjusted_pattern = adjusted_pattern.replace(os.sep, "/")
 
             patterns.append(adjusted_pattern)
 

--- a/src/serena/util/file_system.py
+++ b/src/serena/util/file_system.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -10,6 +11,18 @@ from pathspec import PathSpec
 from sensai.util.logging import LogTime
 
 log = logging.getLogger(__name__)
+
+# Characters meaningful to pathspec's gitignore grammar: glob wildcards, bracket expressions,
+# the escape character itself, and '!'/'#' which change a whole pattern's meaning when they
+# are its first character. Backslash-escaping them makes a literal name safe to interpolate.
+_GITIGNORE_PATTERN_SPECIAL_CHARS_RE = re.compile(r"([\\*?\[\]!#])")
+
+
+def _escape_gitignore_path_component(component: str) -> str:
+    """Escape gitignore/pathspec pattern metacharacters in a single path component (no
+    separators) so it is matched as a literal name rather than as glob syntax.
+    """
+    return _GITIGNORE_PATTERN_SPECIAL_CHARS_RE.sub(r"\\\1", component)
 
 
 class ScanResult(NamedTuple):
@@ -228,6 +241,11 @@ class GitignoreParser:
         if rel_dir == ".":
             rel_dir = ""
 
+        # rel_dir is a filesystem path, but the code below interpolates it into pattern
+        # position; escape each of its components so a directory name containing pattern
+        # metacharacters (e.g. "***") is matched literally instead of as glob syntax.
+        rel_dir_pattern = os.sep.join(_escape_gitignore_path_component(part) for part in rel_dir.split(os.sep)) if rel_dir else rel_dir
+
         for line in content.splitlines():
             # Strip trailing whitespace (but preserve leading whitespace for now)
             line = line.rstrip()
@@ -260,16 +278,16 @@ class GitignoreParser:
             if rel_dir:
                 if is_anchored:
                     # Anchored patterns are relative to the gitignore directory
-                    adjusted_pattern = os.path.join(rel_dir, line)
+                    adjusted_pattern = os.path.join(rel_dir_pattern, line)
                 else:
                     # Non-anchored patterns can match anywhere below the gitignore directory
                     # We need to preserve this behavior
                     if line.startswith("**/"):
                         # Even if pattern starts with **, it should still be scoped to the subdirectory
-                        adjusted_pattern = os.path.join(rel_dir, line)
+                        adjusted_pattern = os.path.join(rel_dir_pattern, line)
                     else:
                         # Add the directory prefix but also allow matching in subdirectories
-                        adjusted_pattern = os.path.join(rel_dir, "**", line)
+                        adjusted_pattern = os.path.join(rel_dir_pattern, "**", line)
             else:
                 if is_anchored:
                     # Anchored patterns in root should only match at root level

--- a/test/serena/util/test_file_system.py
+++ b/test/serena/util/test_file_system.py
@@ -1,11 +1,13 @@
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 
+import pytest
 from pathspec import PathSpec
 
-from serena.util.file_system import GitignoreParser, GitignoreSpec, match_path
+from serena.util.file_system import GitignoreParser, GitignoreSpec, _escape_gitignore_path_component, match_path
 
 
 class TestGitignoreParser:
@@ -715,6 +717,7 @@ src/*.o
         # foo.txt in other/ should NOT be ignored (outside foo/ subtree)
         assert not parser.should_ignore("other/foo.txt"), "other/foo.txt should NOT be ignored by foo/.gitignore"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="'*' is illegal in Windows filenames; this directory name cannot exist there")
     def test_gitignore_dir_name_with_glob_metachars_is_not_a_wildcard(self):
         """A directory named with glob metacharacters (e.g. a stray '***' venv) must be
         matched literally, not interpreted as a pattern (issue #1806).
@@ -756,6 +759,7 @@ src/*.o
         assert not parser.should_ignore("pkg/mod.py"), "pkg/mod.py should not be ignored by a[1]/.gitignore"
         assert parser.should_ignore("a[1]/mod.py"), "a[1]/mod.py should be ignored by its own /mod.py pattern"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="'?' is illegal in Windows filenames; this directory name cannot exist there")
     def test_gitignore_dir_name_with_metachars_implicit_double_star_pattern(self):
         """A non-anchored pattern with no leading '**/' is joined as (rel_dir, "**", line):
         the third join site. An unescaped '?' in the directory name would leak the pattern
@@ -777,6 +781,16 @@ src/*.o
         # "q?/.gitignore" must not reach into the sibling "qA/" directory just because "?"
         # would match the "A" in "qA" if left as a wildcard.
         assert not parser.should_ignore("qA/sub/mod.py"), "qA/sub/mod.py should not be ignored by q?/.gitignore"
+
+    def test_escape_gitignore_path_component_escapes_all_metachars(self):
+        """Pure-function coverage for the '*' and '?' escaping cases the two directory-creation
+        tests above cannot exercise on Windows (those characters are illegal in Windows
+        filenames, so this runs on every platform instead of touching the filesystem).
+        """
+        assert _escape_gitignore_path_component("***") == "\\*\\*\\*"
+        assert _escape_gitignore_path_component("q?") == "q\\?"
+        assert _escape_gitignore_path_component("a[1]") == "a\\[1\\]"
+        assert _escape_gitignore_path_component("plain") == "plain"
 
 
 class TestGitignoreParserPermissionError:

--- a/test/serena/util/test_file_system.py
+++ b/test/serena/util/test_file_system.py
@@ -715,6 +715,69 @@ src/*.o
         # foo.txt in other/ should NOT be ignored (outside foo/ subtree)
         assert not parser.should_ignore("other/foo.txt"), "other/foo.txt should NOT be ignored by foo/.gitignore"
 
+    def test_gitignore_dir_name_with_glob_metachars_is_not_a_wildcard(self):
+        """A directory named with glob metacharacters (e.g. a stray '***' venv) must be
+        matched literally, not interpreted as a pattern (issue #1806).
+        """
+        test_dir = self.repo_path / "test_metachar_dirname"
+        test_dir.mkdir()
+        (test_dir / "pkg").mkdir()
+        (test_dir / "***").mkdir()
+
+        (test_dir / "pkg" / "mod.py").touch()
+        (test_dir / "***" / "junk.txt").touch()
+
+        gitignore = test_dir / "***" / ".gitignore"
+        gitignore.write_text("*\n")
+
+        parser = GitignoreParser(str(test_dir))
+
+        # pkg/mod.py is outside the "***" directory and must not be affected by its gitignore
+        assert not parser.should_ignore("pkg/mod.py"), "pkg/mod.py should not be ignored by ***/.gitignore"
+
+        # junk.txt inside "***" is still ignored by its own gitignore's "*" pattern
+        assert parser.should_ignore("***/junk.txt"), "***/junk.txt should be ignored by its own gitignore"
+
+    def test_gitignore_dir_name_with_metachars_anchored_pattern(self):
+        """Same as above, for the anchored-pattern join site."""
+        test_dir = self.repo_path / "test_metachar_dirname_anchored"
+        test_dir.mkdir()
+        (test_dir / "pkg").mkdir()
+        (test_dir / "a[1]").mkdir()
+
+        (test_dir / "pkg" / "mod.py").touch()
+        (test_dir / "a[1]" / "mod.py").touch()
+
+        gitignore = test_dir / "a[1]" / ".gitignore"
+        gitignore.write_text("/mod.py\n")
+
+        parser = GitignoreParser(str(test_dir))
+
+        assert not parser.should_ignore("pkg/mod.py"), "pkg/mod.py should not be ignored by a[1]/.gitignore"
+        assert parser.should_ignore("a[1]/mod.py"), "a[1]/mod.py should be ignored by its own /mod.py pattern"
+
+    def test_gitignore_dir_name_with_metachars_implicit_double_star_pattern(self):
+        """A non-anchored pattern with no leading '**/' is joined as (rel_dir, "**", line):
+        the third join site. An unescaped '?' in the directory name would leak the pattern
+        into a sibling directory whose name merely matches the wildcard (issue #1806).
+        """
+        test_dir = self.repo_path / "test_metachar_dirname_implicit_doublestar"
+        test_dir.mkdir()
+        (test_dir / "q?").mkdir()
+        (test_dir / "qA").mkdir()
+        (test_dir / "qA" / "sub").mkdir()
+
+        (test_dir / "qA" / "sub" / "mod.py").touch()
+
+        gitignore = test_dir / "q?" / ".gitignore"
+        gitignore.write_text("mod.py\n")
+
+        parser = GitignoreParser(str(test_dir))
+
+        # "q?/.gitignore" must not reach into the sibling "qA/" directory just because "?"
+        # would match the "A" in "qA" if left as a wildcard.
+        assert not parser.should_ignore("qA/sub/mod.py"), "qA/sub/mod.py should not be ignored by q?/.gitignore"
+
 
 class TestGitignoreParserPermissionError:
     """Test PermissionError handling in GitignoreParser."""


### PR DESCRIPTION
## Root cause

`GitignoreParser._parse_gitignore_content` rescopes patterns from a nested `.gitignore` by
joining the gitignore directory's relative path (`rel_dir`) onto each pattern line (three
join sites, `src/serena/util/file_system.py:263,269,272` at HEAD `29d07d4f`). `rel_dir` comes
from `os.path.relpath` and is a filesystem name, but it lands directly in pattern position,
where `pathspec`'s `GitWildMatchPattern` reads `*`, `?`, `[`, `]`, `!` and `#` as syntax rather
than literal characters.

A directory whose name contains one of those characters (the concrete case in the issue: a
stray venv literally named `***`, whose own `.gitignore` is just `*`) turns a scoped pattern
into a much broader one: `***/**/*` reads as "any first segment, then anything at depth >= 2",
so it ends up excluding nearly the whole project. Indexing then reports 0 files with exit code
0, and nothing points at the actual cause.

## Invariant

A pattern segment built from a filesystem name must match that name literally, never as glob
syntax. The fix escapes each path component of `rel_dir` (backslash before `\ * ? [ ] ! #`,
following `pathspec`'s own escaping convention) at all three join sites before it is folded
into the pattern string, so directory names are always matched literally regardless of their
content.

## Verification

- Added three regression tests in `test/serena/util/test_file_system.py`, one per join site
  (anchored, `**/`-prefixed non-anchored, and the implicit-`**` non-anchored case), plus the
  issue's own `***` scenario. Ran in a clean `python:3.11-slim` container against HEAD
  `29d07d4f`: all three fail on unmodified `main` and pass on this branch.
- `uv run poe test test/serena/util/test_file_system.py`: 27/27 pass (24 existing + 3 new).
- `uv run poe lint` and `uv run poe type-check`: clean. `codespell` on the changed files: clean.
- Not run: the full CI matrix (language-server batches across ubuntu/windows/macos) and
  `test/serena/util/test_exception.py`'s three pre-existing GUI-dependent failures, which are
  unrelated to this change and reproduce identically on unmodified `main` in this container.

Fixes #1806

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.



## Update (second commit)

The initial Windows CI run (before any review) failed 3 new tests, not the 3 unrelated
pre-existing flakes documented above: `test_gitignore_dir_name_with_metachars_anchored_pattern`
failed with a real `AssertionError` (not the platform-limitation `OSError` the other two
metachar tests hit for `*`/`?`, which are illegal in Windows filenames). Root cause: the
escaping added above inserts literal backslash escape characters, and on Windows `os.sep` is
also backslash, so `os.path.join(rel_dir_pattern, line)` mixed path-separator backslashes with
escape backslashes; the pre-existing trailing `.replace(os.sep, "/")` then converted all of
them indiscriminately, turning an escaped `a\\[1\\]` into `a/[1/]`, which no longer matches
the literal directory name.

Fixed by building every pattern with a literal `/` from the start (never `os.sep`/
`os.path.join`), and removing the now-unneeded (and on Windows actively harmful) blanket
separator replace. Verified with `ntpath` (Windows path semantics) on this Linux session:
simulating the old chain on a Windows-style relpath produces `a/[1/]/mod.py` (does not match
`a[1]/mod.py` via `pathspec`); the new construction produces `a\\[1\\]/mod.py` (matches).
The two tests that create a directory literally named `***`/`q?` are marked
`skipif(sys.platform == "win32")` (those characters can't exist in a Windows filename, a test
limitation, not a fix limitation); added a pure-function test for
`_escape_gitignore_path_component` so that escaping logic keeps cross-platform coverage without
touching the filesystem.
