### PR TITLE
More liberal handling of ignored paths in file access tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ Status of the `main` branch. Changes prior to the next official version change w
 * Tools:
   - `find_symbol`, `jet_brains_find_symbol`: Change tool description to improve tool search results in clients that load tools dynamically
   - `get_current_config`: Result now includes language server status #1782
+  - More liberal handling of ignored paths in file access tools:
+    - Tools that explicitly target a single file (`create_text_file`, `read_file`, `replace_content`) no longer 
+      consider ignored paths in general, i.e. all files can be accessed. 
+      When a path is explicitly accessed, we should not try to prevent it; the agent is assumed to have a good reason 
+      for doing so.
+    - Tools that traverse a subtree of the project (`list_dir`, `find_file`, `search_for_pattern`) now all have an 
+      option `skip_ignored_files` (whether to skip ignored sub-paths).
+      Note that if the base path is itself ignored, ignored paths cannot be considered.
 
 * Language Servers: 
   - Allow language server priorities to be configured in `serena_config.yml` (for auto-detection during 

--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -277,6 +278,19 @@ class Project(ToStringMixin):
 
         return self._is_ignored_relative_path(str(relative_path), ignore_non_source_files=ignore_non_source_files)
 
+    def get_is_ignored_path_fn(self, base_path: str, skip_ignored_paths: bool) -> Callable[[str], bool]:
+        """
+        Returns a function for checking whether a path should be ignored during a traversal of the given base path.
+
+        :param base_path: the relative base path representing the starting point of the traversal.
+            If the path is itself ignored, then the returned function will not consider ignored paths.
+        :param skip_ignored_paths: whether to skip ignored (sub-)paths
+        :return: a function that takes a path and returns True if the path should be ignored, False otherwise.
+        """
+        if not skip_ignored_paths or self.is_ignored_path(base_path):
+            return lambda _: False
+        return self.is_ignored_path
+
     def is_path_in_project(self, path: str | Path) -> bool:
         """
         Checks if the given (absolute or relative) path is inside the project directory.
@@ -328,7 +342,7 @@ class Project(ToStringMixin):
 
         if require_not_ignored:
             if self.is_ignored_path(relative_path):
-                raise ValueError(f"Path {relative_path} is ignored; cannot access for safety reasons")
+                raise ValueError(f"Path {relative_path} is ignored")
 
     def gather_source_files(self, relative_path: str = "") -> list[str]:
         """Retrieves relative paths of all source files, optionally limited to the given path
@@ -367,7 +381,15 @@ class Project(ToStringMixin):
                         )
             return rel_file_paths
 
-    def _create_file_collection(self, relative_path: str, code_files_only: bool) -> FileCollection:
+    def _create_file_collection(self, relative_path: str, *, code_files_only: bool, skip_ignored_files: bool) -> FileCollection:
+        """
+        Creates the file collection for the given relative path.
+
+        :param relative_path: the relative path to create the file collection for, relative to the project root
+        :param code_files_only: whether to include only (non-ignored) code files
+        :param skip_ignored_files: whether to skip ignored files; has no effect if `code_files_only` is True
+        :return:
+        """
         if FileProxy.is_external_path(relative_path):
             # single external path: create appropriate proxy
             file_collection = FileCollection([FileProxy.from_project_relative_path(self, relative_path)])
@@ -385,11 +407,12 @@ class Project(ToStringMixin):
                 if os.path.isfile(abs_path):
                     rel_paths_to_search = [relative_path]
                 else:
+                    is_ignored_path_fn = self.get_is_ignored_path_fn(base_path=relative_path, skip_ignored_paths=skip_ignored_files)
                     _dirs, rel_paths_to_search = scan_directory(
                         path=abs_path,
                         recursive=True,
-                        is_ignored_dir=self.is_ignored_path,
-                        is_ignored_file=self.is_ignored_path,
+                        is_ignored_dir=is_ignored_path_fn,
+                        is_ignored_file=is_ignored_path_fn,
                         relative_to=self.project_root,
                     )
                 file_collection = FileCollection.from_local_project_paths(rel_paths_to_search, self)
@@ -405,20 +428,34 @@ class Project(ToStringMixin):
         paths_exclude_glob: str | None = None,
         multiline: bool = True,
         code_files_only: bool = True,
+        skip_ignored_files: bool = True,
     ) -> list[MatchedConsecutiveLines]:
         """
         Search for a pattern across all (non-ignored) source files
 
-        :param pattern: Regular expression pattern to search for, either as a compiled Pattern or string
-        :param relative_path:
-        :param context_lines_before: Number of lines of context to include before each match
-        :param context_lines_after: Number of lines of context to include after each match
-        :param paths_include_glob: Glob pattern to filter which files to include in the search
-        :param paths_exclude_glob: Glob pattern to filter which files to exclude from the search. Takes precedence over paths_include_glob.
-        :param multiline: Whether to compile the regex with the DOTALL flag (``.`` matches newlines).
-        :return: List of matched consecutive lines with context
+        :param pattern: regular expression pattern to search for, either as a compiled Pattern or string
+        :param relative_path: the relative path to search in, relative to the project root; if empty, search in the entire project
+        :param context_lines_before: number of lines of context to include before each match
+        :param context_lines_after: number of lines of context to include after each match
+        :param paths_include_glob: glob pattern to filter which files to include in the search
+        :param paths_exclude_glob: glob pattern to filter which files to exclude from the search. Takes precedence over paths_include_glob.
+        :param multiline: whether to compile the regex with the DOTALL flag (`.` matches newlines).
+        :param code_files_only: whether to include only (non-ignored) code files
+        :param skip_ignored_files: whether to skip ignored files; has no effect if `code_files_only` is True
+        :return: list of matches
         """
-        file_collection = self._create_file_collection(relative_path, code_files_only)
+        file_collection = self._create_file_collection(
+            relative_path, code_files_only=code_files_only, skip_ignored_files=skip_ignored_files
+        )
+        return search_files(
+            file_collection,
+            pattern,
+            context_lines_before=context_lines_before,
+            context_lines_after=context_lines_after,
+            paths_include_glob=paths_include_glob,
+            paths_exclude_glob=paths_exclude_glob,
+            multiline=multiline,
+        )
         return search_files(
             file_collection,
             pattern,

--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -40,7 +40,7 @@ class ReadFileTool(Tool):
             required for the task.
         :return: the full text of the file at the given relative path
         """
-        self.project.validate_relative_path(relative_path, require_not_ignored=True)
+        self.project.validate_relative_path(relative_path)
 
         # read lines, using the same (LSP-compliant) notion of line breaks as the line-based editing tools
         result = self.project.read_file(relative_path)
@@ -75,7 +75,7 @@ class CreateTextFileTool(EditingToolWithDiagnostics):
             will_overwrite_existing = abs_path.exists()
 
             if will_overwrite_existing:
-                self.project.validate_relative_path(relative_path, require_not_ignored=True)
+                self.project.validate_relative_path(relative_path)
             else:
                 assert abs_path.is_relative_to(self.get_project_root()), (
                     f"Cannot create file outside of the project directory, got {relative_path=}"
@@ -117,14 +117,15 @@ class ListDirTool(Tool):
             }
             return self._to_json(error_info)
 
-        self.project.validate_relative_path(relative_path, require_not_ignored=skip_ignored_files)
+        self.project.validate_relative_path(relative_path)
 
+        is_ignored_path_fn = self.project.get_is_ignored_path_fn(relative_path, skip_ignored_files)
         dirs, files = scan_directory(
             os.path.join(self.get_project_root(), relative_path),
             relative_to=self.get_project_root(),
             recursive=recursive,
-            is_ignored_dir=self.project.is_ignored_path if skip_ignored_files else None,
-            is_ignored_file=self.project.is_ignored_path if skip_ignored_files else None,
+            is_ignored_dir=is_ignored_path_fn,
+            is_ignored_file=is_ignored_path_fn,
         )
 
         result = self._to_json({"dirs": dirs, "files": files})
@@ -138,19 +139,21 @@ class FindFileTool(Tool):
 
     def apply(self, file_mask: str, relative_path: str) -> str:
         """
-        Finds non-gitignored files matching the given file mask within the given relative path
+        Finds files matching the given file mask within the given relative path
 
         :param file_mask: the filename or file mask (using the wildcards * or ?) to search for
         :param relative_path: the relative path to the directory to search in; pass "." to scan the project root
+        :param skip_ignored_files: whether to skip ignored files/directories
         :return: a JSON object with the list of matching files
         """
-        self.project.validate_relative_path(relative_path, require_not_ignored=True)
+        self.project.validate_relative_path(relative_path)
 
+        is_ignored_path_fn = self.project.get_is_ignored_path_fn(relative_path, skip_ignored_paths=False)
         dir_to_scan = os.path.join(self.get_project_root(), relative_path)
 
         # find the files by ignoring everything that doesn't match
         def is_ignored_file(abs_path: str) -> bool:
-            if self.project.is_ignored_path(abs_path):
+            if is_ignored_path_fn(abs_path):
                 return True
             filename = os.path.basename(abs_path)
             return not fnmatch(filename, file_mask)
@@ -158,7 +161,7 @@ class FindFileTool(Tool):
         _dirs, files = scan_directory(
             path=dir_to_scan,
             recursive=True,
-            is_ignored_dir=self.project.is_ignored_path,
+            is_ignored_dir=is_ignored_path_fn,
             is_ignored_file=is_ignored_file,
             relative_to=self.get_project_root(),
         )
@@ -202,25 +205,8 @@ class ReplaceContentTool(EditingToolWithDiagnostics):
         :param allow_multiple_occurrences: whether to allow matching and replacing multiple occurrences.
             If false and multiple occurrences are found, an error will be returned
         """
-        return self.replace_content(
-            relative_path, needle, repl, mode=mode, allow_multiple_occurrences=allow_multiple_occurrences, require_not_ignored=True
-        )
-
-    def replace_content(
-        self,
-        relative_path: str,
-        needle: str,
-        repl: str,
-        mode: Literal["literal", "regex"],
-        allow_multiple_occurrences: bool = False,
-        require_not_ignored: bool = True,
-    ) -> str:
-        """
-        Performs the replacement, with additional options not exposed in the tool.
-        This function can be used internally by other tools.
-        """
         with self.DiagnosticsContext(self, relative_path) as diagnostics_context:
-            self.project.validate_relative_path(relative_path, require_not_ignored=require_not_ignored)
+            self.project.validate_relative_path(relative_path)
             with EditedFileContext(relative_path, self.create_code_editor()) as context:
                 original_content = context.get_original_content()
                 replacer = ContentReplacer(mode=mode, allow_multiple_occurrences=allow_multiple_occurrences)
@@ -555,10 +541,6 @@ class InsertAtLineTool(EditingToolWithDiagnostics, ToolMarkerOptional):
 
 
 class SearchForPatternTool(Tool):
-    """
-    Performs a search for a pattern in the project.
-    """
-
     def apply(
         self,
         substring_pattern: str,
@@ -568,6 +550,7 @@ class SearchForPatternTool(Tool):
         paths_exclude_glob: str = "",
         relative_path: str = "",
         restrict_search_to_code_files: bool = False,
+        skip_ignored_files: bool = True,
         multiline: bool = True,
         max_answer_chars: int = -1,
     ) -> str:
@@ -581,8 +564,9 @@ class SearchForPatternTool(Tool):
         :param paths_include_glob: optional glob (relative to project root, e.g. ``"src/**/*.ts"``) restricting which files are searched.
         :param paths_exclude_glob: optional glob to exclude files; takes precedence over `paths_include_glob`.
         :param relative_path: restricts the search to this file or subdirectory of the project root
-        :param restrict_search_to_code_files: whether to search only files containing analyzable code symbols
+        :param restrict_search_to_code_files: whether to search only (non-ignored) files containing analyzable code symbols
             (useful when looking for class/method definitions); otherwise also search non-code files.
+        :param skip_ignored_files: whether to skip ignored sub-paths (default: True)
         :param multiline: whether to apply multi-line matching (default: True), enabling the flags re.DOTALL and re.MULTILINE
         :param max_answer_chars: if the output exceeds this many characters, a progressively shortened summary is returned instead.
             ``-1`` uses the configured default.
@@ -590,7 +574,7 @@ class SearchForPatternTool(Tool):
         """
         relative_path = relative_path.strip()
         if relative_path:
-            self.project.validate_relative_path(relative_path, require_not_ignored=True)
+            self.project.validate_relative_path(relative_path)
 
         matches = self.project.search_project_files_for_pattern(
             pattern=substring_pattern,
@@ -601,6 +585,7 @@ class SearchForPatternTool(Tool):
             paths_exclude_glob=paths_exclude_glob.strip(),
             multiline=multiline,
             code_files_only=restrict_search_to_code_files,
+            skip_ignored_files=skip_ignored_files,
         )
 
         # group matches by file
@@ -672,3 +657,7 @@ class SearchForPatternTool(Tool):
                 make_summary,
             ],
         )
+
+    """
+    Performs a search for a pattern in the project.
+    """


### PR DESCRIPTION
 - Tools that explicitly target a single file (`create_text_file`, `read_file`, `replace_content`) no longer consider ignored paths in general, i.e. all files can be accessed. When a path is explicitly accessed, we should not try to prevent it; the agent is assumed to have a good reason for doing so.
 - Tools that traverse a subtree of the project (`list_dir`, `find_file`, `search_for_pattern`) now all have an option `skip_ignored_files` (whether to skip ignored sub-paths). Note that if the base path is itself ignored, ignored paths cannot be considered.

Resolves #1805