### PR TITLE
docs: correct the language-server test gating description in critical_info

### DIFF
--- a/.serena/memories/critical_info.md
+++ b/.serena/memories/critical_info.md
@@ -20,7 +20,10 @@ The key principle is to test *only* externally observable behavior and guarantee
   absence of an implementation detail is not a behaviour, and such tests only freeze the current implementation and burden maintenance.
 * Fewer, behaviour-anchored tests are preferred; a missing test is better than an implementation-coupled one.
 
-Language-server tests are pytest-marker-gated (one marker per language; see `pyproject.toml` `[tool.pytest.ini_options].markers`). Default `poe test` runs unmarked tests + whatever `PYTEST_MARKERS` selects.
+Language-server tests carry one pytest marker per language (see `pyproject.toml` `[tool.pytest.ini_options].markers`).
+There is no default marker filter: no `addopts`, and `poe test` is plain `pytest test -vv`, so it collects every language's tests.
+Gating is by `skipif`, not by marker selection — `test/conftest.py:_determine_disabled_language_servers` disables a language whose toolchain/LS is absent (rules differ on/off CI).
+Languages enabled everywhere (python, typescript, go, java) therefore really run and start real language servers on a bare `poe test`; narrow with `-m <lang>`. CI selects markers per job in `.github/workflows/pytest.yml`.
 Snapshot tests use syrupy.
 
 # Docstrings & Comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Status of the `main` branch. Changes prior to the next official version change w
     Metals reports, bounded by the new `indexing_timeout`, `indexing_start_grace` and
     `indexing_quiet_period` settings
 
+* Memories:
+  - Fix: `critical_info` described language-server test gating as marker selection driven by a
+    `PYTEST_MARKERS` variable, which does not exist; there is no `addopts` either, so a bare
+    `poe test` collects every language's tests rather than only the unmarked ones
+
 * Dependencies:
   - Remove the redundant `dotenv` dependency; the `dotenv` module is provided by `python-dotenv`
 


### PR DESCRIPTION
`critical_info` is the entry point of the memory graph, so an agent reads it before
touching the test suite. It currently states:

> Default `poe test` runs unmarked tests + whatever `PYTEST_MARKERS` selects.

`PYTEST_MARKERS` does not exist anywhere in the repository, and there is no `addopts`
in `pyproject.toml` (nor a `pytest.ini`/`setup.cfg`/`tox.ini`). `pytest_configure` in
`test/conftest.py` only sets a PyCharm option and does not touch `markexpr`. Markers
therefore deselect nothing by default.

The practical consequence is the opposite of what the memory implies: a contributor
who reads it expects `poe test` to be a narrow, quick run, when in fact it collects
every language's tests and starts real language servers for those whose toolchain is
present.

Actual mechanism: gating is the per-language `skipif` that
`_determine_disabled_language_servers` attaches, which skips only languages whose
toolchain or language server is unavailable in the current environment.

### Verification

Measured on a clean checkout at `93ec0431`, Python 3.13, `uv sync --extra dev`:

Collection is not filtered by default —

```
$ python -m pytest --collect-only -q test/
2147 tests collected in 1.97s

$ python -m pytest --collect-only -q test/ -m python
179/2147 tests collected (1968 deselected) in 0.44s
```

If a default marker filter existed, the first number would not be 2147.

Marked tests really execute rather than skip —

```
$ python -m pytest test/solidlsp/python/test_symbol_retrieval.py -m python -q -rs
........................................................................ [ 90%]
........                                                                 [100%]
INFO solidlsp.ls_process:_read_ls_process_stdout:624 - Language server stdout reader thread has terminated

80 passed in 12.32s
```

80 passed, 0 skipped, with a real language-server process started.

**Not tested:** the on-CI branches of `_determine_disabled_language_servers` (the
`is_ci` paths), and languages other than Python. The claim about which languages are
enabled everywhere follows that function's own docstring, category 4.

### Scope

Documentation only; no source or test changes. `CHANGELOG.md` entry added under
`Memories` per `CONTRIBUTING.md`.
