### PR TITLE
Docs: correct docstrings that render wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Status of the `main` branch. Changes prior to the next official version change w
 * General:
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
+  - Fix: Docstrings that named a parameter which does not exist, used an invalid Sphinx role, or wrote
+    glob patterns as unescaped RST markup. Five are tool `apply` docstrings, which are published as
+    MCP tool descriptions, so those descriptions now render their lists as lists
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)

--- a/src/serena/agno.py
+++ b/src/serena/agno.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import os

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -144,6 +144,7 @@ class ToolInclusionDefinition:
     """
     Defines which tools to include/exclude in Serena's operation.
     This can mean either
+
       * defining exclusions/inclusions to apply to an existing set of tools [incremental mode], or
       * defining a fixed set of tools to use [fixed mode].
     """
@@ -867,7 +868,7 @@ class RegisteredProject(ToStringMixin):
 class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
     """
     Holds the Serena agent configuration, which is typically loaded from a YAML configuration file
-    (when instantiated via :method:`from_config_file`), which is updated when projects are added or removed.
+    (when instantiated via :meth:`from_config_file`), which is updated when projects are added or removed.
     For testing purposes, it can also be instantiated directly with the desired parameters.
     """
 
@@ -907,16 +908,19 @@ class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
     """
 
     ignored_paths: list[str] = field(default_factory=list)
-    """List of paths to ignore across all projects. Same syntax as gitignore, so you can use * and **.
+    """List of paths to ignore across all projects. Same syntax as gitignore, so you can use ``*`` and ``**``.
     These patterns are merged additively with each project's own ignored_paths."""
 
     project_serena_folder_location: str = DEFAULT_PROJECT_SERENA_FOLDER_LOCATION
     """
     Template for the location of the per-project .serena data folder (memories, caches, etc.).
     Supports the following placeholders:
+
       - $projectDir: the absolute path to the project root directory
       - $projectFolderName: the name of the project folder
+
     Examples:
+
       - "$projectDir/.serena" (default, stores data inside the project)
       - "/projects-metadata/$projectFolderName/.serena" (stores data in a central location)
     """

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -182,12 +182,13 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
             return self.n_recent_non_symbolic_uses >= self._NON_SYMBOLIC_USES_THRESHOLD
 
         def is_hook_active(self, now: datetime) -> bool:
-            """:return: whether the hook should engage at all at ``now``. Returns
-            ``False`` while we are still within :attr:`_MIN_DENY_INTERVAL_SECONDS`
-            of the most recent emitted deny — in that case the entire hook is
-            short-circuited (no counter updates, no deny). Returns ``True`` when
-            no deny has been emitted yet in this session, or when the window has
-            elapsed.
+            """
+            :return: whether the hook should engage at all at ``now``. Returns
+                ``False`` while we are still within :attr:`_MIN_DENY_INTERVAL_SECONDS`
+                of the most recent emitted deny — in that case the entire hook is
+                short-circuited (no counter updates, no deny). Returns ``True`` when
+                no deny has been emitted yet in this session, or when the window has
+                elapsed.
             """
             if self.last_deny_timestamp is None:
                 return True

--- a/src/serena/project.py
+++ b/src/serena/project.py
@@ -30,6 +30,12 @@ log = logging.getLogger(__name__)
 
 
 class Project(ToStringMixin):
+    """
+    Represents a project Serena operates on: the project root and its configuration, file access
+    with gitignore-aware ignore handling, and the connection to the language-server backend that
+    powers the symbolic operations.
+    """
+
     def __init__(
         self,
         *,

--- a/src/serena/symbol.py
+++ b/src/serena/symbol.py
@@ -150,9 +150,11 @@ class NamePathMatcher(ToStringMixin):
     uniquely identify it.
 
     A matching pattern can be:
+
      * a simple name (e.g. "method"), which will match any symbol with that name
      * a relative path like "class/method", which will match any symbol with that name path suffix
      * an absolute name path "/class/method" (absolute name path), which requires an exact match of the full name path within the source file.
+
     Append an index `[i]` to match a specific overload only, e.g. "MyClass/my_method[1]".
     """
 

--- a/src/serena/tools/cmd_tools.py
+++ b/src/serena/tools/cmd_tools.py
@@ -24,6 +24,7 @@ class ExecuteShellCommandTool(Tool, ToolMarkerCanEdit):
         Execute a shell command and return its output. If there is a memory about suggested commands, read that first.
         Never execute unsafe shell commands!
         IMPORTANT: Do not use this tool to start
+
           * long-running processes (e.g. servers) that are not intended to terminate quickly,
           * processes that require user interaction.
 

--- a/src/serena/tools/file_tools.py
+++ b/src/serena/tools/file_tools.py
@@ -241,6 +241,7 @@ class ReplaceInFilesTool(EditingToolWithDiagnostics):
         replaces many single-file replacements with long disambiguating needles.
 
         Recommended protocol whenever there is ANY risk of unintended replacements:
+
         1. Call with dry_run=True: every prospective change is returned as a minimal line diff with an
            occurrence id; nothing is modified.
         2. Call again with dry_run=False, passing the ids you want in occurrence_ids (omit it to apply
@@ -256,7 +257,7 @@ class ReplaceInFilesTool(EditingToolWithDiagnostics):
             specified as $!1, $!2, etc.
         :param mode: either "literal" or "regex", specifying how `needle` is to be interpreted
         :param relative_path: only consider this file or directory (default: the whole project)
-        :param paths_include_glob: optional glob (relative to the project root, e.g. "src/**/*.java")
+        :param paths_include_glob: optional glob (relative to the project root, e.g. ``"src/**/*.java"``)
             restricting which files are considered
         :param paths_exclude_glob: optional glob of files to exclude; takes precedence over the include glob
         :param dry_run: if True, do not modify anything; return the prospective changes as a list of

--- a/src/serena/tools/jetbrains_tools.py
+++ b/src/serena/tools/jetbrains_tools.py
@@ -49,12 +49,14 @@ class JetBrainsFindSymbolTool(Tool, ToolMarkerSymbolicRead, ToolMarkerOptional):
 
         To search for a symbol, you provide a name path pattern that is used to match against name paths.
         It can be
+
          * a simple name (e.g. "method"), which will match any symbol with that name
          * a relative path like "class/method", which will match any symbol with that name path suffix
          * an absolute name path "/class/method" (absolute name path), which requires an exact match of the full name path within the source file.
+
         Append an index `[i]` to match a specific overload only, e.g. "MyClass/my_method[1]".
-        In any path component, using `*` will match any sequence of characters (excluding /), e.g. "Class/*substring*" matches a member substring.
-        A pattern must not contain only wildcards (e.g. "*" or "/*").
+        In any path component, using ``*`` will match any sequence of characters (excluding /), e.g. ``"Class/*substring*"`` matches a member substring.
+        A pattern must not contain only wildcards (e.g. ``"*"`` or ``"/*"``).
 
         :param name_path_pattern: the name path matching pattern (see above)
         :param depth: depth up to which descendants shall be retrieved (e.g. use 1 to also retrieve immediate children;
@@ -164,13 +166,18 @@ class JetBrainsMoveTool(Tool, ToolMarkerSymbolicEdit, ToolMarkerOptional, ToolMa
 
 
         Valid moves:
+
         - Symbol:
+
            * (relative_path, name_path) -> new parent symbol (target_relative_path, target_parent_name_path)
-           * (relative_path, name_path) -> top level of target file or directory (target_relative_path)
+           * (relative_path, name_path) -> top level of target file or directory (target_relative_path).
              Always consider the concrete language-specific semantics!
+
              - target is a file: valid for languages like Python, where files are modules
              - target is a directory: valid for languages like Java, where directories are packages and can contain classes
+
         - File or directory:
+
            * relative_path -> new parent directory (target_relative_path)
 
         :param relative_path: the relative path to the file containing the symbol to move.

--- a/src/serena/tools/symbol_tools.py
+++ b/src/serena/tools/symbol_tools.py
@@ -166,9 +166,11 @@ class FindSymbolTool(Tool, ToolMarkerSymbolicRead):
 
         To search for a symbol, you provide a name path pattern that is used to match against name paths.
         It can be
+
          * a simple name (e.g. "method"), which will match any symbol with that name
          * a relative path like "class/method", which will match any symbol with that name path suffix
          * an absolute name path "/class/method" (absolute name path), which requires an exact match of the full name path within the source file.
+
         Append an index `[i]` to match a specific overload only, e.g. "MyClass/my_method[1]".
 
         :param name_path_pattern: the name path matching pattern (see above)

--- a/src/serena/tools/tools_base.py
+++ b/src/serena/tools/tools_base.py
@@ -331,7 +331,7 @@ class Tool(Component):
         """
         Applies the tool with logging and exception handling, using the given keyword arguments.
         This method either returns a string result or raises a ToolCallError in case of an error during tool application
-        (but if `catch_exception is enabled, it will return the error message as a string instead of raising the exception).
+        (but if ``catch_exceptions`` is enabled, it will return the error message as a string instead of raising the exception).
 
         :param log_call: whether to log the tool call and its result
         :param catch_exceptions: whether to catch exceptions and return their messages as strings, instead of raising a ToolCallError

--- a/src/serena/util/ls_diagnostics.py
+++ b/src/serena/util/ls_diagnostics.py
@@ -100,21 +100,24 @@ class GroupedDiagnostics:
 
     def get_dict(self) -> dict[str, dict[str, dict[str, list[dict[str, Any]]]]]:
         """
-        Returns a nested dictionary of the form:
-        {
-            relative_file_path: {
-                severity_name: {
-                    name_path: [
-                        diagnostic_dict,
+        Returns a nested dictionary of the form::
+
+            {
+                relative_file_path: {
+                    severity_name: {
+                        name_path: [
+                            diagnostic_dict,
+                            ...
+                        ],
                         ...
-                    ],
+                    },
                     ...
                 },
                 ...
-            },
-            ...
-        }
+            }
+
         where:
+
         - relative_file_path is the relative path of the file containing the diagnostic
         - severity_name is the name of the diagnostic severity (e.g. "Warning", "Error")
         - name_path is the name path of the symbol that owns the diagnostic (or "<file>" if no owner symbol was found)

--- a/src/serena/util/text_utils.py
+++ b/src/serena/util/text_utils.py
@@ -190,18 +190,20 @@ class GlobMatcher(ToStringMixin):
     Supports matching a file path against a glob pattern.
 
     Supports standard glob patterns:
-    - * matches any number of characters except /
-    - ** matches any number of directories (zero or more)
-    - ? matches a single character except /
-    - [seq] matches any character in seq
+
+    - ``*`` matches any number of characters except /
+    - ``**`` matches any number of directories (zero or more)
+    - ``?`` matches a single character except /
+    - ``[seq]`` matches any character in seq
 
     Supports brace expansion:
-    - {a,b,c} expands to multiple patterns (including nesting)
+
+    - ``{a,b,c}`` expands to multiple patterns (including nesting)
     """
 
     def __init__(self, expr: str):
         """
-        :param expr: a glob pattern which may make use of brace expansion (e.g., "src/**/*.{js,jsx,ts,tsx}")
+        :param expr: a glob pattern which may make use of brace expansion (e.g., ``"src/**/*.{js,jsx,ts,tsx}"``)
         """
         expr = expr.replace("\\", "/")  # normalise backslashes to forward slashes
         self._glob_expr = expr


### PR DESCRIPTION
## Problem

Twelve docstrings in `src/serena` document something the code does not do, or use markup that discards what they are trying to say. They fall into four kinds:

| kind | where | effect |
|:--|:--|:--|
| the documented name is not the parameter | `Tool.apply_ex` documents `catch_exception`; the parameter is `catch_exceptions` | the documented name falls into `**kwargs`, reaches `apply`, and returns as a `ToolCallError: TypeError: … unexpected keyword argument` — a string, since `catch_exceptions` defaults to `True` |
| an invalid role | `SerenaConfig` uses `:method:` | docutils: `Unknown interpreted text role "method"`; the reference never resolves |
| markup consuming its subject | `ignored_paths`, `GlobMatcher`, and the glob parameters of `replace_in_files`, `find_symbol`, `jet_brains_find_symbol` write `*` and `**` bare | in RST those are emphasis markers, so the patterns being documented vanish from the output |
| structure that collapses | field bodies and list items with no blank line or an inconsistent indent; a JSON-shaped example with no literal block | list items and `:return:` bodies merge into the preceding paragraph |

Rendering these modules with Sphinx produces **25 warnings across 9 modules** — 16 docutils warnings and 9 errors; the corrected versions produce none.

## Fix

Each is a one- or two-line correction, except `GroupedDiagnostics.get_dict`, where a ten-line JSON example becomes a literal block so it keeps its shape. `Project` gains a class docstring, having had none. `agno.py` gains `from __future__ import annotations`. Nothing under `src/` imports it and it has no module docstring, so autodoc does not load it today — the import is insurance for when it does. `SerenaAgnoAgentProvider._agent: Agent | None` is a class-level annotation, evaluated when the class is created, so with `agno` mocked it raises `TypeError: unsupported operand type(s) for |`. Postponing evaluation keeps the module documentable without the optional dependency being installed.

Five of the twelve are tool `apply` docstrings, which `mcp.py` publishes as the MCP tool description. Those descriptions therefore change too — by eleven blank lines and five literals, one to sixteen characters each. Ten of the blank lines precede a bullet list, and neither RST nor Markdown renders a list that begins without one, so a client displaying these as Markdown has been running the items together; `find_symbol`'s three name-path forms are the clearest case. Double backticks are a valid code span in Markdown as well, so nothing regresses there.

## Verification

| check | result |
|:--|:--|
| `ruff format --check` / `ruff check` on the changed files | 12 files already formatted, all checks passed |
| `test/serena/util` | 46 passed |
| Sphinx warnings from these docstrings, before / after | 25 across 9 modules / 0 |
| `agno.py` import under `autodoc_mock_imports`, before / after | fails / succeeds |
| change | 13 files changed, 63 insertions(+), 29 deletions(-) |

<sub>Measured at `be69af62`, against `93ec0431`, with Sphinx 7.4.7. Each module is rendered by `.. automodule::` with `:members:` and `:undoc-members:` — the options `docs/autogen_docs.py:module_template` uses — with `agno` and `sqlalchemy` mocked. Both runs render the same module set and differ only in the source.</sub>

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.

