### PR TITLE
CI: format prompt_factory.py so that poe lint passes again

### DIFF
--- a/src/interprompt/prompt_factory.py
+++ b/src/interprompt/prompt_factory.py
@@ -40,8 +40,9 @@ class PromptFactoryBase:
         return self._prompt_collection.get_prompt_list(prompt_name, self.lang_code)
 
 
-def autogenerate_prompt_factory_module(prompts_dir: str, target_module_path: str, interprompt_library_package: str = "interprompt",
-        class_name: str = "PromptFactory") -> None:
+def autogenerate_prompt_factory_module(
+    prompts_dir: str, target_module_path: str, interprompt_library_package: str = "interprompt", class_name: str = "PromptFactory"
+) -> None:
     """
     Auto-generates a prompt factory module for the given prompt directory.
     The generated `PromptFactory` class is meant to be the central entry class for retrieving and rendering prompt templates and prompt


### PR DESCRIPTION
## Problem

`ruff format --check` has been failing on `main` since `1814fc9a` (2026-08-14), the commit that syncs `interprompt` in from its own repository. The signature of `autogenerate_prompt_factory_module` came across in hanging-indent style; at **175 characters against a line-length of 140** it has to wrap somehow, and ruff rewrites that wrap. `_ruff_format_check` aborts, so `poe lint` exits non-zero.

The failing step is **`Check formatting`**, which is gated on the `catch-all` batch and sits in front of that job's test and type-check steps. It is a narrow outage, not a total one:

| | |
|:--|:--|
| failing jobs | `catch-all` on `ubuntu-latest`, `windows-latest`, `macos-latest` — 3 jobs, all at `Check formatting` |
| unaffected | the other four batches ran normally — in run [31830619911](https://github.com/oraios/serena/actions/runs/31830619911), `Test with pytest` passed on **10 of 13 jobs** |
| what has not run since 2026-08-14 | `catch-all`'s own pytest, and `Type-checking with ty`, which is in no other batch and so reached **0 of 13 jobs** |

Every pull request opened since carries the same three red checks, and 5 open PRs currently fail *only* checks that `main` fails too — nothing their authors can do from the branch.

## Change

One signature, rewrapped to what `ruff format` produces. Nothing else.

```python
-def autogenerate_prompt_factory_module(prompts_dir: str, target_module_path: str, interprompt_library_package: str = "interprompt",
-        class_name: str = "PromptFactory") -> None:
+def autogenerate_prompt_factory_module(
+    prompts_dir: str, target_module_path: str, interprompt_library_package: str = "interprompt", class_name: str = "PromptFactory"
+) -> None:
```

## Verification

| check | result |
|:--|:--|
| `git diff --shortstat upstream/main..HEAD` | `1 file changed, 3 insertions(+), 2 deletions(-)` |
| signature parsed back out of the file with `ast.unparse` | `prompts_dir: str, target_module_path: str, interprompt_library_package: str='interprompt', class_name: str='PromptFactory'` — identical to before |
| `uv run poe lint` — the step CI dies on | `408 files already formatted` · `All checks passed!` |

`poe type-check` is also clean, but it is `ty check src/serena src/solidlsp` and `ty check test`, so it says nothing about this file — noted here only because it is the other thing `catch-all` has not been able to run.

> [!NOTE]
> This edit lives in `src/interprompt`. The file at interprompt `edbee703` is still the old blob, so unless the wrap is pulled back into that repository, the next push from there restores the old wrapping and the same failure with it.
