### PR TITLE
fix(dart): handle analyzer status notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Status of the `main` branch. Changes prior to the next official version change w
     project list in `serena_config.yml`
 
 * Language Servers:
+  - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/src/solidlsp/language_servers/dart_language_server.py
+++ b/src/solidlsp/language_servers/dart_language_server.py
@@ -192,6 +192,7 @@ class DartLanguageServer(SolidLanguageServer):
         self.server.on_notification("window/logMessage", window_log_message)
         self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
         self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("$/analyzerStatus", do_nothing)
         self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
         self.server.on_notification("language/actionableNotification", do_nothing)
         self.server.on_notification("experimental/serverStatus", check_experimental_status)

--- a/test/solidlsp/dart/test_dart_startup.py
+++ b/test/solidlsp/dart/test_dart_startup.py
@@ -1,0 +1,75 @@
+"""Regression test for Dart analyzer-status notification handling."""
+
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from solidlsp.language_servers.dart_language_server import DartLanguageServer
+from solidlsp.ls_config import LanguageServerConfig, LanguageServerId
+from solidlsp.ls_process import LanguageServerInterface
+from solidlsp.settings import SolidLSPSettings
+
+pytestmark = pytest.mark.dart
+
+
+class _FakeLanguageServerInterface(LanguageServerInterface):
+    def __init__(self) -> None:
+        super().__init__(LanguageServerId.DART, lambda _line: logging.INFO)
+        self._running = False
+
+    def is_running(self) -> bool:
+        return self._running
+
+    def _start(self) -> None:
+        self._running = True
+
+    def _stop(self, timeout: float) -> None:
+        self._running = False
+
+    def _send_payload(self, payload: dict[str, Any]) -> None:
+        if "id" not in payload:
+            return
+        result: Any = {"capabilities": {}} if payload.get("method") == "initialize" else None
+        self._receive_payload({"jsonrpc": "2.0", "id": payload["id"], "result": result})
+
+    def receive_notification(self, method: str, params: Any) -> None:
+        self._receive_payload({"jsonrpc": "2.0", "method": method, "params": params})
+
+
+def test_analyzer_status_notification_is_handled_after_startup(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = SolidLSPSettings(
+        solidlsp_dir=str(tmp_path / "global"),
+        project_data_path=str(tmp_path / "project"),
+        ls_specific_settings={LanguageServerId.DART: {}},
+    )
+    server_interface = _FakeLanguageServerInterface()
+
+    with (
+        patch.object(
+            DartLanguageServer,
+            "_setup_runtime_dependencies",
+            return_value=str(tmp_path / "dart-sdk"),
+        ),
+        patch.object(
+            DartLanguageServer,
+            "_create_language_server_interface",
+            return_value=server_interface,
+        ),
+    ):
+        server = DartLanguageServer(
+            LanguageServerConfig(ls_id=LanguageServerId.DART),
+            str(tmp_path),
+            settings,
+        )
+        server.start()
+
+    with caplog.at_level(logging.WARNING):
+        server_interface.receive_notification("$/analyzerStatus", {"isAnalyzing": True})
+
+    assert "Unhandled method '$/analyzerStatus'" not in caplog.messages


### PR DESCRIPTION
## Problem

The Dart analysis server emits `$/analyzerStatus` notifications while it analyzes a workspace. Serena's Dart adapter did not register this server-specific notification, so the generic notification dispatcher logged every event as an unhandled-method warning. This creates repeated warning noise even though the notification does not require action from Serena.

## Cause

The Dart adapter already registers no-op handlers for other informational notifications such as `$/progress` and `language/status`, but `$/analyzerStatus` was missing from that adapter-specific list. The global dispatcher therefore treated it as genuinely unknown.

## Fix

Register `$/analyzerStatus` with the Dart adapter's existing no-op handler. Global handling of unknown notifications is unchanged, so unexpected methods from other servers continue to produce warnings.

Add a regression test that starts the Dart adapter against an in-memory LSP interface, sends `$/analyzerStatus` through the production notification dispatcher, and verifies that the unhandled-method warning is not emitted.

## Verification

- Regression test fails on `main` with `Unhandled method '$/analyzerStatus'` and passes with this change.
- `uv run poe test -m dart -q --tb=short`: 22 passed, 2 skipped.
- `uv run poe lint`: passed.
- `uv run poe type-check`: passed.
- `uvx --from codespell codespell CHANGELOG.md src/solidlsp/language_servers/dart_language_server.py test/solidlsp/dart/test_dart_startup.py`: passed.

## Compatibility

No public API, configuration, dependency, or global notification behavior changes.

Fixes #1855

## Disclosure

Prepared with assistance from OpenAI Codex. I reviewed the implementation and test design and ran the verification above.

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.
