### PR TITLE
Document safer Codex hook defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
 
+* Hooks:
+  - Document safer Codex hook defaults, timeouts, status messages, event mappings and troubleshooting guidance.
+
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -319,16 +319,9 @@ asking Codex to "Activate the current dir as project using serena" at the start 
 do this automatically).
 
 **Hooks.**
-Codex supports lifecycle hooks; see the
-[Codex hooks documentation](https://developers.openai.com/codex/hooks) for details. To enable
-Serena's hooks for Codex, add this feature flag to `~/.codex/config.toml`:
-
-```toml
-[features]
-codex_hooks = true
-```
-
-Then create `~/.codex/hooks.json` with the following content:
+Current Codex versions enable lifecycle hooks by default, so no feature flag is required. See the
+[Codex hooks documentation](https://developers.openai.com/codex/hooks) for details. Create
+`~/.codex/hooks.json` with the following content:
 
 ```json
 {
@@ -339,7 +332,9 @@ Then create `~/.codex/hooks.json` with the following content:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "serena-hooks remind --client=codex"
+                        "command": "serena-hooks remind --client=codex",
+                        "statusMessage": "Checking Serena tool usage",
+                        "timeout": 5
                     }
                 ]
             }
@@ -350,7 +345,9 @@ Then create `~/.codex/hooks.json` with the following content:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "serena-hooks activate --client=codex"
+                        "command": "serena-hooks activate --client=codex",
+                        "statusMessage": "Activating Serena project",
+                        "timeout": 5
                     }
                 ]
             }
@@ -360,7 +357,9 @@ Then create `~/.codex/hooks.json` with the following content:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "serena-hooks cleanup --client=codex"
+                        "command": "serena-hooks cleanup --client=codex",
+                        "statusMessage": "Cleaning up Serena hook state",
+                        "timeout": 3
                     }
                 ]
             }
@@ -369,22 +368,45 @@ Then create `~/.codex/hooks.json` with the following content:
 }
 ```
 
+These timeout values are specific to Codex. Without an explicit timeout, Codex allows most hooks
+to run for 600 seconds, so the five-second reminder and activation timeouts prevent a stuck hook
+from blocking a `Bash` call or session startup for that entire default. `SessionEnd` instead
+defaults to one second and supports at most three seconds, so the cleanup hook uses that maximum.
+Codex reports timed-out commands as hook failures. Other clients may have different timeout
+behaviour; in particular, the Grok cleanup example below intentionally remains at five seconds.
+
 The `SessionEnd` cleanup hook requires Codex 0.145.0 or newer. Older Codex versions only support
 `Stop` for cleanup, which currently has a [known compatibility issue](https://github.com/oraios/serena/issues/1533).
 If you still configure it, replace `SessionEnd` with `Stop` in the example above. Configure cleanup
 under exactly one of these events, never both: `Stop` runs after every turn, while `SessionEnd` runs
 when Codex tears down the root thread.
 
-The hooks will:
+Each Codex event maps to one Serena hook command:
 
-- **`activate`**: Prompt the agent to activate the current project and read Serena's instructions
-  when a Codex session starts or resumes.
-- **`remind`**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive
-  code-search or code-file-read calls without using Serena tools in between.
-- **`cleanup`**: Clean up hook session data when the session ends.
+| Codex event | Serena command | When it runs |
+| --- | --- | --- |
+| `PreToolUse` with matcher `Bash` | `serena-hooks remind` | Before a shell command, to detect drift from Serena's symbolic tools |
+| `SessionStart` with matcher `startup\|resume` | `serena-hooks activate` | When a session starts or resumes, to prompt project activation |
+| `SessionEnd` | `serena-hooks cleanup` | When Codex tears down the root thread, to clean up hook session data |
+
+The distinct `statusMessage` values make the three kinds of hook activity distinguishable while
+they run.
 
 The `PreToolUse` matcher is intentionally restricted to `Bash`. The Serena reminder hook for Codex
 tracks shell-based grep and code-file reads, so running it for every tool call is unnecessary.
+
+### Diagnosing opaque Codex hook failures
+
+Codex may report that a hook failed without identifying the configured command or showing enough
+of its output to diagnose the cause. [Codex issue #27052](https://github.com/openai/codex/issues/27052)
+tracks richer hook failure diagnostics. Use Codex's `/hooks` command first to inspect hook sources,
+trust state, and enabled hooks.
+
+While that issue remains open, an advanced local wrapper can add an inner timeout and capture a
+bounded, redacted tail of stdout and stderr. Keep wrappers out of the standard setup: they add
+another script and executable path, platform-specific timeout behaviour, log rotation and redaction
+concerns, and another hook definition hash to review and trust. Such wrappers work around Codex's
+diagnostic limitations; Serena does not require them.
 
 ## Grok
 


### PR DESCRIPTION
## Summary

- clarify that current Codex versions enable lifecycle hooks by default, so Serena's setup does not require a feature flag
- add explicit Codex timeouts for Serena's reminder, activation, and cleanup hooks
- add distinct status messages and map each Codex event to its Serena command
- document how to diagnose opaque hook failures while keeping wrapper scripts out of the standard setup

## Rationale

Current Codex documentation identifies `hooks` as the canonical feature key, with `codex_hooks` retained only as a deprecated alias, and says hooks are enabled by default. Serena's standard setup should therefore create `hooks.json` directly instead of asking users to add a redundant deprecated feature flag.

Codex allows most hooks to run for 600 seconds when no timeout is specified, which can leave a `Bash` call or session startup blocked by a stuck hook. `SessionEnd` is different: it defaults to one second and supports at most three seconds.

The example now uses five seconds for `remind` and `activate`, and the maximum three seconds for `cleanup`. These values are intentionally Codex-specific; the Grok cleanup example remains at five seconds.

Codex issue openai/codex#27052 tracks richer diagnostics for hook failures. The troubleshooting guidance recommends `/hooks` first and describes local wrappers only as an advanced workaround because wrappers add executable-path, cross-platform timeout, logging/redaction, and hook-trust concerns.

## Validation

- parsed the Codex JSON example and asserted `remind = 5`, `activate = 5`, and `cleanup = 3`, with distinct status messages
- asserted that the Codex section documents default enablement and contains no `codex_hooks` feature flag
- parsed the Grok JSON example and confirmed cleanup remains `5`
- built the Sphinx HTML documentation with `-W --keep-going` using writable temporary cache and output directories
- `git diff --check upstream/main...HEAD`
