### PR TITLE
fix(nix): use published diagnostics for nixd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     project creation) 
   - Add `python_basedpyright` as an alternative Python language server
   - Nix/nixd: support custom `ls_path` launchers and external JSON settings through `config_path` #1737
+  - Fix: Nix/nixd diagnostics now use published diagnostics instead of the unsupported
+    `textDocument/diagnostic` request, which terminated nixd #1802
   - Fix: `get_diagnostics_for_file` crashed with `SolidLSPException` for any Ansible file with at least
     one lint finding, because `ansible-language-server` doesn't implement `textDocument/documentSymbol`
     and the request used to map diagnostics onto owning symbols just threw. `AnsibleLanguageServer` now

--- a/src/solidlsp/language_servers/nixd_ls.py
+++ b/src/solidlsp/language_servers/nixd_ls.py
@@ -378,6 +378,12 @@ class NixLanguageServer(SolidLanguageServer):
         }
         return initialize_params
 
+    @override
+    def _supports_pull_diagnostics(self) -> bool:
+        # nixd publishes diagnostics after textDocument/didOpen but terminates when it receives
+        # textDocument/diagnostic. Force the published-diagnostics path instead.
+        return False
+
     def _start_server(self):
         """Start nixd server process"""
         initialize_params = self._create_initialize_params()

--- a/test/solidlsp/nix/test_nix_basic.py
+++ b/test/solidlsp/nix/test_nix_basic.py
@@ -259,3 +259,4 @@ class TestNixLanguageServer:
             (),
             min_count=1,
         )
+        assert language_server.is_running()


### PR DESCRIPTION
## Summary

- use published diagnostics for nixd instead of sending the unsupported `textDocument/diagnostic` request
- extend the Nix diagnostics regression test to confirm nixd remains running
- document the fix in the changelog

## Root cause

nixd publishes diagnostics after `textDocument/didOpen`, but terminates when Serena sends `textDocument/diagnostic`. The generic diagnostics fallback previously masked that termination; the fix for #1770 correctly exposed it. This change preserves termination propagation globally and selects the published-diagnostics path only for nixd.

Fixes #1802.

## Validation

- `CI=true .venv/bin/pytest test/solidlsp/nix/test_nix_basic.py -vv` (`12 passed, 1 xfailed`)
- `.venv/bin/ty check src/serena src/solidlsp`
- `.venv/bin/ty check test --exclude test/resources`
- `.venv/bin/ruff check src/solidlsp/language_servers/nixd_ls.py test/solidlsp/nix/test_nix_basic.py`
- `.venv/bin/ruff format --check src/solidlsp/language_servers/nixd_ls.py test/solidlsp/nix/test_nix_basic.py`
- `git diff --check`

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that fix problems, I added a concise entry to `CHANGELOG.md`.
