### PR TITLE
Docs: headings, language-server links, and machine-readable surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Status of the `main` branch. Changes prior to the next official version change w
 * General:
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
+  - Docs: the tool list and the supported-language list are now built from headings rather than bold
+    list items, so every entry can be linked and reached from a table of contents; each language
+    entry names its language server, links the project and says how the server is obtained; and the
+    build emits `llms.txt`, `sitemap.xml`, `robots.txt` and a For Agents page served as markdown at
+    the site root
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)

--- a/docs/01-about/020_programming-languages.md
+++ b/docs/01-about/020_programming-languages.md
@@ -28,164 +28,176 @@ or at least freely available for use.
 We currently provide direct, out-of-the-box support for the programming languages listed below.
 Some languages require additional installations or setup steps, as noted.
 
-* **Ada / SPARK**  
+### Ada / SPARK
   (uses AdaCore's [Ada Language Server (ALS)](https://github.com/AdaCore/ada_language_server),
   automatically downloaded; supports `.ads`, `.adb`, and `.ada` files;
   works best with a `.gpr` GNAT project file at the repository root;
   SPARK is handled by the same server transparently — set language `ada` for both.
   To use a pre-installed ALS (e.g. from Alire, GNAT Studio, or the VS Code Ada extension),
   set `ls_specific_settings.ada.ls_path`.)
-* **AL**
-* **Angular**  
-  (experimental; requires Node.js + npm, plus `npm install` having been run in the project root so that `@angular/core`
+### AL
+  (uses the AL Language Server from Microsoft's [AL extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-dynamics-smb.al) (`ms-dynamics-smb.al`), automatically downloaded from the VS Code Marketplace)
+### Angular
+  (experimental; uses the official [@angular/language-server](https://github.com/angular/angular/tree/main/vscode-ng-language-service) (ngserver), automatically installed via npm; requires Node.js + npm, plus `npm install` having been run in the project root so that `@angular/core`
   is resolvable — without it, template-aware features silently return empty;
   subsumes `typescript` and `html` for `.ts`/`.html` files, so do not also list those)
-* **Ansible**  
-  (experimental; requires Node.js and npm; automatically installs `@ansible/ansible-language-server`;
+### Ansible
+  (experimental; requires Node.js and npm; automatically installs [`@ansible/ansible-language-server`](https://github.com/ansible/vscode-ansible);
   must be explicitly specified in the `languages` entry in the `project.yml`; requires `ansible` in PATH for full functionality)
   the upstream `@ansible/ansible-language-server@1.2.3` supports hover, completion, definition,
   semantic tokens, and validation; document symbols, workspace symbols, references, and rename
   are not supported by this version)
-* **Bash**
-* **BSL** (1C:Enterprise / OneScript)  
+### Bash
+  (uses [bash-language-server](https://github.com/bash-lsp/bash-language-server), automatically installed via npm; requires Node.js and npm on PATH; a pinned ShellCheck binary is downloaded automatically)
+### BSL (1C:Enterprise / OneScript)
   (requires Java 21+ on PATH; uses [bsl-language-server](https://github.com/1c-syntax/bsl-language-server) by 1c-syntax; the JAR is auto-downloaded and SHA-256-verified for the bundled default version; supports `.bsl` and `.os` files; configure optional `ls_path` or `bsl_ls_version` under `ls_specific_settings.bsl`)
-* **C#**  
-  (by default, uses the Roslyn language server (language `csharp`), requiring [.NET v10+](https://dotnet.microsoft.com/en-us/download/dotnet) and, on Windows, `pwsh` ([PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows?view=powershell-7.5));
+### C#
+  (by default, uses the [Roslyn language server](https://www.nuget.org/packages/roslyn-language-server) (language `csharp`), requiring [.NET v10+](https://dotnet.microsoft.com/en-us/download/dotnet) and, on Windows, `pwsh` ([PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows?view=powershell-7.5));
   set language to `csharp_omnisharp` to use OmiSharp instead)
-* **C/C++**  
-  (by default, uses the clangd language server (language `cpp`) but we also support ccls (language `cpp_ccls`);
+### C/C++
+  (by default, uses the [clangd](https://clangd.llvm.org/) language server (language `cpp`) but we also support [ccls](https://github.com/MaskRay/ccls) (language `cpp_ccls`);
   for best results, provide a `compile_commands.json` at the repository root;
   see the [C/C++ Setup Guide](../03-special-guides/cpp_setup) for details;
   for Unreal Engine 5 projects, see the [Unreal Engine Setup Guide](../03-special-guides/unreal_engine_setup_guide_for_serena).)
-* **Clojure**
-* **Crystal**  
+### Clojure
+  (uses [clojure-lsp](https://github.com/clojure-lsp/clojure-lsp), automatically downloaded; requires the [Clojure CLI](https://clojure.org/guides/getting_started) to be installed)
+### Crystal
   (requires [Crystalline](https://github.com/elbywan/crystalline) language server to be installed and available on PATH;
   note: Crystalline has limited go-to-definition support and does not support find-references)
-* **CUE**
-* **Dart**
-* **Elixir**  
-  (requires Elixir installation; Expert language server is downloaded automatically)
-* **Elm**  
-  (requires Elm compiler)
-* **Erlang**  
+### CUE
+  (uses `cue lsp` from the official [cue](https://github.com/cue-lang/cue) binary, automatically downloaded)
+### Dart
+  (uses the [Dart SDK](https://dart.dev)'s built-in language server (`dart language-server`); the SDK is downloaded automatically)
+### Elixir
+  (requires Elixir installation; [Expert](https://github.com/elixir-lang/expert) language server is downloaded automatically)
+### Elm
+  (requires Elm compiler; uses [elm-language-server](https://github.com/elm-tooling/elm-language-server), installed automatically via npm)
+### Erlang
   (requires installation of beam and [erlang_ls](https://github.com/erlang-ls/erlang_ls); experimental, might be slow or hang;
   note that functions are addressed as `name#arity`, e.g. `create_user#4`, because `/` is reserved as the name path separator)
-* **F#**  
-  (requires [.NET v8.0+](https://dotnet.microsoft.com/en-us/download/dotnet); uses FsAutoComplete/Ionide, which is auto-installed; for Homebrew .NET on macOS, set DOTNET_ROOT in your environment)
-* **Fortran**   
-  (requires installation of fortls: `pip install fortls`)
-* **GDScript** (Godot Engine)  
-  (requires the Godot editor to be running with its built-in LSP enabled — default on port 6008;
+### F#
+  (requires [.NET v8.0+](https://dotnet.microsoft.com/en-us/download/dotnet); uses [FsAutoComplete](https://github.com/ionide/FsAutoComplete)/Ionide, which is auto-installed; for Homebrew .NET on macOS, set DOTNET_ROOT in your environment)
+### Fortran
+  (uses [fortls](https://github.com/fortran-lang/fortls), run automatically via `uvx`; requires `uv`/`uvx` in PATH)
+### GDScript (Godot Engine)
+  (requires the [Godot](https://godotengine.org) editor to be running with its built-in LSP enabled — default on port 6008;
   Serena connects over TCP and does not launch Godot itself;
   see the [GDScript Setup Guide](../03-special-guides/godot_gdscript_setup_guide_for_serena) for details)
-* **Gleam**  
+### Gleam
   (requires the [Gleam compiler](https://gleam.run) on PATH; the language server is bundled with the compiler and started via `gleam lsp`)
-* **Go**  
-  (requires installation of `gopls`)
-* **Groovy**  
-  (requires local groovy-language-server.jar setup via `GROOVY_LS_JAR_PATH` or configuration)
-* **Haskell**  
-  (automatically locates HLS via ghcup, stack, or system PATH; supports Stack and Cabal projects)
-* **Haxe**
+### Go
+  (requires installation of [`gopls`](https://pkg.go.dev/golang.org/x/tools/gopls))
+### Groovy
+  (requires local [groovy-language-server.jar](https://github.com/GroovyLanguageServer/groovy-language-server) setup via `GROOVY_LS_JAR_PATH` or configuration)
+### Haskell
+  (automatically locates [HLS](https://github.com/haskell/haskell-language-server) via ghcup, stack, or system PATH; supports Stack and Cabal projects)
+### Haxe
   (requires Haxe compiler 3.4.0+ and Node.js; uses the [vshaxe language server](https://github.com/vshaxe/haxe-language-server);
   automatically downloaded from Open VSX, or discovered from the vshaxe VSCode extension)
-* **HLSL / GLSL / WGSL**
+### HLSL / GLSL / WGSL
   (uses [shader-language-server](https://github.com/antaalt/shader-sense) (language `hlsl`); automatically downloaded;
   on macOS, requires Rust toolchain for building from source;
   note: reference search is not supported by this language server)
-* **HTML**
-  (experimental; requires Node.js + npm)
-* **Java**  
-* **JavaScript**  
-  (supported via the TypeScript language server, i.e. use language `typescript` for both JavaScript and TypeScript)
-* **Julia**
-* **Kotlin**  
+### HTML
+  (experimental; requires Node.js + npm; automatically installs [vscode-html-language-server](https://github.com/hrsh7th/vscode-langservers-extracted) via the `vscode-langservers-extracted` npm package)
+### Java
+  (uses Eclipse JDT LS via the [vscode-java](https://github.com/redhat-developer/vscode-java) extension bundle, automatically downloaded with a bundled JRE)
+### JavaScript
+  (supported via the [TypeScript language server](https://github.com/typescript-language-server/typescript-language-server), i.e. use language `typescript` for both JavaScript and TypeScript)
+### Julia
+  (requires a Julia installation; uses [LanguageServer.jl](https://github.com/julia-vscode/LanguageServer.jl), automatically installed via Pkg if missing)
+### Kotlin
   (uses the pre-alpha [official kotlin LS](https://github.com/Kotlin/kotlin-lsp), some issues may appear)
-* **LaTeX**  
+### LaTeX
   (experimental; must be explicitly enabled via language `latex`; uses [texlab](https://github.com/latex-lsp/texlab),
   auto-downloaded as a SHA-256-verified prebuilt binary; supports `.tex`, `.bib`, `.sty`, and `.cls` files; texlab is
   GPL-3.0 and runs as a separate downloaded process)
-* **Lean 4**  
+### Lean 4
   (requires `lean` and `lake` installed via [elan](https://github.com/leanprover/elan); uses the built-in Lean 4 LSP;
   the project must be a Lake project with `lake build` run before use)
-* **Lua**
-* **Luau**
-* **Markdown**  
-  (must explicitly enable language `markdown`, primarily useful for documentation-heavy projects)
-* **MATLAB**  
-  (requires Node.js and a licensed local MATLAB installation, R2021b or later; Serena automatically downloads version 1.3.9 of the VS Code MATLAB extension, which bundles the language server)
-* **mSL** (mIRC Scripting Language)  
+### Lua
+  (uses [lua-language-server](https://github.com/LuaLS/lua-language-server), taken from PATH if present, otherwise downloaded automatically)
+### Luau
+  (uses [luau-lsp](https://github.com/JohnnyMorganz/luau-lsp), taken from PATH or automatically downloaded)
+### Markdown
+  (uses [Marksman](https://github.com/artempyanykh/marksman), automatically downloaded; must explicitly enable language `markdown`, primarily useful for documentation-heavy projects)
+### MATLAB
+  (requires Node.js and a licensed local MATLAB installation, R2021b or later; Serena automatically downloads version 1.3.9 of the VS Code MATLAB extension, which bundles the [MATLAB language server](https://github.com/mathworks/MATLAB-language-server))
+### mSL (mIRC Scripting Language)
   (auto-installed; no external dependencies required — uses a custom pygls-based LSP server shipped with Serena;
   supports document symbols, workspace symbols, references, and go-to-definition for aliases, events, menus, dialogs, and CTCP handlers in `.mrc` files)
-* **Nextflow**  
+### Nextflow
   (uses the official [Nextflow language server](https://github.com/nextflow-io/language-server), which is automatically
   downloaded; requires a Java 17+ runtime, discovered via `ls_specific_settings.nextflow.java_home`, `JAVA_HOME` or `java` on PATH;
   covers `.nf` scripts — Nextflow `.config` files are not treated as source files, since the language server reports no symbols for them;
   processes, workflows and functions are reported under their declared name, e.g. `GREET` for `process GREET`)
-* **Nix**  
-  (requires nixd installation)
-* **OCaml**
-  (requires opam and ocaml-lsp-server to be installed manually; see the [OCaml Setup Guide](../03-special-guides/ocaml_setup_guide_for_serena.md))
-* **Pascal**  
-  (uses Pascal/Lazarus, which is automatically downloaded; set `PP` and `FPCDIR` environment variables for source navigation)
-* **Perl**  
-  (requires installation of Perl::LanguageServer)
-* **PHP**  
-  (by default, uses the Intelephense language server (language `php`), set `INTELEPHENSE_LICENSE_KEY` environment variable for premium features;
+### Nix
+  (requires [nixd](https://github.com/nix-community/nixd) installation)
+### OCaml
+  (requires opam and [ocaml-lsp-server](https://github.com/ocaml/ocaml-lsp) to be installed manually; see the [OCaml Setup Guide](../03-special-guides/ocaml_setup_guide_for_serena.md))
+### Pascal
+  (uses the [Pascal/Lazarus language server (pasls)](https://github.com/zen010101/pascal-language-server), which is automatically downloaded; set `PP` and `FPCDIR` environment variables for source navigation)
+### Perl
+  (requires installation of [Perl::LanguageServer](https://metacpan.org/pod/Perl::LanguageServer))
+### PHP
+  (by default, uses the [Intelephense](https://intelephense.com) language server (language `php`), set `INTELEPHENSE_LICENSE_KEY` environment variable for premium features;
   we also support [Phpactor](https://github.com/phpactor/phpactor) (language `php_phpactor`), which requires PHP 8.1+;
   and the experimental [PHPantom](https://github.com/PHPantom-dev/phpantom_lsp) backend (language `php_phpantom`)
-* **PowerShell**  
-  (requires PowerShell 7+ (`pwsh`) on PATH or in a standard install location; Serena automatically downloads PowerShell Editor Services 4.4.0 and installs PSScriptAnalyzer 1.25.0 via `Save-Module` from your configured PowerShell repository)
-* **Python**
+### PowerShell
+  (requires PowerShell 7+ (`pwsh`) on PATH or in a standard install location; Serena automatically downloads [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) 4.4.0 and installs PSScriptAnalyzer 1.25.0 via `Save-Module` from your configured PowerShell repository)
+### Python
   (by default, uses [Pyright](https://github.com/microsoft/pyright) (language `python`);
   alternatives: [BasedPyright](https://github.com/DetachHead/basedpyright) (language `python_basedpyright`),
   [ty](https://github.com/astral-sh/ty) (language `python_ty`),
   [pyrefly](https://github.com/facebook/pyrefly) (language `python_pyrefly`),
-  [Jedi](https://github.com/palotas/jedi-language-server) (language `python_jedi`);
+  [Jedi](https://github.com/pappasam/jedi-language-server) (language `python_jedi`);
   Pyright, BasedPyright, ty, and pyrefly require `uv`/`uvx` in PATH)
-* **QML**
-  (requires Qt 6, provides `qmlls` or `qmlls6` on PATH; see the [Qt qmlls documentation](https://doc.qt.io/qt-6/qtqml-tool-qmlls.html))
-* **R**  
-  (requires installation of the `languageserver` R package)
-* **Rego**  
+### QML
+  (requires Qt 6, provides `qmlls` or `qmlls6` on PATH; see the [Qt qmlls documentation](https://doc.qt.io/qt-6/qtqml-tooling-qmlls.html))
+### R
+  (requires installation of the [`languageserver`](https://github.com/REditorSupport/languageserver) R package)
+### Rego
   (requires the [Regal](https://github.com/open-policy-agent/regal) language server on PATH)
-* **Ruby**  
+### Ruby
   (by default, uses [ruby-lsp](https://github.com/Shopify/ruby-lsp) (language `ruby`); use language `ruby_solargraph` to use Solargraph instead.)
-* **Rust**  
-  (requires [rustup](https://rustup.rs/) - uses rust-analyzer from your toolchain)
-* **Scala**  
-  (uses Metals LSP, which imports the build on first use — see the [setup guide](../03-special-guides/scala_setup_guide_for_serena))
-* **SCSS / Sass / CSS**
+### Rust
+  (requires [rustup](https://rustup.rs/) - uses [rust-analyzer](https://github.com/rust-lang/rust-analyzer) from your toolchain)
+### Scala
+  (uses [Metals](https://scalameta.org/metals/) LSP, which imports the build on first use — see the [setup guide](../03-special-guides/scala_setup_guide_for_serena))
+### SCSS / Sass / CSS
   (experimental; requires Node.js + npm; uses [some-sass-language-server](https://github.com/wkillerud/some-sass) to handle
   `.scss`, `.sass`, and `.css`)
-* **Solidity**  
-  (experimental; requires Node.js and npm; automatically installs `@nomicfoundation/solidity-language-server`;
+### Solidity
+  (experimental; requires Node.js and npm; automatically installs [`@nomicfoundation/solidity-language-server`](https://github.com/NomicFoundation/hardhat-vscode);
   works best with a `foundry.toml` or `hardhat.config.js` in the project root)
-* **Svelte**
-  (requires Node.js v18+ and npm; supports `.svelte` Single File Components plus TypeScript/JavaScript files via `svelte-language-server`; a companion `typescript-language-server` + `typescript-svelte-plugin` is spawned automatically for cross-file rename, go-to-definition, and references across `.ts`/`.js` and `.svelte` files; use language `svelte` for Svelte projects instead of also enabling `typescript`)
-* **Swift**
-* **SystemVerilog**  
-  (uses `verible-verilog-ls`, taken from PATH if present, otherwise version `v0.0-4051-g9fdb4057` is downloaded automatically)
-* **Terraform**  
-  (uses `terraform-ls` 0.36.5, which Serena downloads automatically; requires Terraform on PATH)
-* **TOML**  
-  (experimental; uses Taplo 0.10.0, taken from PATH if present, otherwise downloaded automatically)
-* **TypeScript**
-* **Deno**  
-  (experimental; requires the `deno` CLI on PATH — it bundles the language server used here;
+### Svelte
+  (requires Node.js v18+ and npm; supports `.svelte` Single File Components plus TypeScript/JavaScript files via [`svelte-language-server`](https://github.com/sveltejs/language-tools); a companion `typescript-language-server` + `typescript-svelte-plugin` is spawned automatically for cross-file rename, go-to-definition, and references across `.ts`/`.js` and `.svelte` files; use language `svelte` for Svelte projects instead of also enabling `typescript`)
+### Swift
+  (uses [sourcekit-lsp](https://github.com/apple/sourcekit-lsp), which must be installed and available on your PATH)
+### SystemVerilog
+  (uses [`verible-verilog-ls`](https://github.com/chipsalliance/verible), taken from PATH if present, otherwise version `v0.0-4051-g9fdb4057` is downloaded automatically)
+### Terraform
+  (uses [`terraform-ls`](https://github.com/hashicorp/terraform-ls) 0.36.5, which Serena downloads automatically; requires Terraform on PATH)
+### TOML
+  (experimental; uses [Taplo](https://github.com/tamasfe/taplo) 0.10.0, taken from PATH if present, otherwise downloaded automatically)
+### TypeScript
+  (uses [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server) together with the `typescript` package, both installed automatically via npm; requires Node.js and npm)
+### Deno
+  (experimental; requires the [`deno` CLI](https://docs.deno.com/runtime/getting_started/installation/) on PATH — it bundles the language server used here;
   serves Deno TypeScript/JavaScript and understands `npm:` / `jsr:` / `https:` imports and the `Deno.*`
   globals, which the plain TypeScript language server does not; overlaps `typescript` on file extensions,
   so it is not auto-detected and must be set as the language explicitly — do not also enable `typescript`
   for the same files)
-* **Vue**
-  (3.x with TypeScript; requires Node.js v18+ and npm; supports .vue Single File Components with monorepo detection)
-* **Wolfram Language**
+### Vue
+  (3.x with TypeScript; uses [`@vue/language-server`](https://github.com/vuejs/language-tools) (Volar), installed automatically via npm; requires Node.js v18+ and npm; supports .vue Single File Components with monorepo detection)
+### Wolfram Language
   (requires Wolfram Mathematica 13.0+ or Wolfram Engine 12.1+; uses the official [WolframResearch LSPServer](https://github.com/WolframResearch/LSPServer) paclet; supports .wl and .wls files; references are within-file only)
-* **YAML**
-* **JSON**  
-  (experimental; must be explicitly added to the languages list; requires Node.js and npm)
-* **Zig**  
-  (requires installation of ZLS - Zig Language Server)
+### YAML
+  (experimental; uses [yaml-language-server](https://github.com/redhat-developer/yaml-language-server) (Red Hat), installed automatically via npm; requires Node.js and npm)
+### JSON
+  (experimental; uses `vscode-json-languageserver` (Microsoft), installed automatically via npm; must be explicitly added to the languages list; requires Node.js and npm)
+### Zig
+  (requires installation of [ZLS](https://github.com/zigtools/zls) - Zig Language Server)
 
 Support for further languages can easily be added by providing a shallow adapter for a new language server implementation,
 see Serena's [memory on that](https://github.com/oraios/serena/blob/main/.serena/memories/adding_new_language_support_guide.md).

--- a/docs/02-usage/035_for-agents.md
+++ b/docs/02-usage/035_for-agents.md
@@ -1,0 +1,82 @@
+# For Agents
+
+This page is addressed to you: the coding agent whose human just dropped this URL into the
+conversation. Serena is an MCP server that gives you symbol-level tools for finding, reading
+and editing code — the operations an IDE gives a human, over the protocol you already speak.
+Here is what to do with it.
+
+## What You Get
+
+Text search finds strings; these tools find **symbols**. `find_symbol` resolves a name to its
+definition, `find_referencing_symbols` walks the callers, and `get_symbols_overview` maps a
+file without reading it. The editing tools — `replace_symbol_body`, `insert_after_symbol`,
+and regex-capable `replace_content` — land edits without pulling whole files into your
+context. The full set, with what each one does, is on the [Tools](../01-about/035_tools)
+page. The practical effect: fewer tokens spent reading, smaller blast radius writing.
+
+## Getting Your Human Set Up
+
+Serena runs on their machine. If it is not installed yet, these are the commands to suggest
+(details on the [Installation](010_installation) page):
+
+    uv tool install -p 3.13 serena-agent
+    serena init
+
+Then it connects to the client you run in — every client's exact configuration is on the
+[Clients](030_clients) page. For Claude Code it is one command:
+
+    claude mcp add --scope user serena -- serena start-mcp-server --context claude-code --project-from-cwd
+
+For Codex, `serena setup codex` does the whole thing. The other clients are covered on the
+same page.
+
+## Your First Moves
+
+1. **Call `initial_instructions` first.** It is the server's own manual, served as a tool —
+   it tells you how the active context and modes expect you to work.
+2. **On a new project, run `onboarding`.** It studies the codebase and writes
+   [memories](045_memories) — notes that persist between sessions, for you and for every
+   agent that comes after you.
+3. **Read the memories before re-deriving anything.** `list_memories` and `read_memory` are
+   cheaper than rediscovery.
+
+## Working Well
+
+- Prefer `get_symbols_overview` and `find_symbol` to reading files whole; read a body when
+  you are about to change it.
+- Edit at the symbol level where you can; use `replace_content` with wildcard patterns where
+  you cannot. An ambiguous match comes back as an error you can refine, not a wrong edit.
+- If the language backend's picture of the code goes stale, the optional
+  `restart_language_server` tool resets it.
+- Your human can watch the work on the [dashboard](060_dashboard) and in the
+  [logs](065_logs) — point them there when something needs a human eye.
+
+## Quick Reference
+
+The most common needs, and the page that answers each:
+
+| you need | go to |
+|:--|:--|
+| connect a specific client | [Clients](030_clients) |
+| every tool, one line each | [Tools](../01-about/035_tools) |
+| contexts, modes, project activation | [Configuration](050_configuration) |
+| which languages, and what each needs installed | [Language Support](../01-about/020_programming-languages) |
+| install or update Serena | [Installation](010_installation) |
+| what persists between sessions | [Memories](045_memories) |
+| show your human what happened | [Dashboard](060_dashboard), [Logs](065_logs) |
+| what runs where, and what is trusted | [Security](070_security) |
+| per-stack setup: C/C++, Scala, Godot, Unreal… | [Special Guides](../03-special-guides/000_intro) |
+| the whole site, one line per page | `llms.txt` at the site root |
+
+## The Machine Surfaces
+
+These docs describe themselves in forms you can fetch directly:
+
+- `llms.txt` at the site root — every page, one line each.
+- `_sources/<path>.md` — the raw markdown of any page, this one included.
+- `sitemap.xml` and `robots.txt` — the crawler's view.
+- This page again at a stable root URL: `for-agents.md`, plain markdown, made to be handed
+  to an agent in one link.
+
+If you are reading the root copy: this page's rendered home is
+`02-usage/035_for-agents.html`, and the relative links above resolve from there.

--- a/docs/03-special-guides/custom_agent.md
+++ b/docs/03-special-guides/custom_agent.md
@@ -6,6 +6,8 @@ Agno is a model-agnostic agent framework that allows you to turn Serena into an 
 added support for MCP servers out of the box, our Agno integration predates this and is a good illustration of how
 easy it is to integrate Serena into an arbitrary agent framework.
 
+## Setting Up the Agno Agent
+
 Here's how it works:
 
 1. Download the agent-ui code with npx
@@ -45,10 +47,14 @@ Here's how it works:
    the same tools as in the MCP server version.
 
 
+## A Short Demo
+
 Here is a short demo of Serena performing a small analysis task with the newest Gemini model:
 
 https://github.com/user-attachments/assets/ccfcb968-277d-4ca9-af7f-b84578858c62
 
+
+## A Word on Safety
 
 ⚠️ IMPORTANT: In contrast to the MCP server approach, tool execution in the Agno UI does
 not ask for the user's permission. The shell tool is particularly critical, as it can perform arbitrary code execution. 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -98,6 +98,9 @@ sphinx:
     - sphinx.ext.autodoc
     - sphinx.ext.viewcode
     - sphinx_toolbox.more_autodoc.sourcelink
+    # local module beside conf.py: emits llms.txt at the site root; the doc-build
+    # task puts docs/ on PYTHONPATH so the name resolves
+    - llms_txt
     #- sphinxcontrib.spelling
   local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
   recursive_update          : false # A boolean indicating whether to overwrite the Sphinx config (true) or recursively update (false)

--- a/docs/autogen_docs.py
+++ b/docs/autogen_docs.py
@@ -160,20 +160,78 @@ def autogen_tool_list(target_filename = "01-about/035_tools.md"):
         tools_by_module = ToolRegistry().get_registered_tools_by_module()
         priority_modules = {"serena.tools.symbol_tools": 1, "serena.tools.jetbrains_tools": 2}
 
+        # each module becomes a section heading, so the page's structure is navigable
+        # (an in-page TOC can only anchor to headings, not to bold list markers)
+        module_headings = {"jetbrains_tools": "JetBrains Tools", "cmd_tools": "Command Tools"}
         text = TextBuilder()
         sorted_modules = sorted(tools_by_module.keys(), key=lambda m: (priority_modules.get(m, 3), m))
         for module in sorted_modules:
             tools = tools_by_module[module]
             module = module.replace("serena.tools.", "")
-            text.with_line(f"* **{module}**")
+            heading = module_headings.get(module, module.replace("_", " ").title())
+            text.with_line(f"## {heading}\n")
             for tool in tools:
                 info = ""
                 if tool.is_optional:
                     info += " *(optional)*"
                 if tool.is_beta:
                     info += " [BETA]"
-                text.with_line(f"* `{tool.tool_name}`{info}: {tool.class_docstring}", indent=2)
+                text.with_line(f"* `{tool.tool_name}`{info}: {tool.class_docstring}")
+            text.with_line("")
         f.write(text.build())
+
+
+def autogen_about_orientation():
+    """Append the orientation sections to the About page: how the system is shaped, how
+    these docs are laid out and read, and where an agent should start. Appending (rather
+    than editing the file) keeps the README-derived part regenerable on its own."""
+    docs_root = Path(__file__).parent
+    # the Contributing section lives on its own branch; link it only when it is present,
+    # so this page builds warning-free with or without it
+    contributing_intro = docs_root / "06-contributing" / "000_contributing-intro.md"
+    contributing_entry = (
+        "- **[Contributing](../06-contributing/000_contributing-intro)**"
+        if contributing_intro.is_file()
+        else "- **Contributing**"
+    )
+    with open(docs_root / "01-about" / "000_intro.md", "a", encoding="utf-8") as f:
+        f.write(
+            "## The Shape of the System\n\n"
+            "Serena has three layers. At the top, an **MCP server** that plugs into the coding\n"
+            "agent you already use — see [Clients](../02-usage/030_clients) for who connects and\n"
+            "how. In the middle, the **tools**: symbol-level find, read and edit operations,\n"
+            "listed in [Tools](035_tools) and enabled per\n"
+            "[context, mode and project](../02-usage/050_configuration). Underneath, a\n"
+            "**language backend** that supplies the semantic understanding — a language server\n"
+            "for any [supported language](020_programming-languages), or the JetBrains plugin\n"
+            "riding your IDE's own analysis.\n\n"
+            "## How the Docs Are Laid Out\n\n"
+            "- **About** — what Serena is, [the tools it carries](035_tools), and\n"
+            "  [the languages it speaks](020_programming-languages).\n"
+            "- **[Usage](../02-usage/000_intro)** — installing, connecting a client,\n"
+            "  configuration, the dashboard and the logs. Start at\n"
+            "  [Installation](../02-usage/010_installation).\n"
+            "- **[Special Guides](../03-special-guides/000_intro)** — per-stack walkthroughs:\n"
+            "  C/C++, Scala, Godot, Unreal Engine, ChatGPT and more.\n"
+            "- **[Evaluation](../04-evaluation/000_evaluation-intro)** — Serena measured against\n"
+            "  real tasks, with the full transcripts.\n"
+            f"{contributing_entry} — working on Serena itself, from a first change to a\n"
+            "  new language server, with a guided code reference.\n\n"
+            "## Reading Them Well\n\n"
+            "New here? Go straight down: this page, then\n"
+            "[Installation](../02-usage/010_installation), then your\n"
+            "[client's page](../02-usage/030_clients) — that is a working setup. After that the\n"
+            "docs are built for dipping into, not reading through: come back when something\n"
+            "surprises you, and take the guide or reference page that answers it.\n\n"
+            "## If Your Reader Is an Agent\n\n"
+            "These docs describe themselves. [For Agents](../02-usage/035_for-agents) is the\n"
+            "page written to the agent directly — also served as plain markdown at the site\n"
+            "root, `for-agents.md`, one link to hand over in a chat. Beyond it, `llms.txt` at\n"
+            "the site root lists every page with a one-line summary, and each page's markdown\n"
+            "source is published beside it under `_sources/` — fetch `_sources/<path>.md` for\n"
+            "the raw text. All of it is generated from the same sources as the pages, so none\n"
+            "of it can drift.\n\n"
+        )
 
 
 def autogen_about_intro_features():
@@ -194,6 +252,20 @@ def autogen_about_intro_features():
         f.write(autogen_info)
         f.write("# About Serena\n\n")
         f.write(f"**{tagline}**\n\n")
+
+        # A large share of these readers are agents, and they arrive at this page first.
+        # The pointer sits above the prose rather than in the orientation section below,
+        # because an agent handed one link should not have to read the site to find the
+        # page written for it.
+        f.write(
+            "```{admonition} Reading this as an agent?\n"
+            ":class: tip\n"
+            "[For Agents](../02-usage/035_for-agents) is addressed to you: what the symbol tools\n"
+            "change, the setup to suggest to your human, your first moves, and a quick reference\n"
+            "for the most common needs. It is also served as plain markdown at `/for-agents.md`,\n"
+            "if you would rather fetch one file than read a site.\n"
+            "```\n\n"
+        )
 
         # adjust link
         about_text = about_text.replace("resources/serena-block-diagram.svg", "https://raw.githubusercontent.com/oraios/serena/main/resources/serena-block-diagram.svg")
@@ -238,6 +310,7 @@ if __name__ == "__main__":
     enable_module_docs = False
 
     autogen_about_intro_features()
+    autogen_about_orientation()
 
     autogen_tool_list()
 

--- a/docs/llms_txt.py
+++ b/docs/llms_txt.py
@@ -1,0 +1,145 @@
+"""Emit an ``llms.txt`` at the site root — the agent-readable map of these docs.
+
+The convention (https://llmstxt.org) is a small markdown file listing a site's pages
+with one-line descriptions, so a language model can orient itself without crawling
+HTML. For a project whose users *are* coding agents, the docs should extend the same
+courtesy: this extension derives the file from the markdown sources at the end of
+every build, so it can never go stale relative to the pages it describes.
+"""
+
+import os
+import re
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+_MD_LINK = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_MYST_TARGET = re.compile(r"^\([^)]*\)=$")
+
+
+def _first_heading_and_line(text: str) -> tuple[str | None, str | None]:
+    """The page's h1, and the first prose line after it."""
+    title = None
+    in_comment = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if in_comment:
+            if "-->" in line:
+                in_comment = False
+            continue
+        if line.startswith("<!--"):
+            if "-->" not in line:
+                in_comment = True
+            continue
+        if not line or _MYST_TARGET.match(line):
+            continue
+        if line.startswith("# ") and title is None:
+            title = line[2:].strip()
+            continue
+        if title is not None:
+            if line.startswith(("#", "```", ":", "<", "|", "* ", "- ", "1.", ">")):
+                continue
+            desc = _MD_LINK.sub(r"\1", line).replace("**", "").replace("`", "").strip()
+            if len(desc) > 140:
+                desc = desc[:140].rsplit(" ", 1)[0] + "…"
+            return title, desc
+    return title, None
+
+
+def _section_name(dirname: str) -> str:
+    return re.sub(r"^\d+-", "", dirname).replace("-", " ").title()
+
+
+def write_llms_txt(app, exception) -> None:
+    if exception is not None:
+        return
+    srcdir = Path(app.srcdir)
+    outdir = Path(app.outdir)
+
+    lines: list[str] = []
+    index = srcdir / "index.md"
+    if index.is_file():
+        title, desc = _first_heading_and_line(index.read_text(encoding="utf-8"))
+        lines.append(f"# {title or 'Serena'}")
+        if desc:
+            lines.append(f"\n> {desc}")
+    else:
+        lines.append("# Serena")
+
+    for section_dir in sorted(p for p in srcdir.iterdir() if p.is_dir() and not p.name.startswith(("_", "."))):
+        entries = []
+        for md in sorted(section_dir.rglob("*.md")):
+            title, desc = _first_heading_and_line(md.read_text(encoding="utf-8"))
+            if title is None:
+                continue
+            url = md.relative_to(srcdir).with_suffix(".html").as_posix()
+            entries.append(f"- [{title}]({url})" + (f": {desc}" if desc else ""))
+        if entries:
+            lines.append(f"\n## {_section_name(section_dir.name)}\n")
+            lines.extend(entries)
+
+    (outdir / "llms.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_sitemap_and_robots(app, exception) -> None:
+    """robots.txt always (allow-all — these docs have no reason to turn crawlers away),
+    sitemap.xml only when a base URL is known: the sitemap format requires absolute URLs,
+    so it keys off ``html_baseurl``, with the ``DOCS_BASEURL`` environment variable as a
+    deploy-time override for builds of the same sources published elsewhere. Note that
+    crawlers only honor a robots.txt served at the domain root — on a project-pages
+    subpath these files are for direct submission and for agents, not for discovery."""
+    if exception is not None:
+        return
+    outdir = Path(app.outdir)
+    # the environment wins: it is the deploy-time truth about where THIS build will be
+    # served, while html_baseurl states the project's canonical home
+    base = (os.environ.get("DOCS_BASEURL", "") or getattr(app.config, "html_baseurl", "")).rstrip("/")
+
+    robots = "User-agent: *\nAllow: /\n"
+    if base:
+        robots += f"\nSitemap: {base}/sitemap.xml\n"
+    (outdir / "robots.txt").write_text(robots, encoding="utf-8")
+
+    if not base:
+        return
+    skip = {"genindex.html", "search.html", "py-modindex.html", "404.html"}
+    urls = []
+    for page in sorted(outdir.rglob("*.html")):
+        rel = page.relative_to(outdir)
+        if rel.parts[0].startswith(("_", ".")) or rel.name in skip:
+            continue
+        urls.append(f"  <url><loc>{escape(f'{base}/{rel.as_posix()}')}</loc></url>")
+    (outdir / "sitemap.xml").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        + "\n".join(urls)
+        + "\n</urlset>\n",
+        encoding="utf-8",
+    )
+
+
+def write_for_agents_alias(app, exception) -> None:
+    """Serve the For Agents page at a memorable root URL, twice over: ``for-agents.md``
+    is the page's raw markdown (what an agent handed one link actually wants), and
+    ``for-agents.html`` redirects a human's browser to the rendered page."""
+    if exception is not None:
+        return
+    source = Path(app.srcdir) / "02-usage" / "035_for-agents.md"
+    if not source.is_file():
+        return
+    outdir = Path(app.outdir)
+    (outdir / "for-agents.md").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    target = "02-usage/035_for-agents.html"
+    (outdir / "for-agents.html").write_text(
+        '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        f'<meta http-equiv="refresh" content="0; url={target}">\n'
+        f'<link rel="canonical" href="{target}">\n<title>For Agents</title>\n</head>\n'
+        f'<body><p>Continue to <a href="{target}">For Agents</a>.</p></body>\n</html>\n',
+        encoding="utf-8",
+    )
+
+
+def setup(app):
+    app.connect("build-finished", write_llms_txt)
+    app.connect("build-finished", write_sitemap_and_robots)
+    app.connect("build-finished", write_for_agents_alias)
+    return {"version": "1.0", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,9 @@ type-check = ["_ty_core", "_ty_test"]
 ty = ["type-check"]
 # docs
 _autogen_docs = "python docs/autogen_docs.py"
-_sphinx_build = "sphinx-build -b html docs docs/_build -W --keep-going"
+# PYTHONPATH: the generated conf.py lists local extensions by module name only,
+# so the docs dir (where they live) must be importable when sphinx runs
+_sphinx_build = { cmd = "sphinx-build -b html docs docs/_build -W --keep-going", env = { PYTHONPATH = "${POE_ROOT}/docs" } }
 _jb_generate_toc = "python docs/create_toc.py"
 _jb_generate_config = "jupyter-book config sphinx docs/"
 doc-clean = "rm -rf docs/_build docs/03_api"


### PR DESCRIPTION
Two things a documentation site owes its readers, and Serena's readers are unusual: a large share of them are agents.

**Structure, so a page can be navigated.** Several pages carry their content as bold list items rather than headings — which means no anchors, no entry in any table of contents, and no way to link to a section. The tool list becomes eight headings, one per tool group, emitted by the generator rather than written by hand. Every supported language becomes a heading, so the language page turns into a jump list of 64 entries instead of one unbroken scroll. The custom-agent guide gains its three sections.

**And, while every language was being touched: 62 of the 64 entries now name their language server, link its project, and say how it arrives** — automatically downloaded, installed via npm, taken from `PATH`, or requiring a manual install. That is 76 links inside the entries, where the page previously named most servers only in prose. (The two without one are mSL, whose server ships inside Serena, and JSON, for which no canonical project page could be confirmed.) Each was traced to its adapter in `src/solidlsp/language_servers/` and every URL requested before it landed; three entries were corrected on the way, including one whose repository is archived and now lives in a monorepo. Two links already on the page were dead and are repaired: the Jedi language server had changed owner, and Qt renamed its `qmlls` page.

**Machine-readable surfaces**, emitted at build time by one local Sphinx extension:

| file | what it is |
|:--|:--|
| `llms.txt` | the [llmstxt.org](https://llmstxt.org) convention — every page with a one-line description, so a model can orient without crawling HTML |
| `sitemap.xml` | absolute URLs from `html_baseurl`; omitted when no base URL is configured, since the format requires them |
| `robots.txt` | allow-all, advertising the sitemap |
| `for-agents.md` | the new **For Agents** page, served as raw markdown at the site root — one URL to hand an agent in a chat |

All four are derived from the same sources as the pages themselves, so they cannot drift from what they describe.

**For Agents** (`02-usage/035_for-agents.md`) is written in second person to the agent reading it: what the symbol tools change, the setup to suggest to its human, its first moves (`initial_instructions`, then `onboarding`, then the memories), and a quick-reference table of the ten most common needs. Every tool name, command and behavioural claim in it was checked against the source before it was written down.

The About page gains an orientation section — the shape of the system in three layers, how the sections are laid out, how to read them — and, directly under the tagline where an arriving agent will see it, a pointer to **For Agents**.

## Verification

| check | result |
|:--|:--|
| `poe doc-build` (sphinx `-W`) | build succeeded, 0 warnings |
| language entries on the language page | 64 |
| entries naming and linking their server | 62 |
| links inside those entries | 76 |
| dead links repaired | 2 |
| change | 8 files changed, 431 insertions(+), 103 deletions(-) |

<sub>Measured at `f6fee155`, against `93ec0431`. The theme is not involved: this builds on the stock `sphinx-book-theme`.</sub>

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.
