### PR TITLE
Add Codex plan-aware Serena hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
 
+* Hooks:
+  - Document safer Codex hook defaults, timeouts, status messages, event mappings and troubleshooting guidance.
+
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Status of the `main` branch. Changes prior to the next official version change w
     project list in `serena_config.yml`
 
 * Hooks:
+  - Add Codex plan-mode context and enforcement hooks driven by each tool's edit-capability metadata. #1854
   - Document safer Codex hook defaults, timeouts, status messages, event mappings and troubleshooting guidance.
 
 * Language Servers:

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -337,6 +337,17 @@ Current Codex versions enable lifecycle hooks by default, so no feature flag is 
                         "timeout": 5
                     }
                 ]
+            },
+            {
+                "matcher": "^mcp__serena__",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "serena-hooks plan-guard --client=codex",
+                        "statusMessage": "Checking Serena plan-mode permissions",
+                        "timeout": 5
+                    }
+                ]
             }
         ],
         "SessionStart": [
@@ -347,6 +358,18 @@ Current Codex versions enable lifecycle hooks by default, so no feature flag is 
                         "type": "command",
                         "command": "serena-hooks activate --client=codex",
                         "statusMessage": "Activating Serena project",
+                        "timeout": 5
+                    }
+                ]
+            }
+        ],
+        "UserPromptSubmit": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "serena-hooks plan-context --client=codex",
+                        "statusMessage": "Applying Serena plan context",
                         "timeout": 5
                     }
                 ]
@@ -386,14 +409,21 @@ Each Codex event maps to one Serena hook command:
 | Codex event | Serena command | When it runs |
 | --- | --- | --- |
 | `PreToolUse` with matcher `Bash` | `serena-hooks remind` | Before a shell command, to detect drift from Serena's symbolic tools |
+| `PreToolUse` with matcher `^mcp__serena__` | `serena-hooks plan-guard` | Before a Serena MCP tool call, to block edit-capable tools in plan mode |
 | `SessionStart` with matcher `startup\|resume` | `serena-hooks activate` | When a session starts or resumes, to prompt project activation |
+| `UserPromptSubmit` | `serena-hooks plan-context` | Before each prompt, to add read-only Serena guidance in plan mode |
 | `SessionEnd` | `serena-hooks cleanup` | When Codex tears down the root thread, to clean up hook session data |
 
-The distinct `statusMessage` values make the three kinds of hook activity distinguishable while
+The distinct `statusMessage` values make the five kinds of hook activity distinguishable while
 they run.
 
-The `PreToolUse` matcher is intentionally restricted to `Bash`. The Serena reminder hook for Codex
-tracks shell-based grep and code-file reads, so running it for every tool call is unnecessary.
+The reminder hook's `PreToolUse` matcher is intentionally restricted to `Bash`. It tracks
+shell-based grep and code-file reads, so running it for every tool call is unnecessary. The separate
+plan guard targets Serena MCP calls. While Codex reports `permission_mode: "plan"`, it blocks every
+Serena tool marked as edit-capable, including memory-writing and shell-command tools, while leaving
+read-only tools available. Both plan hooks evaluate the current event without retaining mode state,
+so they become silent and editing is available again as soon as Codex leaves plan mode; Serena's MCP
+server does not need to restart.
 
 ### Diagnosing opaque Codex hook failures
 

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -319,16 +319,9 @@ asking Codex to "Activate the current dir as project using serena" at the start 
 do this automatically).
 
 **Hooks.**
-Codex supports lifecycle hooks; see the
-[Codex hooks documentation](https://developers.openai.com/codex/hooks) for details. To enable
-Serena's hooks for Codex, add this feature flag to `~/.codex/config.toml`:
-
-```toml
-[features]
-codex_hooks = true
-```
-
-Then create `~/.codex/hooks.json` with the following content:
+Current Codex versions enable lifecycle hooks by default, so no feature flag is required. See the
+[Codex hooks documentation](https://developers.openai.com/codex/hooks) for details. Create
+`~/.codex/hooks.json` with the following content:
 
 ```json
 {
@@ -339,7 +332,9 @@ Then create `~/.codex/hooks.json` with the following content:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "serena-hooks remind --client=codex"
+                        "command": "serena-hooks remind --client=codex",
+                        "statusMessage": "Checking Serena tool usage",
+                        "timeout": 5
                     }
                 ]
             }
@@ -350,7 +345,9 @@ Then create `~/.codex/hooks.json` with the following content:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "serena-hooks activate --client=codex"
+                        "command": "serena-hooks activate --client=codex",
+                        "statusMessage": "Activating Serena project",
+                        "timeout": 5
                     }
                 ]
             }
@@ -360,7 +357,9 @@ Then create `~/.codex/hooks.json` with the following content:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "serena-hooks cleanup --client=codex"
+                        "command": "serena-hooks cleanup --client=codex",
+                        "statusMessage": "Cleaning up Serena hook state",
+                        "timeout": 3
                     }
                 ]
             }
@@ -369,22 +368,45 @@ Then create `~/.codex/hooks.json` with the following content:
 }
 ```
 
+These timeout values are specific to Codex. Without an explicit timeout, Codex allows most hooks
+to run for 600 seconds, so the five-second reminder and activation timeouts prevent a stuck hook
+from blocking a `Bash` call or session startup for that entire default. `SessionEnd` instead
+defaults to one second and supports at most three seconds, so the cleanup hook uses that maximum.
+Codex reports timed-out commands as hook failures. Other clients may have different timeout
+behaviour; in particular, the Grok cleanup example below intentionally remains at five seconds.
+
 The `SessionEnd` cleanup hook requires Codex 0.145.0 or newer. Older Codex versions only support
 `Stop` for cleanup, which currently has a [known compatibility issue](https://github.com/oraios/serena/issues/1533).
 If you still configure it, replace `SessionEnd` with `Stop` in the example above. Configure cleanup
 under exactly one of these events, never both: `Stop` runs after every turn, while `SessionEnd` runs
 when Codex tears down the root thread.
 
-The hooks will:
+Each Codex event maps to one Serena hook command:
 
-- **`activate`**: Prompt the agent to activate the current project and read Serena's instructions
-  when a Codex session starts or resumes.
-- **`remind`**: Nudge the agent to use Serena's symbolic tools when it makes too many consecutive
-  code-search or code-file-read calls without using Serena tools in between.
-- **`cleanup`**: Clean up hook session data when the session ends.
+| Codex event | Serena command | When it runs |
+| --- | --- | --- |
+| `PreToolUse` with matcher `Bash` | `serena-hooks remind` | Before a shell command, to detect drift from Serena's symbolic tools |
+| `SessionStart` with matcher `startup\|resume` | `serena-hooks activate` | When a session starts or resumes, to prompt project activation |
+| `SessionEnd` | `serena-hooks cleanup` | When Codex tears down the root thread, to clean up hook session data |
+
+The distinct `statusMessage` values make the three kinds of hook activity distinguishable while
+they run.
 
 The `PreToolUse` matcher is intentionally restricted to `Bash`. The Serena reminder hook for Codex
 tracks shell-based grep and code-file reads, so running it for every tool call is unnecessary.
+
+### Diagnosing opaque Codex hook failures
+
+Codex may report that a hook failed without identifying the configured command or showing enough
+of its output to diagnose the cause. [Codex issue #27052](https://github.com/openai/codex/issues/27052)
+tracks richer hook failure diagnostics. Use Codex's `/hooks` command first to inspect hook sources,
+trust state, and enabled hooks.
+
+While that issue remains open, an advanced local wrapper can add an inner timeout and capture a
+bounded, redacted tail of stdout and stderr. Keep wrappers out of the standard setup: they add
+another script and executable path, platform-specific timeout behaviour, log rotation and redaction
+concerns, and another hook definition hash to review and trust. Such wrappers work around Codex's
+diagnostic limitations; Serena does not require them.
 
 ## Grok
 

--- a/scripts/gen_tool_capabilities.py
+++ b/scripts/gen_tool_capabilities.py
@@ -1,0 +1,35 @@
+"""Generate lightweight tool-capability metadata for hook processes."""
+
+from pathlib import Path
+
+from serena.constants import REPO_ROOT
+from serena.tools import ToolRegistry
+
+TARGET_PATH = Path(REPO_ROOT) / "src" / "serena" / "generated" / "tool_capabilities.py"
+
+
+def _render_tool_capabilities(edit_capable_tool_names: list[str]) -> str:
+    entries = "\n".join(f'        "{tool_name}",' for tool_name in edit_capable_tool_names)
+    return f'''"""Generated tool-capability metadata. Do not edit manually."""
+
+EDIT_CAPABLE_TOOL_NAMES: frozenset[str] = frozenset(
+    {{
+{entries}
+    }}
+)
+'''
+
+
+def main() -> None:
+    # derive the manifest exclusively from registered tool metadata
+    registry = ToolRegistry()
+    edit_capable_tool_names = sorted(
+        tool_class.get_name_from_cls() for tool_class in registry.get_all_tool_classes() if tool_class.can_edit()
+    )
+
+    # replace the generated module deterministically
+    TARGET_PATH.write_text(_render_tool_capabilities(edit_capable_tool_names))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/serena/generated/tool_capabilities.py
+++ b/src/serena/generated/tool_capabilities.py
@@ -1,0 +1,26 @@
+"""Generated tool-capability metadata. Do not edit manually."""
+
+EDIT_CAPABLE_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "create_text_file",
+        "delete_lines",
+        "delete_memory",
+        "edit_memory",
+        "execute_shell_command",
+        "insert_after_symbol",
+        "insert_at_line",
+        "insert_before_symbol",
+        "jet_brains_inline_symbol",
+        "jet_brains_move",
+        "jet_brains_rename",
+        "jet_brains_safe_delete",
+        "rename_memory",
+        "rename_symbol",
+        "replace_content",
+        "replace_in_files",
+        "replace_lines",
+        "replace_symbol_body",
+        "safe_delete_symbol",
+        "write_memory",
+    }
+)

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -12,6 +12,7 @@ from typing import Literal, Self
 
 import click
 
+from serena.generated.tool_capabilities import EDIT_CAPABLE_TOOL_NAMES
 from serena.util.cli_util import AutoRegisteringGroup
 
 # copied from serena_config.py, we don't want to import anything here to keep the hook commands fast
@@ -35,6 +36,10 @@ class Hook(ABC):
         self._input_data = input_data
         self._client = client
 
+        # parse the permission mode shared by Codex hook events
+        raw_permission_mode = input_data.get("permission_mode") or input_data.get("permissionMode") or ""
+        self._permission_mode = str(raw_permission_mode).strip()
+
         session_id = input_data.get("session_id") or input_data.get("sessionId")
         if not session_id:
             raise ValueError("Session ID is required in the hook input data")
@@ -46,6 +51,10 @@ class Hook(ABC):
     @abstractmethod
     def execute(self) -> None:
         pass
+
+    def _is_plan_mode(self) -> bool:
+        """Whether the current hook payload reports Codex plan mode."""
+        return self._permission_mode == "plan"
 
 
 class PreToolUseHook(Hook, ABC):
@@ -78,10 +87,6 @@ class PreToolUseHook(Hook, ABC):
         #  We currently don't parse such tool input and hence don't react to it in hooks
         self._tool_input: dict | None = raw_tool_input if isinstance(raw_tool_input, dict) else None
 
-        # only relevant in claude code at the moment, (not all events include this field; default to empty string)
-        raw_permission_mode = self._input_data.get("permission_mode") or self._input_data.get("permissionMode") or ""
-        self._permission_mode = str(raw_permission_mode).strip()
-
     @dataclass
     class OutputData:
         permission_decision: Literal["deny", "allow"]
@@ -110,6 +115,15 @@ class PreToolUseHook(Hook, ABC):
         return "serena" in self._tool_name and not any(
             substring in self._tool_name for substring in self._NON_SYMBOLIC_SERENA_TOOL_NAME_SUBSTRINGS
         )
+
+    def _get_codex_serena_tool_name(self) -> str | None:
+        """Serena tool name from a canonical Codex MCP hook name, if present."""
+        prefix = "mcp__serena__"
+        if not self._tool_name.startswith(prefix):
+            return None
+
+        tool_name = self._tool_name.removeprefix(prefix)
+        return tool_name or None
 
 
 class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
@@ -583,6 +597,49 @@ class PreToolUseAutoApproveSerenaHook(PreToolUseHook):
         click.echo(output_data.to_json_string(self._client))
 
 
+class CodexPlanContextHook(Hook):
+    """User-prompt hook that supplies Serena's plan-mode usage boundary to Codex."""
+
+    _ADDITIONAL_CONTEXT = (
+        "Codex is in plan mode. Use Serena only for read-only repository analysis and planning; do not call edit-capable Serena tools."
+    )
+
+    def execute(self) -> None:
+        # gate guidance on the current event's permission mode
+        if not self._is_plan_mode():
+            return
+
+        # emit Codex's event-specific additional-context shape
+        result = {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": self._ADDITIONAL_CONTEXT,
+            }
+        }
+        click.echo(json.dumps(result))
+
+
+class CodexPlanGuardHook(PreToolUseHook):
+    """Pre-tool-use hook that blocks edit-capable Serena tools in Codex plan mode."""
+
+    def execute(self) -> None:
+        # gate enforcement on the current event's permission mode
+        if not self._is_plan_mode():
+            return
+
+        # classify the canonical MCP tool name through generated metadata
+        tool_name = self._get_codex_serena_tool_name()
+        if tool_name not in EDIT_CAPABLE_TOOL_NAMES:
+            return
+
+        # deny only edit-capable Serena tools
+        output_data = self.OutputData(
+            permission_decision="deny",
+            permission_decision_reason=f"Blocked Serena tool '{tool_name}': edit-capable tools are unavailable in plan mode.",
+        )
+        click.echo(output_data.to_json_string(self._client))
+
+
 _client_option = click.option(
     "--client",
     type=click.Choice([e.value for e in HookClient], case_sensitive=False),
@@ -595,6 +652,14 @@ _client_option = click.option(
 class HookCommands(AutoRegisteringGroup):
     def __init__(self) -> None:
         super().__init__(name="serena-hook", help="Commands that send reminders to agents when appropriate, to be used in hooks.")
+
+    @staticmethod
+    def _require_codex_client(client: str) -> HookClient:
+        """Codex client value or a usage error for unsupported clients."""
+        hook_client = HookClient(client)
+        if hook_client != HookClient.CODEX:
+            raise click.UsageError("This command is only supported for Codex (--client=codex).")
+        return hook_client
 
     @staticmethod
     @click.command(
@@ -629,6 +694,24 @@ class HookCommands(AutoRegisteringGroup):
     @_client_option
     def auto_approve(client: str) -> None:
         PreToolUseAutoApproveSerenaHook(HookClient(client)).execute()
+
+    @staticmethod
+    @click.command(
+        "plan-context",
+        help="Set this as a Codex UserPromptSubmit hook to add Serena's read-only plan-mode guidance.",
+    )
+    @_client_option
+    def plan_context(client: str) -> None:
+        CodexPlanContextHook(HookCommands._require_codex_client(client)).execute()
+
+    @staticmethod
+    @click.command(
+        "plan-guard",
+        help="Set this as a Codex PreToolUse hook to block edit-capable Serena tools in plan mode.",
+    )
+    @_client_option
+    def plan_guard(client: str) -> None:
+        CodexPlanGuardHook(HookCommands._require_codex_client(client)).execute()
 
 
 hook_commands = HookCommands()

--- a/test/serena/config/test_codex_docs.py
+++ b/test/serena/config/test_codex_docs.py
@@ -1,0 +1,64 @@
+import json
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _extract_codex_hook_config(markdown: str) -> dict:
+    section_match = re.search(r"\n## Codex \(CLI and App\)\n(.*?)(?=\n## |\Z)", markdown, re.DOTALL)
+    assert section_match is not None
+
+    config_match = re.search(r"```json\n(\{.*?\})\n```", section_match.group(1), re.DOTALL)
+    assert config_match is not None
+    return json.loads(config_match.group(1))
+
+
+def _handlers_by_command(config: dict) -> dict[str, dict]:
+    handlers_by_command = {}
+    for event, groups in config["hooks"].items():
+        for group in groups:
+            for handler in group["hooks"]:
+                handlers_by_command[handler["command"]] = {
+                    "event": event,
+                    "matcher": group.get("matcher"),
+                    "statusMessage": handler.get("statusMessage"),
+                    "timeout": handler.get("timeout"),
+                }
+    return handlers_by_command
+
+
+def test_codex_hook_example_configures_plan_awareness_and_preserves_existing_timeouts():
+    clients_doc = (PROJECT_ROOT / "docs/02-usage/030_clients.md").read_text()
+    handlers = _handlers_by_command(_extract_codex_hook_config(clients_doc))
+
+    assert handlers["serena-hooks remind --client=codex"] == {
+        "event": "PreToolUse",
+        "matcher": "Bash",
+        "statusMessage": "Checking Serena tool usage",
+        "timeout": 5,
+    }
+    assert handlers["serena-hooks plan-guard --client=codex"] == {
+        "event": "PreToolUse",
+        "matcher": "^mcp__serena__",
+        "statusMessage": "Checking Serena plan-mode permissions",
+        "timeout": 5,
+    }
+    assert handlers["serena-hooks activate --client=codex"] == {
+        "event": "SessionStart",
+        "matcher": "startup|resume",
+        "statusMessage": "Activating Serena project",
+        "timeout": 5,
+    }
+    assert handlers["serena-hooks plan-context --client=codex"] == {
+        "event": "UserPromptSubmit",
+        "matcher": None,
+        "statusMessage": "Applying Serena plan context",
+        "timeout": 5,
+    }
+    assert handlers["serena-hooks cleanup --client=codex"] == {
+        "event": "SessionEnd",
+        "matcher": None,
+        "statusMessage": "Cleaning up Serena hook state",
+        "timeout": 3,
+    }

--- a/test/serena/test_edit_marker.py
+++ b/test/serena/test_edit_marker.py
@@ -1,4 +1,5 @@
-from serena.tools import CreateTextFileTool, ReadFileTool, Tool
+from serena.generated.tool_capabilities import EDIT_CAPABLE_TOOL_NAMES
+from serena.tools import CreateTextFileTool, ReadFileTool, Tool, ToolRegistry
 
 
 class TestEditMarker:
@@ -11,3 +12,11 @@ class TestEditMarker:
         # Editing tool should return True
         assert issubclass(CreateTextFileTool, Tool)
         assert CreateTextFileTool.can_edit()
+
+    def test_generated_edit_capabilities_match_tool_metadata(self):
+        registry = ToolRegistry()
+        expected_edit_capabilities = frozenset(
+            tool_class.get_name_from_cls() for tool_class in registry.get_all_tool_classes() if tool_class.can_edit()
+        )
+
+        assert expected_edit_capabilities == EDIT_CAPABLE_TOOL_NAMES

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -61,6 +61,33 @@ def _read_input(tool_name: str = "read", session_id: str = "test-session-123", f
     }
 
 
+def _codex_prompt_input(permission_mode: str | None, permission_mode_key: str = "permission_mode") -> dict:
+    data = {
+        "session_id": "codex-plan-context",
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Plan this change",
+    }
+    if permission_mode is not None:
+        data[permission_mode_key] = permission_mode
+    return data
+
+
+def _codex_tool_input(
+    tool_name: str,
+    permission_mode: str | None,
+    session_id: str = "codex-plan-guard",
+) -> dict:
+    data = {
+        "session_id": session_id,
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool_name,
+        "tool_input": {},
+    }
+    if permission_mode is not None:
+        data["permission_mode"] = permission_mode
+    return data
+
+
 def _execute_remind_hook(client: HookClient, payload: dict, tmp_path: Path) -> None:
     with patch("sys.stdin", _make_stdin(payload)), patch("serena.hooks.serena_home_dir", str(tmp_path)):
         PreToolUseRemindAboutSymbolicToolsHook(client).execute()
@@ -930,6 +957,138 @@ class TestPreToolUseAutoApproveSerenaHook:
         with patch("sys.stdin", _make_stdin(stdin_data)), patch("serena.hooks.serena_home_dir", str(tmp_path)):
             PreToolUseAutoApproveSerenaHook(HookClient.CLAUDE_CODE).execute()
         assert capsys.readouterr().out == ""
+
+
+class TestCodexPlanHooks:
+    def test_plan_context_emits_read_only_guidance(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            hook_commands,
+            ["plan-context", "--client", "codex"],
+            input=json.dumps(_codex_prompt_input("plan")),
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": (
+                    "Codex is in plan mode. Use Serena only for read-only repository analysis and planning; "
+                    "do not call edit-capable Serena tools."
+                ),
+            }
+        }
+
+    def test_plan_context_accepts_camel_case_permission_mode(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            hook_commands,
+            ["plan-context", "--client", "codex"],
+            input=json.dumps(_codex_prompt_input("plan", permission_mode_key="permissionMode")),
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output)["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+
+    @pytest.mark.parametrize("permission_mode", [None, "default", "acceptEdits", "dontAsk", "bypassPermissions"])
+    def test_plan_context_stays_silent_outside_plan_mode(self, permission_mode: str | None):
+        runner = CliRunner()
+        result = runner.invoke(
+            hook_commands,
+            ["plan-context", "--client", "codex"],
+            input=json.dumps(_codex_prompt_input(permission_mode)),
+        )
+
+        assert result.exit_code == 0
+        assert result.output == ""
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "mcp__serena__replace_symbol_body",
+            "mcp__serena__create_text_file",
+            "mcp__serena__write_memory",
+            "mcp__serena__execute_shell_command",
+        ],
+    )
+    def test_plan_guard_denies_edit_capable_serena_tools(self, tool_name: str):
+        runner = CliRunner()
+        result = runner.invoke(
+            hook_commands,
+            ["plan-guard", "--client", "codex"],
+            input=json.dumps(_codex_tool_input(tool_name, "plan")),
+        )
+
+        assert result.exit_code == 0
+        hook_output = json.loads(result.output)["hookSpecificOutput"]
+        assert hook_output["hookEventName"] == "PreToolUse"
+        assert hook_output["permissionDecision"] == "deny"
+        assert tool_name.removeprefix("mcp__serena__") in hook_output["permissionDecisionReason"]
+        assert "plan mode" in hook_output["permissionDecisionReason"]
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "mcp__serena__find_symbol",
+            "mcp__serena__future_unknown_tool",
+            "mcp__filesystem__replace_symbol_body",
+            "replace_symbol_body",
+        ],
+    )
+    def test_plan_guard_stays_silent_for_unblocked_tools(self, tool_name: str):
+        runner = CliRunner()
+        result = runner.invoke(
+            hook_commands,
+            ["plan-guard", "--client", "codex"],
+            input=json.dumps(_codex_tool_input(tool_name, "plan")),
+        )
+
+        assert result.exit_code == 0
+        assert result.output == ""
+
+    @pytest.mark.parametrize("permission_mode", [None, "default", "acceptEdits", "dontAsk", "bypassPermissions"])
+    def test_plan_guard_stays_silent_outside_plan_mode(self, permission_mode: str | None):
+        runner = CliRunner()
+        result = runner.invoke(
+            hook_commands,
+            ["plan-guard", "--client", "codex"],
+            input=json.dumps(_codex_tool_input("mcp__serena__replace_symbol_body", permission_mode)),
+        )
+
+        assert result.exit_code == 0
+        assert result.output == ""
+
+    def test_plan_guard_uses_each_payload_without_persisting_mode(self):
+        runner = CliRunner()
+        session_id = "codex-plan-transition"
+
+        plan_result = runner.invoke(
+            hook_commands,
+            ["plan-guard", "--client", "codex"],
+            input=json.dumps(_codex_tool_input("mcp__serena__replace_symbol_body", "plan", session_id=session_id)),
+        )
+        default_result = runner.invoke(
+            hook_commands,
+            ["plan-guard", "--client", "codex"],
+            input=json.dumps(_codex_tool_input("mcp__serena__replace_symbol_body", "default", session_id=session_id)),
+        )
+
+        assert json.loads(plan_result.output)["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert default_result.exit_code == 0
+        assert default_result.output == ""
+
+    @pytest.mark.parametrize("command", ["plan-context", "plan-guard"])
+    def test_plan_commands_reject_non_codex_clients(self, command: str):
+        payload = _codex_prompt_input("plan") if command == "plan-context" else _codex_tool_input("mcp__serena__find_symbol", "plan")
+        runner = CliRunner()
+        result = runner.invoke(
+            hook_commands,
+            [command, "--client", "claude-code"],
+            input=json.dumps(payload),
+        )
+
+        assert result.exit_code != 0
+        assert "only supported for codex" in result.output.lower()
 
 
 class TestSessionEndCleanupHook:


### PR DESCRIPTION
## Summary

- generate a deterministic projection of every registered Serena tool whose class reports `can_edit()`
- add stateless Codex `plan-context` and `plan-guard` hooks using each invocation's current permission mode
- document the Codex hook configuration and protect its commands, matchers, status messages, and timeout values with a parsed documentation test

This is a stacked follow-up to #1853. Until that PR merges, its documentation commit will also appear in this draft's comparison.

Closes #1854.

## Behavior

In exact `plan` mode, `plan-context` adds read-only planning guidance and `plan-guard` denies Serena MCP tools present in the generated edit-capability set. Missing or non-plan modes remain silent, as do read-only, unknown, malformed, and non-Serena tool names. No mode state is persisted, so edit-capable tools become available immediately when a later invocation is outside plan mode.

## Validation

- `109 passed` across the hook, edit-marker, and Codex documentation tests
- source and test type checking passed
- changed-file Ruff lint and formatting checks passed
- Sphinx documentation build passed with warnings treated as errors
- regenerated the capability manifest and confirmed no diff
- confirmed importing `serena.hooks` does not import `serena.tools`
- `git diff --check` passed

The repository-wide lint command still reports five unrelated existing findings in `scripts/live_test_grok.py` and existing Java/TypeScript tests. The complete pytest suite could not finish in the managed sandbox because configuration-file access and the Serena dashboard/news endpoint were blocked; CI should provide the full-suite result.
