### PR TITLE
fix(analytics): replace retired model id in Anthropic token count estimator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Status of the `main` branch. Changes prior to the next official version change w
 * General:
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
+  - Fix: the `ANTHROPIC_CLAUDE_SONNET_4` token count estimator requested `claude-sonnet-4-20250514`,
+    which Anthropic retired on 2026-06-15, so the estimator failed for anyone who selected it; it now
+    requests `claude-sonnet-4-6`
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)

--- a/src/serena/analytics.py
+++ b/src/serena/analytics.py
@@ -51,7 +51,7 @@ class AnthropicTokenCount(TokenCountEstimator):
     See https://docs.anthropic.com/en/docs/build-with-claude/token-counting
     """
 
-    def __init__(self, model_name: str = "claude-sonnet-4-20250514", api_key: str | None = None):
+    def __init__(self, model_name: str = "claude-sonnet-4-6", api_key: str | None = None):
         import anthropic
 
         self._model_name = model_name
@@ -102,7 +102,7 @@ class RegisteredTokenCountEstimator(Enum):
             case RegisteredTokenCountEstimator.TIKTOKEN_GPT4O:
                 return TiktokenCountEstimator(model_name="gpt-4o")
             case RegisteredTokenCountEstimator.ANTHROPIC_CLAUDE_SONNET_4:
-                return AnthropicTokenCount(model_name="claude-sonnet-4-20250514")
+                return AnthropicTokenCount(model_name="claude-sonnet-4-6")
             case RegisteredTokenCountEstimator.CHAR_COUNT:
                 return CharCountEstimator(avg_chars_per_token=4)
             case _:


### PR DESCRIPTION
## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.

## What

`AnthropicTokenCount` requests `claude-sonnet-4-20250514`. Anthropic retired that model on the Claude API on 15 June 2026, so requests to it now fail. Replaced with `claude-sonnet-4-6`, the replacement Anthropic lists for it.

Two occurrences in `src/serena/analytics.py`: the `__init__` default and the `ANTHROPIC_CLAUDE_SONNET_4` branch of `_create_estimator`.

## Impact

Only affects users who set `token_count_estimator: ANTHROPIC_CLAUDE_SONNET_4` — the template default is `CHAR_COUNT`, so most installs are unaffected. For those who did opt in, the estimator has been calling a retired model since mid-June.

## On the enum name

I deliberately did not touch `RegisteredTokenCountEstimator.ANTHROPIC_CLAUDE_SONNET_4`. It is a documented config value in `serena_config.template.yml`, so renaming it would break existing `serena_config.yml` files. The consequence is that the name now says "Sonnet 4" while the request uses Sonnet 4.6. If you would rather rename it and migrate configs, or add an alias, happy to follow up — that felt like your call rather than something to slip into a bug fix.

## Verification

Clean clone, isolated environment:

- `ruff==0.12.5 check src/serena/analytics.py` — passed before and after
- `ruff==0.12.5 format --check src/serena/analytics.py` — already formatted, before and after
- `python -m py_compile src/serena/analytics.py` — OK before and after

I did not run the full suite: it needs the language servers, which I could not provision here. Nothing in `test/` covers `analytics.py`, and the change is a constant, so I would not expect movement there — but flagging it rather than implying I ran more than I did.

## Scope

2 files: the fix, plus the `CHANGELOG.md` entry `CONTRIBUTING.md` asks for. No refactoring, no other model identifiers touched.