### PR TITLE
Force the Nextflow server's deferred workspace scan before finding references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,12 +46,6 @@ Status of the `main` branch. Changes prior to the next official version change w
   - **Add support for Nextflow** (language server `nextflow`), using the official
     [Nextflow language server](https://github.com/nextflow-io/language-server); the JAR is downloaded
     automatically, a Java 17+ runtime is required
-  - `nextflow`: Fix: `find_referencing_symbols`/`request_references` returned an empty list for any
-    symbol during the first seconds of a session. The server defers its workspace scan behind a 1s
-    debounce and re-defers it whenever a file change is pending, so the very first `didOpen` pushed the
-    scan out past the reference request, which then saw an AST cache holding only the file it had just
-    opened. Cross-file requests now force the scan via the server's own synchronous update path, so they
-    are correct regardless of workspace size.
   - Add `python_basedpyright` as an alternative Python language server
   - Java/JDTLS: stop downloading and loading the unused IntelliCode completion-ranking bundle; the retired
     `intellicode_version`, `intellicode_xmx` and `intellicode_xms` settings remain accepted but are ignored #1821

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ Status of the `main` branch. Changes prior to the next official version change w
   - **Add support for Nextflow** (language server `nextflow`), using the official
     [Nextflow language server](https://github.com/nextflow-io/language-server); the JAR is downloaded
     automatically, a Java 17+ runtime is required
+  - `nextflow`: Fix: `find_referencing_symbols`/`request_references` returned an empty list for any
+    symbol during the first seconds of a session. The server defers its workspace scan behind a 1s
+    debounce and re-defers it whenever a file change is pending, so the very first `didOpen` pushed the
+    scan out past the reference request, which then saw an AST cache holding only the file it had just
+    opened. Cross-file requests now force the scan via the server's own synchronous update path, so they
+    are correct regardless of workspace size.
   - Add `python_basedpyright` as an alternative Python language server
   - Java/JDTLS: stop downloading and loading the unused IntelliCode completion-ranking bundle; the retired
     `intellicode_version`, `intellicode_xmx` and `intellicode_xms` settings remain accepted but are ignored #1821

--- a/src/solidlsp/language_servers/nextflow_language_server.py
+++ b/src/solidlsp/language_servers/nextflow_language_server.py
@@ -88,6 +88,10 @@ class NextflowLanguageServer(SolidLanguageServer):
         self._active_progress_tokens: set[str] = set()
         self._progress_lock = threading.Lock()
 
+        # Whether the server's deferred workspace scan has been observed to complete
+        # (see _flush_deferred_workspace_scan).
+        self._workspace_scan_flushed = False
+
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
         return self.DependencyProvider(self._custom_settings, self._ls_resources_dir)
 
@@ -297,6 +301,46 @@ class NextflowLanguageServer(SolidLanguageServer):
         else:
             log.warning("Nextflow LS did not signal scan completion within %.0fs; proceeding anyway", _WORKSPACE_SCAN_TIMEOUT)
 
+    def _flush_deferred_workspace_scan(self, relative_file_path: str) -> None:
+        """
+        Forces the server to scan the workspace, which it does not do when it appears to.
+
+        ``LanguageService.initialize`` (which the "Initializing" progress notification wraps) only marks
+        the workspace as unscanned; the scan itself happens in ``LanguageService.update0``, behind a 1s
+        debounce, and *only* on a round where no file change is pending -- a round that finds pending
+        changes re-defers it via ``updateLater``. The first ``didOpen`` of a session therefore pushes the
+        scan out by at least one further round, so a references request issued right after it sees an AST
+        cache holding nothing but the file it just opened, and answers with an empty list.
+
+        ``completion`` is one of the two requests that call ``updateNow`` before consulting their provider,
+        and ``DebouncingExecutor.executeNow`` cancels the pending debounce and runs the update synchronously
+        on the request thread, so the response is not sent until that round has finished. Two rounds suffice
+        whatever the workspace size: the first drains the pending file changes -- which is what re-defers
+        the scan -- and the second finds nothing pending, so it takes the ``getWorkspaceFiles`` branch and
+        compiles the whole workspace before replying.
+
+        Waiting on the workspace symbol index instead would be unsound: ``LanguageService.symbol`` neither
+        awaits the update nor holds the monitor that ``update`` synchronises on, so once a workspace is big
+        enough for the scan to outlast a poll interval, a poll can observe a half-populated cache and
+        conclude the scan is done while files are still being compiled.
+
+        The completion results are discarded; only the barrier matters, and it is reached before the
+        provider runs, so even a provider-side failure leaves the workspace scanned.
+        """
+        if self._workspace_scan_flushed:
+            return
+
+        params: lsp_types.CompletionParams = {
+            "textDocument": {"uri": self._resolve_file_uri(relative_file_path)},
+            "position": {"line": 0, "character": 0},
+        }
+        for _ in range(2):
+            try:
+                self.server.send.completion(params)
+            except Exception as e:
+                log.debug("Completion request used to flush the Nextflow workspace scan failed: %s", e)
+        self._workspace_scan_flushed = True
+
     @override
     def _send_references_request(self, relative_file_path: str, line: int, column: int) -> list[lsp_types.Location] | None:
         """
@@ -309,13 +353,14 @@ class NextflowLanguageServer(SolidLanguageServer):
         come back empty. Sending a ``documentSymbol`` request for the same file first is a cheap way to
         block until the update has been applied.
         """
+        self._flush_deferred_workspace_scan(relative_file_path)
         self.server.send.document_symbol({"textDocument": {"uri": self._resolve_file_uri(relative_file_path)}})
         return super()._send_references_request(relative_file_path, line, column)
 
     @override
     def _get_wait_time_for_cross_file_referencing(self) -> float:
-        """Small safety buffer; the actual synchronisation happens in _send_references_request."""
-        return 1.0
+        """No blind wait is needed: _send_references_request synchronises with the server explicitly."""
+        return 0.0
 
     @override
     def _document_symbols_cache_fingerprint(self) -> Hashable:

--- a/src/solidlsp/language_servers/nextflow_language_server.py
+++ b/src/solidlsp/language_servers/nextflow_language_server.py
@@ -303,29 +303,15 @@ class NextflowLanguageServer(SolidLanguageServer):
 
     def _flush_deferred_workspace_scan(self, relative_file_path: str) -> None:
         """
-        Forces the server to scan the workspace, which it does not do when it appears to.
+        Forces the workspace scan, which the server defers past the first request of a session.
 
-        ``LanguageService.initialize`` (which the "Initializing" progress notification wraps) only marks
-        the workspace as unscanned; the scan itself happens in ``LanguageService.update0``, behind a 1s
-        debounce, and *only* on a round where no file change is pending -- a round that finds pending
-        changes re-defers it via ``updateLater``. The first ``didOpen`` of a session therefore pushes the
-        scan out by at least one further round, so a references request issued right after it sees an AST
-        cache holding nothing but the file it just opened, and answers with an empty list.
+        The scan runs in ``LanguageService.update0`` behind a 1s debounce, and only on a round with no
+        pending file change; the session's first ``didOpen`` re-defers it, leaving references to be
+        answered from an AST cache holding just that one file.
 
-        ``completion`` is one of the two requests that call ``updateNow`` before consulting their provider,
-        and ``DebouncingExecutor.executeNow`` cancels the pending debounce and runs the update synchronously
-        on the request thread, so the response is not sent until that round has finished. Two rounds suffice
-        whatever the workspace size: the first drains the pending file changes -- which is what re-defers
-        the scan -- and the second finds nothing pending, so it takes the ``getWorkspaceFiles`` branch and
-        compiles the whole workspace before replying.
-
-        Waiting on the workspace symbol index instead would be unsound: ``LanguageService.symbol`` neither
-        awaits the update nor holds the monitor that ``update`` synchronises on, so once a workspace is big
-        enough for the scan to outlast a poll interval, a poll can observe a half-populated cache and
-        conclude the scan is done while files are still being compiled.
-
-        The completion results are discarded; only the barrier matters, and it is reached before the
-        provider runs, so even a provider-side failure leaves the workspace scanned.
+        ``completion`` calls ``updateNow``, which runs the update synchronously before replying, so two
+        such requests force the scan whatever the workspace size: the first drains the pending change,
+        the second finds none and scans. Their results are discarded.
         """
         if self._workspace_scan_flushed:
             return

--- a/test/solidlsp/nextflow/test_nextflow_basic.py
+++ b/test/solidlsp/nextflow/test_nextflow_basic.py
@@ -7,6 +7,7 @@ import pytest
 from solidlsp import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerId
 from solidlsp.ls_utils import SymbolUtils
+from test.conftest import start_default_ls_context
 
 pytestmark = pytest.mark.skipif(shutil.which("java") is None, reason="Nextflow language server requires a Java runtime")
 
@@ -71,6 +72,25 @@ class TestNextflowLanguageServer:
         ref_lines = self._reference_lines(refs)
         # main.nf, 0-indexed line 2: include { GREET; SHOUT } from './modules/greet/main.nf'
         assert ("main.nf", 2) in ref_lines, f"include of GREET in main.nf not found. Found: {ref_lines}"
+        # main.nf, 0-indexed line 12: greetings = GREET(names)
+        assert ("main.nf", 12) in ref_lines, f"invocation of GREET in main.nf not found. Found: {ref_lines}"
+
+    def test_find_references_across_files_on_a_fresh_server(self) -> None:
+        """Cross-file references must not depend on another request having opened the referencing file.
+
+        The module-scoped ``language_server`` fixture is shared, so by the time
+        ``test_find_references_across_files`` runs, earlier tests have already opened main.nf and thereby
+        forced the server to compile it. This test starts its own server and touches nothing but the
+        defining file, which is what a real session's first request looks like.
+        """
+        module_path = os.path.join("modules", "greet", "main.nf")
+        with start_default_ls_context(LanguageServerId.NEXTFLOW) as language_server:
+            symbol = self._get_symbol(language_server, module_path, "GREET")
+            start = symbol["selectionRange"]["start"]
+
+            refs = language_server.request_references(module_path, start["line"], start["character"])
+
+        ref_lines = self._reference_lines(refs)
         # main.nf, 0-indexed line 12: greetings = GREET(names)
         assert ("main.nf", 12) in ref_lines, f"invocation of GREET in main.nf not found. Found: {ref_lines}"
 


### PR DESCRIPTION
Follow-up to #1815. On a fresh server, `find_referencing_symbols` on any Nextflow symbol returned an empty list for the first seconds of a session.

### Cause

The Nextflow language server does not scan the workspace when it appears to. `LanguageService.initialize` — which the `"Initializing"` progress notification we currently wait for wraps — only marks the workspace as unscanned and clears the AST cache. The scan itself happens in `LanguageService.update0`, behind a 1s debounce, and only on a round that finds no pending file change; a round that finds one re-defers it via `updateLater`:

```java
if( !scanned ) {
    if( uris.isEmpty() ) { uris = getWorkspaceFiles(); astCache.clear(); this.scanned = true; }
    else { updateLater(); }
}
```

The first `didOpen` of a session therefore pushes the scan out by at least one further round. A references request issued right after it sees an AST cache holding nothing but the file it just opened, and answers with `[]`.

### Fix

Force the scan instead of waiting for it. `completion` is one of the two requests that call `updateNow` before consulting their provider, and `DebouncingExecutor.executeNow` cancels the pending debounce and runs the update synchronously on the request thread, so the response is not sent until that round has finished. Two rounds suffice whatever the workspace size: the first drains the pending file changes — which is what re-defers the scan — and the second finds nothing pending, so it takes the `getWorkspaceFiles` branch and compiles the whole workspace before replying.

Polling the workspace symbol index instead would be unsound: `LanguageService.symbol` neither awaits the update nor holds the monitor that `update` synchronises on. On a generated 1050-file workspace, polling it made the server raise `java.util.ConcurrentModificationException` from inside the scan, non-deterministically (6, 3 and 0 occurrences across three runs).

### Verification

Generated workspace of 1000 modules + 50 workflows, where the target process has exactly 100 references (50 includes + 50 calls), with only the defining file ever opened:

| | references found | time |
|---|---|---|
| without the fix | 0 / 100 | 2.2s |
| with the fix | 100 / 100 | 2.5s |

Also verified on a real 68-file pipeline (3/3 references, cold).

### Why the existing test missed it

`test_find_references_across_files` passed because the `language_server` fixture is module-scoped: earlier tests in the class had already opened `main.nf` and forced the server to compile it, so the assertion held for a reason that does not apply to a real session. Run alone it failed:

```
pytest test/solidlsp/nextflow/test_nextflow_basic.py -k test_find_references_across_files
→ 1 failed
```

The added `test_find_references_across_files_on_a_fresh_server` starts its own server and opens nothing but the defining file. It fails on the pre-fix baseline and passes with the fix; the isolated original test now passes too.

I have also reported the underlying server behaviour upstream at nextflow-io/language-server#175.

### Checks

`poe lint`, `poe type-check` and `pytest test/solidlsp/nextflow/` (7 passed) all clean.
