### PR TITLE
fix(clojure): declare didChangeWatchedFiles client capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
+  - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
+    outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate
+    its analysis; symbol queries could then answer from a stale index, e.g. `find_symbol` returning a
+    body from the position the symbol used to occupy (#1593)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/src/solidlsp/language_servers/clojure_lsp.py
+++ b/src/solidlsp/language_servers/clojure_lsp.py
@@ -325,6 +325,12 @@ class ClojureLSP(SolidLanguageServer):
                 "workspace": {
                     "applyEdit": True,
                     "workspaceEdit": {"documentChanges": True},
+                    # Serena notifies language servers about files changed outside its own
+                    # edit tools (git checkout, another editor, a build step) via
+                    # workspace/didChangeWatchedFiles; see LanguageServerManager.poll_and_notify.
+                    # Without declaring the capability, clojure-lsp is not told the client
+                    # sends those notifications and may keep answering from its stale analysis.
+                    "didChangeWatchedFiles": {"dynamicRegistration": True},
                     "symbol": {"symbolKind": {"valueSet": list(range(1, 27))}},
                     "workspaceFolders": True,
                 },

--- a/test/solidlsp/clojure/test_clojure_initialize_params.py
+++ b/test/solidlsp/clojure/test_clojure_initialize_params.py
@@ -1,0 +1,42 @@
+import pytest
+
+from solidlsp.language_servers.clojure_lsp import ClojureLSP
+
+pytestmark = pytest.mark.clojure
+
+
+def _make_server(monkeypatch: pytest.MonkeyPatch) -> ClojureLSP:
+    """Build a ClojureLSP without running __init__ (no clojure-lsp binary needed)."""
+    server = object.__new__(ClojureLSP)
+    monkeypatch.setattr(ClojureLSP, "_resolve_source_paths", lambda _self: None)
+    return server
+
+
+def test_declares_did_change_watched_files_capability(monkeypatch: pytest.MonkeyPatch) -> None:
+    """clojure-lsp must announce that the client sends workspace/didChangeWatchedFiles.
+
+    Serena notifies language servers about files changed outside its own edit tools
+    (git checkout, another editor, a build step) via that notification
+    (LanguageServerManager.poll_and_notify). A server that was never told the client
+    supports it may keep answering symbol queries from its own stale analysis, which
+    surfaces as find_symbol returning a body from the wrong location.
+    """
+    params = _make_server(monkeypatch)._create_base_initialize_params()
+
+    workspace = params["capabilities"]["workspace"]
+    assert "didChangeWatchedFiles" in workspace, (
+        "clojure-lsp does not declare the didChangeWatchedFiles client capability, so external file changes may not invalidate its analysis"
+    )
+    assert workspace["didChangeWatchedFiles"]["dynamicRegistration"] is True
+
+
+def test_base_initialize_params_keep_existing_workspace_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The added capability must not displace the ones already relied upon."""
+    workspace = _make_server(monkeypatch)._create_base_initialize_params()["capabilities"]["workspace"]
+
+    assert workspace["applyEdit"] is True
+    assert workspace["workspaceEdit"] == {"documentChanges": True}
+    assert workspace["workspaceFolders"] is True
+    assert workspace["symbol"]["symbolKind"]["valueSet"] == list(range(1, 27))


### PR DESCRIPTION
Relates to #1593.

`ClojureLSP` never declared the `workspace.didChangeWatchedFiles` client capability, so clojure-lsp is not told that Serena sends those notifications.

## Why that matters

Serena already handles the "file changed outside my own edit tools" case: `LanguageServerManager.poll_and_notify` (`src/serena/ls_manager.py:296-356`) diffs mtimes across tracked source files and sends `workspace/didChangeWatchedFiles` to every running language server. Its docstring names the scenario exactly:

> edits made through any other channel (another editor, a second agent, a git checkout, a build step) are otherwise invisible to a warm language server, causing symbolic queries to answer from a stale index

But per LSP, `didChangeWatchedFiles` is a **client capability**. A server that never saw it advertised has no obligation to act on those notifications (and may not register watchers or invalidate its analysis on them). clojure-lsp keeps its own analysis database, which is what would then go stale.

`DefaultInitializeParamsBuilder` (`src/solidlsp/initialize_params.py`) only injects `processId`, `rootPath`, `rootUri`, `clientInfo`, `workspaceFolders` and `initializationOptions` — it never merges a default `capabilities` block, so nothing supplied this on the server's behalf.

For reference, `rust_analyzer.py`, `pyright_server.py`, `eclipse_jdtls.py`, `sourcekit_lsp.py` and others already declare it; clojure-lsp did not.

## Change

Adds `"didChangeWatchedFiles": {"dynamicRegistration": True}` to clojure-lsp's workspace capabilities, plus a comment explaining why it must stay.

## Tests

New `test/solidlsp/clojure/test_clojure_initialize_params.py`, 2 tests that need **no** clojure-lsp binary or JVM (they build the params via `object.__new__` like `test_rust_analyzer_settings.py` does):

- `test_declares_did_change_watched_files_capability` — the capability is present with `dynamicRegistration`
- `test_base_initialize_params_keep_existing_workspace_capabilities` — a guard that the addition does not displace `applyEdit` / `workspaceEdit` / `workspaceFolders` / `symbol`

## Verification

- 2 new tests pass.
- Mutation-checked: removing only the added capability line fails `test_declares_did_change_watched_files_capability` while the guard test still passes, so the test measures the change rather than decorating it.
- `test/solidlsp/clojure` + `test_rename_didopen.py` + `test_is_ignored_path_missing.py`: **20 passed, 16 skipped, 1 error**. The error is `TestClojureDiagnostics::test_file_diagnostics`, which needs a live clojure-lsp and is present identically on an unmodified checkout (I have no JVM here).
- `ruff check` and `ruff format --check` clean.
- `CHANGELOG.md` updated under "Language Servers" per CONTRIBUTING.

## Scope / honesty about what this does not prove

I could not run clojure-lsp locally, so I have **not** observed this fixing #1593 end to end. The reasoning is from the code: Serena sends the notification, clojure-lsp was never told the client sends it. If clojure-lsp watches the filesystem on its own initiative regardless of client capabilities, then this is correct protocol hygiene but not the root cause of that issue, and #1593 should stay open.

I deliberately kept this to the capability declaration. The second idea from my analysis on the issue — validating that a symbol's `selectionRange` is contained within its `location.range`, so a mismatched name/body pair is logged instead of silently returned — is a broader change across all language servers and belongs in its own PR if maintainers want it.
