### PR TITLE
Remove redundant `dotenv` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Status of the `main` branch. Changes prior to the next official version change will appear here.
 
+* General:
+  - Remove the redundant `dotenv` dependency; the `dotenv` module is provided by `python-dotenv`
+
 # v1.7.0 (2026-08-09)
 
 * General:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
   "pyyaml==6.0.2",
   "ruamel.yaml==0.18.14",
   "jinja2==3.1.6",
-  "dotenv==0.9.9",
   "pathspec==0.12.1",
   "psutil==7.0.0",
   "docstring_parser==0.17.0",

--- a/uv.lock
+++ b/uv.lock
@@ -609,17 +609,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.9.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dotenv" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/b7/545d2c10c1fc15e48653c91efde329a790f2eecfbbf2bd16003b5db2bab0/dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9", size = 1892, upload-time = "2025-02-19T22:15:01.647Z" },
-]
-
-[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2791,7 +2780,6 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "docstring-parser" },
-    { name = "dotenv" },
     { name = "filelock" },
     { name = "flask" },
     { name = "jinja2" },
@@ -2861,7 +2849,6 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.14.2" },
     { name = "cryptography", specifier = "==50.0.0" },
     { name = "docstring-parser", specifier = "==0.17.0" },
-    { name = "dotenv", specifier = "==0.9.9" },
     { name = "filelock", specifier = "==3.25.2" },
     { name = "flask", specifier = "==3.1.3" },
     { name = "google-genai", marker = "extra == 'google'", specifier = "==1.27.0" },


### PR DESCRIPTION
## What

Removes the `dotenv==0.9.9` entry from `pyproject.toml` and regenerates `uv.lock`.

## Why

`dotenv` and `python-dotenv` are both declared as dependencies, but only the latter
is needed. The `dotenv` module imported in `src/serena/agno.py` and
`src/serena/analytics.py` is provided by `python-dotenv`.

The separately named `dotenv` distribution on PyPI is an unrelated, deprecated
project by another author ([pedroburon/dotenv](https://github.com/pedroburon/dotenv)),
republished as a metadata-only redirect. Its wheel contains no Python module at
all — just `dist-info/` with `Requires-Dist: python-dotenv` and
`Summary: Deprecated package`. It has therefore never contributed anything at
runtime.

It looks like it was introduced by accident: `dotenv>=0.9.9` was added in 605bca19
in the same commit that introduced the `from dotenv import load_dotenv` call in
`src/serena/agno.py`, six days after `python-dotenv>=1.0.0, <2` had already been
added in 276f6a84 — i.e. the module name was mistaken for the distribution name.
The redundancy then survived the bulk pinning pass in 45cd8ca1, which mechanically
rewrote `>=0.9.9` to `==0.9.9`.

Beyond the cleanup, this drops one third-party PyPI name from the set of
distributions implicitly trusted at install time.

## Verification

- `uv lock` produces a diff consisting solely of the `dotenv` removal; no other
  package versions change.
- `from dotenv import load_dotenv` resolves with only `python-dotenv==1.2.2`
  installed:
  $ uv run --no-project --with 'python-dotenv==1.2.2'
      python -c "import dotenv; print(dotenv.file)"
  .../site-packages/dotenv/init.py

No behavioural change.