### PR TITLE
docs: document the three Scala settings the configuration page omitted

### DIFF
--- a/docs/02-usage/050_configuration.md
+++ b/docs/02-usage/050_configuration.md
@@ -1107,6 +1107,11 @@ Supported settings:
 
 Serena uses Metals for Scala support.
 
+Metals serves one build per workspace folder, so in a repository holding several builds — or a single
+build below the repository root — it is the build roots, not the repository root, that Metals must be
+given. Serena detects them automatically; `project_roots` overrides that detection where it guesses
+wrong, and `project_root_scan_depth` bounds how far it looks.
+
 Supported settings:
 
 | Setting | Default | Description |
@@ -1115,6 +1120,9 @@ Supported settings:
 | `client_name` | `Serena` | Client identifier sent to Metals. |
 | `on_stale_lock` | `auto-clean` | How Serena handles stale Metals H2 database locks. Supported values: `auto-clean`, `warn`, `fail`. |
 | `log_multi_instance_notice` | `true` | Log a notice when another Metals instance is detected. |
+| `auto_import_build` | `true` | Answer Metals' build-import prompts affirmatively, which lets it run the project's build tool (e.g. `sbt bloopInstall`). Set to `false` to leave the build un-imported; Metals then has no build server, and every cross-file query is served by the fallback presentation compiler. |
+| `project_roots` | auto-detected | The build roots to serve, as paths relative to the repository root. A path that does not exist is skipped with a warning; if none of them exists, the build roots are detected instead. |
+| `project_root_scan_depth` | `3` | How many directory levels below the repository root the detection searches. Applies whenever the roots are detected — that is, when `project_roots` is unset, or when it names nothing that exists. |
 
 #### SCSS / Sass / CSS
 


### PR DESCRIPTION
The Scala section of `docs/02-usage/050_configuration.md` lists four settings; `_get_scala_settings` returns seven. The three that are missing — `auto_import_build`, `project_roots` and `project_root_scan_depth` — are the ones that arrived with #1767 and #1769, which were mine, so this is my omission to fix.

They are documented in the `ScalaLanguageServer` class docstring, so the information exists; it just never reached the page users are pointed at.

### What this adds

Three rows:

| Setting | Default | Description |
|---|---|---|
| `auto_import_build` | `true` | Answer Metals' build-import prompts affirmatively, which lets it run the project's build tool (e.g. `sbt bloopInstall`). Set to `false` to leave the build un-imported; Metals then has no build server, and every cross-file query is served by the fallback presentation compiler. |
| `project_roots` | auto-detected | The build roots to serve, as paths relative to the repository root. A path that does not exist is skipped with a warning; if none of them exists, the build roots are detected instead. |
| `project_root_scan_depth` | `3` | How many directory levels below the repository root the detection searches. Applies whenever the roots are detected — that is, when `project_roots` is unset, or when it names nothing that exists. |

And a short paragraph above the table, because `project_roots` is hard to make sense of without knowing that Metals serves one build per workspace folder. If you would rather keep the section to just the table, say so and I will drop the paragraph — the SCSS section's prose is what suggested it was in keeping.

### Not included

No code changes, and no changes to the class docstring — it is already correct and complete. This is only the user-facing page catching up to it.

No `CHANGELOG.md` entry either, following what docs-only PRs here have done (#1341, #1366, #1485, #1762). Happy to add one if you would rather.

### Disclosure

Prepared with the assistance of Claude Code (Claude Opus). I checked each of the three descriptions against the source myself and edited the text. I will answer follow-ups personally.

## Checklist

- [X] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [X] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.
