### PR TITLE
CI: give the static gates their own job so they cannot cancel the tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,8 +36,8 @@
 # TESTING / SKIPS
 #   All language skip logic is centralized in test/conftest.py
 #   (`language_tests_enabled()`): a test is skipped when its toolchain is not expected
-#   on the current OS/CI. Lint and type-check are batch-independent and run once per
-#   OS (catch-all only), not in every batch.
+#   on the current OS/CI. Lint and type-check are batch-independent and live in their own
+#   `lint` job (once per OS), so a formatting slip cannot cancel the test matrix.
 # =============================================================================
 name: Tests
 
@@ -148,11 +148,6 @@ jobs:
       - name: List Python dependencies
         shell: bash
         run: uv pip list
-      - name: Check formatting
-        # Lint is batch-independent; run it only once per OS instead of in every batch.
-        if: matrix.batch == 'catch-all'
-        shell: bash
-        run: uv run poe lint
       # Add Go bin directory to PATH for this workflow
       # GITHUB_PATH is a special file that GitHub Actions uses to modify PATH
       # Writing to this file adds the directory to the PATH for subsequent steps
@@ -774,8 +769,61 @@ jobs:
       - name: Test with pytest
         shell: bash
         run: uv run poe test -m "${{ steps.markers.outputs.expr }}" -q --tb=short
+
+  # The static gates -- format, lint, types -- in a job of their own.
+  #
+  # They used to be two steps inside this workflow's test matrix, gated on
+  # `matrix.batch == 'catch-all'`, which put a 1-second check in front of a 10-minute one.
+  # On 2026-08-14 a single unformatted line failed `Check formatting` 31 seconds into a
+  # 628-second job and cancelled everything behind it, so `Test with pytest` and
+  # `Type-checking with ty` did not run on any OS for as long as main stayed unformatted --
+  # and every pull request opened in that window inherited three red checks it could not fix.
+  # Type-checking had the mirror-image problem: it ran last, after pytest, so a 2-second
+  # check took ~10 minutes to report.
+  #
+  # Separated, the verdict lands in well under a minute, it names itself in the checks list
+  # instead of arriving as `catch-all`, and a formatting slip no longer stops the tests.
+  # Deliberately NOT a `needs:` of the test matrix -- re-coupling them is the thing this undoes.
+  #
+  # Same three OSes as before, so nothing is checked less than it was. This adds 3 jobs
+  # (13 -> 16 total, 4 -> 5 on macOS), within the 20-job and 5-macOS ceilings noted above.
+  # Only the venv is installed: ruff and ty need no language servers, no Node and no Go.
+  lint:
+    name: lint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Cache uv virtualenv
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          # Same key as the test matrix, so this job restores that venv instead of
+          # building a second one.
+          key: uv-venv-${{ runner.os }}-${{ matrix.python-version }}-lock-${{ hashFiles('uv.lock') }}
+      - name: Create virtual environment
+        shell: bash
+        run: |
+          if [ ! -d ".venv" ]; then
+            uv venv
+          fi
+      - name: Install Python environment
+        shell: bash
+        run: uv sync --extra dev --locked
+      - name: Check formatting
+        shell: bash
+        run: uv run poe lint
       - name: Type-checking with ty
-        # Type-checking is batch-independent; run it only once per OS instead of in every batch.
-        if: matrix.batch == 'catch-all'
         shell: bash
         run: uv run poe type-check


### PR DESCRIPTION
## Problem

`Check formatting` and `Type-checking with ty` are steps inside the test matrix, gated on `matrix.batch == 'catch-all'`. That places a 1-second check in front of a 10-minute one.

Measured on `catch-all (ubuntu-latest)` in [run 31941796732](https://github.com/oraios/serena/actions/runs/31941796732):

| | |
|:--|:--|
| job total | 628s |
| setup before the check | 30s |
| `Check formatting` | **1s** |
| `Type-checking with ty` | **2s** |
| lint verdict knowable | **31s** into the job |

When `Check formatting` fails, every step behind it is cancelled. On 2026-08-14 one unformatted line did exactly that: `Test with pytest` and `Type-checking with ty` ran on **no OS at all** until the formatting was fixed, and each pull request opened in that window carried three red `catch-all` checks that had nothing to do with it and could not be fixed from the branch.

Type-checking has the mirror-image problem — it is placed *after* pytest, so a 2-second check takes about ten minutes to report.

## Change

Both steps move into a `lint` job of their own.

- The verdict arrives in well under a minute instead of at 628s.
- It names itself in the checks list — `lint (ubuntu-latest)` rather than `catch-all (ubuntu-latest)`, so a formatting failure no longer reads as a test failure.
- A formatting slip cannot stop the tests.

It is deliberately **not** a `needs:` of the test matrix — re-coupling them is the thing this undoes.

On this pull request's own run, the new job reports in `lint (ubuntu-latest) 14s`, `lint (macos-latest) 20s`, `lint (windows-latest) 33s` — against the 628s job the same two checks used to sit inside.

## What is unchanged

| | |
|:--|:--|
| coverage | the same two commands (`poe lint`, `poe type-check`) over the same three operating systems |
| step names | identical, so existing log searches still match |
| test matrix | untouched apart from the two removed steps — `cpu-has-static=False`, `lint-has-both=True` |
| job counts | `total 13->16, macOS 4->5`, inside the 20-job and 5-macOS ceilings this workflow documents |
| uv cache | the new job reuses the existing cache key (it appears twice in the file, unchanged), so it restores the same virtualenv rather than building a second one |

That last point is also why the new job mirrors the surrounding steps' action versions rather than bumping them: a different `actions/cache` major would not share the cache. `actionlint` findings go `main=34 branch=36` — the two additions are further instances of the "action too old" notice already present 34 times, not a new kind of finding. Bumping those majors across the file would be a separate change.

The new job installs only the virtualenv: `ruff` and `ty` need no language servers, no Node and no Go.

## Verification

| check | result |
|:--|:--|
| `git diff --shortstat upstream/main..HEAD` | `1 file changed, 57 insertions(+), 9 deletions(-)` |
| files touched | `.github/workflows/pytest.yml` |
| the new job is not coupled back to the tests | `needs` present: `False` |
| job counts, expanded from the matrix rather than counted by hand | `total 13->16, macOS 4->5` |
