### PR TITLE
Add Nim language server support via nimlangserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     project list in `serena_config.yml`
 
 * Language Servers:
+  - Add experimental Nim support via nimlangserver (`.nim`, `.nims`, `.nimble`); requires the `nimlangserver`
+    binary and a Nim toolchain on PATH (#645)
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Serena incorporates a powerful abstraction layer for the integration of language
 The underlying language servers are typically open-source projects or at least freely available for use.
 
 When using Serena's language server backend, we provide **support for over 40 programming languages**, including
-Ada / SPARK, AL, Angular, Ansible, Bash, BSL, C#, C/C++, Clojure, Crystal, CUE, Dart, Deno, Elixir, Elm, Erlang, Fortran, F#, GDScript, Gleam, GLSL, Go, Groovy, Haskell, Haxe, HLSL, HTML, Java, JavaScript, JSON, Julia, Kotlin, LaTeX, Lean 4, Lua, Luau, Markdown, MATLAB, mSL, Nextflow, Nix, OCaml, Pascal, Perl, PHP, PowerShell, Python, QML, R, Rego, Ruby, Rust, Scala, SCSS / Sass / CSS, Solidity, Svelte, Swift, SystemVerilog, Terraform, TOML, TypeScript, Vue, WGSL, Wolfram Language, YAML, and Zig.
+Ada / SPARK, AL, Angular, Ansible, Bash, BSL, C#, C/C++, Clojure, Crystal, CUE, Dart, Deno, Elixir, Elm, Erlang, Fortran, F#, GDScript, Gleam, GLSL, Go, Groovy, Haskell, Haxe, HLSL, HTML, Java, JavaScript, JSON, Julia, Kotlin, LaTeX, Lean 4, Lua, Luau, Markdown, MATLAB, mSL, Nextflow, Nim, Nix, OCaml, Pascal, Perl, PHP, PowerShell, Python, QML, R, Rego, Ruby, Rust, Scala, SCSS / Sass / CSS, Solidity, Svelte, Swift, SystemVerilog, Terraform, TOML, TypeScript, Vue, WGSL, Wolfram Language, YAML, and Zig.
 
 ### The Serena JetBrains Plugin
 

--- a/docs/01-about/020_programming-languages.md
+++ b/docs/01-about/020_programming-languages.md
@@ -122,6 +122,12 @@ Some languages require additional installations or setup steps, as noted.
   downloaded; requires a Java 17+ runtime, discovered via `ls_specific_settings.nextflow.java_home`, `JAVA_HOME` or `java` on PATH;
   covers `.nf` scripts — Nextflow `.config` files are not treated as source files, since the language server reports no symbols for them;
   processes, workflows and functions are reported under their declared name, e.g. `GREET` for `process GREET`)
+* **Nim** (experimental)  
+  (requires the [nimlangserver](https://github.com/nim-lang/langserver) binary — `nimble install nimlangserver`, which
+  places it in `~/.nimble/bin` — plus a Nim toolchain (`nim`/`nimsuggest`) on PATH; covers `.nim`, `.nims` and `.nimble` files.
+  nimlangserver drives nimsuggest, which compiles the project lazily, so the first lookup of a session can be slow; document
+  symbols and go-to-definition (including across files) work, but nimsuggest's find-references does not resolve cross-file
+  usages reliably)
 * **Nix**  
   (requires nixd installation)
 * **OCaml**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,7 @@ markers = [
   "snapshot: snapshot tests for symbolic editing operations",
   "ruby: language server running for Ruby (uses ruby-lsp)",
   "zig: language server running for Zig",
+  "nim: language server running for Nim",
   "lua: language server running for Lua",
   "luau: language server running for Luau",
   "nextflow: language server running for Nextflow",

--- a/src/serena/resources/project.template.yml
+++ b/src/serena/resources/project.template.yml
@@ -2,6 +2,7 @@
 project_name: "project_name"
 
 # list of language servers to start when using the LSP backend; choose from:
+
 #   ada                    al                     angular                ansible                bash
 #   bsl                    clojure                cpp                    cpp_ccls               crystal
 #   csharp                 csharp_omnisharp       cue                    dart                   deno
@@ -10,13 +11,13 @@ project_name: "project_name"
 #   haxe                   hlsl                   html                   java                   json
 #   julia                  kotlin                 latex                  lean4                  lua
 #   luau                   markdown               matlab                 msl                    nextflow
-#   nix                    ocaml                  pascal                 perl                   php
-#   php_phpactor           php_phpantom           powershell             python                 python_basedpyright
-#   python_jedi            python_pyrefly         python_ty              qml                    r
-#   rego                   ruby                   ruby_solargraph        rust                   scala
-#   scss                   solidity               svelte                 swift                  systemverilog
-#   terraform              toml                   typescript             typescript_vts         vue
-#   wolfram                yaml                   zig
+#   nim                    nix                    ocaml                  pascal                 perl
+#   php                    php_phpactor           php_phpantom           powershell             python
+#   python_basedpyright    python_jedi            python_pyrefly         python_ty              qml
+#   r                      rego                   ruby                   ruby_solargraph        rust
+#   scala                  scss                   solidity               svelte                 swift
+#   systemverilog          terraform              toml                   typescript             typescript_vts
+#   vue                    wolfram                yaml                   zig
 #   (This list may be outdated; generated with scripts/print_language_list.py;
 #   For the current list, see values of the LanguageServerId enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)

--- a/src/solidlsp/language_servers/nim_language_server.py
+++ b/src/solidlsp/language_servers/nim_language_server.py
@@ -1,0 +1,176 @@
+"""
+Provides Nim specific instantiation of the LanguageServer class using nimlangserver.
+"""
+
+import logging
+import os
+import shutil
+
+from overrides import override
+
+from solidlsp.ls import SolidLanguageServer
+from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
+
+log = logging.getLogger(__name__)
+
+
+class NimLanguageServer(SolidLanguageServer):
+    """
+    Nim specific instantiation of the LanguageServer class using nimlangserver.
+
+    nimlangserver (https://github.com/nim-lang/langserver) is the officially
+    maintained language server for Nim. It drives one nimsuggest process per
+    project, so it needs both the ``nimlangserver`` binary and a Nim toolchain
+    (``nim`` / ``nimsuggest``) available on PATH. Install it with
+    ``nimble install nimlangserver``; nimble drops the binary in ``~/.nimble/bin``.
+
+    Nim support is experimental. nimsuggest compiles the project on the first
+    request, so the first symbol/definition lookup of a session can be slow, and
+    cross-file references depend on nimsuggest having the whole project loaded.
+    """
+
+    def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
+        nim_ls_path = self._find_nimlangserver()
+        self._check_nim_toolchain()
+
+        super().__init__(
+            config,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=nim_ls_path, cwd=repository_root_path),
+            "nim",
+            solidlsp_settings,
+        )
+
+    @staticmethod
+    def _find_nimlangserver() -> str:
+        """
+        Find the nimlangserver executable on PATH or in the nimble bin dir.
+
+        :return: path to the nimlangserver executable
+        :raises RuntimeError: if nimlangserver is not found
+        """
+        path = shutil.which("nimlangserver")
+        if path is None:
+            nimble_bin = os.path.join(os.path.expanduser("~"), ".nimble", "bin", "nimlangserver")
+            if os.path.isfile(nimble_bin) and os.access(nimble_bin, os.X_OK):
+                path = nimble_bin
+        if path is None:
+            raise RuntimeError(
+                "nimlangserver (Nim language server) is not installed or not in PATH.\n"
+                "Install it with 'nimble install nimlangserver' and make sure the\n"
+                "'nimlangserver' binary is on your PATH (nimble installs it into ~/.nimble/bin).\n"
+                "See https://github.com/nim-lang/langserver for details."
+            )
+        return path
+
+    @staticmethod
+    def _check_nim_toolchain() -> None:
+        """
+        Ensure the Nim toolchain nimlangserver depends on is available.
+
+        :raises RuntimeError: if nimsuggest is not found
+        """
+        if shutil.which("nimsuggest") is None:
+            nimble_bin = os.path.join(os.path.expanduser("~"), ".nimble", "bin", "nimsuggest")
+            if not (os.path.isfile(nimble_bin) and os.access(nimble_bin, os.X_OK)):
+                raise RuntimeError(
+                    "nimlangserver requires the Nim toolchain (nimsuggest) but it was not found on PATH.\n"
+                    "Install Nim from https://nim-lang.org/install.html (e.g. via choosenim or your\n"
+                    "package manager) and make sure 'nimsuggest' is available on your PATH."
+                )
+
+    def _create_base_initialize_params(self) -> dict:
+        """
+        Return the initialize params for the Nim language server (server-specific keys only).
+        """
+        return {
+            "locale": "en",
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {"didSave": True, "dynamicRegistration": True},
+                    "definition": {"dynamicRegistration": True, "linkSupport": True},
+                    "references": {"dynamicRegistration": True},
+                    "documentSymbol": {
+                        "dynamicRegistration": True,
+                        "hierarchicalDocumentSymbolSupport": True,
+                        "symbolKind": {"valueSet": list(range(1, 27))},
+                    },
+                    "completion": {
+                        "dynamicRegistration": True,
+                        "completionItem": {
+                            "snippetSupport": True,
+                            "documentationFormat": ["markdown", "plaintext"],
+                        },
+                    },
+                    "hover": {
+                        "dynamicRegistration": True,
+                        "contentFormat": ["markdown", "plaintext"],
+                    },
+                },
+                "workspace": {
+                    "workspaceFolders": True,
+                    "didChangeConfiguration": {"dynamicRegistration": True},
+                    "configuration": True,
+                },
+            },
+            # nimlangserver reads its options from the workspace configuration; the
+            # defaults (auto-discovered nimsuggest, auto project mapping) are what we want.
+            "initializationOptions": {},
+        }
+
+    def _start_server(self) -> None:
+        """Start the Nim language server (nimlangserver) process."""
+
+        def register_capability_handler(_params: dict) -> None:
+            return
+
+        def workspace_configuration_handler(params: dict) -> list[dict]:
+            # nimlangserver pulls its configuration via workspace/configuration and expects a
+            # JSON array (one entry per requested item); the nimsuggest defaults are what we want.
+            items = params.get("items", []) if isinstance(params, dict) else []
+            return [{} for _ in items]
+
+        def window_log_message(msg: dict) -> None:
+            log.info(f"LSP: window/logMessage: {msg}")
+
+        def status_update(msg: dict) -> None:
+            # nimlangserver reports nimsuggest lifecycle here (e.g. project loaded).
+            log.info(f"LSP: extension/statusUpdate: {msg}")
+
+        def do_nothing(_params: dict) -> None:
+            return
+
+        self.server.on_request("client/registerCapability", register_capability_handler)
+        self.server.on_request("workspace/configuration", workspace_configuration_handler)
+        self.server.on_notification("window/logMessage", window_log_message)
+        self.server.on_notification("window/showMessage", window_log_message)
+        self.server.on_notification("extension/statusUpdate", status_update)
+        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+
+        log.info("Starting Nim language server (nimlangserver) process")
+        self.server.start()
+        initialize_params = self._create_initialize_params()
+
+        log.info("Sending initialize request from LSP client to LSP server and awaiting response")
+        init_response = self.server.send.initialize(initialize_params)
+
+        capabilities = init_response["capabilities"]
+        log.info(f"Nim language server capabilities: {list(capabilities.keys())}")
+        assert "textDocumentSync" in capabilities, "textDocumentSync capability missing"
+
+        self.server.notify.initialized({})
+
+    @override
+    def _get_wait_time_for_cross_file_referencing(self) -> float:
+        # nimsuggest compiles the project lazily; give it time to load before
+        # cross-file reference queries so it can resolve symbols across modules.
+        return 5.0
+
+    @override
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        # nimcache holds generated C sources / build artifacts; nimble stores
+        # downloaded dependencies under nimbledeps.
+        return super().is_ignored_dirname(dirname) or dirname in ["nimcache", "nimbledeps", "htmldocs"]

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -115,6 +115,13 @@ class LanguageServerId(str, Enum):
     CRYSTAL = "crystal"
     CUE = "cue"
     ZIG = "zig"
+    NIM = "nim"
+    """Nim language server using nimlangserver (nim-lang/langserver).
+    Supports .nim, .nims and .nimble files. Requires the `nimlangserver` binary
+    (nimble install nimlangserver) plus a Nim toolchain (nim/nimsuggest) on PATH.
+    Experimental: nimsuggest compiles the project lazily, so the first lookup of
+    a session can be slow and cross-file references depend on project load state.
+    """
     LUA = "lua"
     LUAU = "luau"
     """Luau Language Server for Roblox's Luau language (typed Lua 5.1 superset).
@@ -346,6 +353,7 @@ class LanguageServerId(str, Enum):
             self.SCSS,
             self.ANGULAR,
             self.DENO,
+            self.NIM,
         }
 
     def is_programming_language(self) -> bool:
@@ -510,6 +518,8 @@ class LanguageServerId(str, Enum):
                 return FilenameMatcher(".toml")
             case self.ZIG:
                 return FilenameMatcher(".zig", ".zon")
+            case self.NIM:
+                return FilenameMatcher(".nim", ".nims", ".nimble")
             case self.LUA:
                 return FilenameMatcher(".lua")
             case self.LUAU:
@@ -778,6 +788,10 @@ class LanguageServerId(str, Enum):
                 from solidlsp.language_servers.zls import ZigLanguageServer
 
                 return ZigLanguageServer
+            case self.NIM:
+                from solidlsp.language_servers.nim_language_server import NimLanguageServer
+
+                return NimLanguageServer
             case self.NIX:
                 from solidlsp.language_servers.nixd_ls import NixLanguageServer
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -471,6 +471,10 @@ def _determine_disabled_language_servers() -> list[LanguageServerId]:
         result.append(LanguageServerId.LEAN4)
     if _sh.which("crystalline") is None:
         result.append(LanguageServerId.CRYSTAL)
+    # nimlangserver drives nimsuggest; both it and the Nim toolchain must be present. nimble installs
+    # the binary into ~/.nimble/bin, which may not be on PATH, so check there too.
+    if _sh.which("nimlangserver") is None and not os.path.isfile(os.path.expanduser("~/.nimble/bin/nimlangserver")):
+        result.append(LanguageServerId.NIM)
     if _sh.which("julia") is None:  # LanguageServer.jl is auto-installed by the LS when julia is present
         result.append(LanguageServerId.JULIA)
     if _sh.which("nixd") is None:

--- a/test/resources/repos/nim/test_repo/.gitignore
+++ b/test/resources/repos/nim/test_repo/.gitignore
@@ -1,0 +1,4 @@
+nimcache/
+nimbledeps/
+main
+*.exe

--- a/test/resources/repos/nim/test_repo/src/main.nim
+++ b/test/resources/repos/nim/test_repo/src/main.nim
@@ -1,0 +1,29 @@
+import utils
+
+type
+  Calculator* = object
+
+  User* = object
+    name*: string
+    age*: int
+
+proc add*(self: Calculator, a, b: int): int =
+  a + b
+
+proc multiply*(self: Calculator, a, b: int): int =
+  a * b
+
+proc greet*(self: User): string =
+  formatGreeting(self.name, self.age)
+
+proc isAdult*(self: User): bool =
+  self.age >= 18
+
+when isMainModule:
+  let calc = Calculator()
+  echo "Result: ", calc.add(5, 3)
+
+  let user = User(name: "Alice", age: 30)
+  echo user.greet()
+
+  echo "Circle area: ", calculateArea(5.0)

--- a/test/resources/repos/nim/test_repo/src/utils.nim
+++ b/test/resources/repos/nim/test_repo/src/utils.nim
@@ -1,0 +1,7 @@
+import std/math
+
+proc calculateArea*(radius: float): float =
+  PI * radius * radius
+
+proc formatGreeting*(name: string, age: int): string =
+  "Hello, my name is " & name & " and I am " & $age & " years old."

--- a/test/resources/repos/nim/test_repo/test_repo.nimble
+++ b/test/resources/repos/nim/test_repo/test_repo.nimble
@@ -1,0 +1,8 @@
+version       = "0.1.0"
+author        = "Serena"
+description    = "Minimal Nim project for Serena language server tests"
+license        = "MIT"
+srcDir         = "src"
+bin            = @["main"]
+
+requires "nim >= 1.6.0"

--- a/test/solidlsp/nim/test_nim_basic.py
+++ b/test/solidlsp/nim/test_nim_basic.py
@@ -1,0 +1,123 @@
+"""
+Basic integration tests for the Nim language server (nimlangserver) functionality.
+
+These validate document symbols, the full symbol tree, within-file references and
+cross-file go-to-definition using the Nim test repository.
+
+nimlangserver drives nimsuggest, which compiles the project lazily, so the first
+requests of a session can be slow. nimsuggest's find-references does not resolve
+cross-file usages reliably, so cross-file navigation is covered via go-to-definition
+(which does work) rather than textDocument/references.
+"""
+
+import os
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import LanguageServerId
+from solidlsp.ls_utils import SymbolUtils
+from test.conftest import language_server_tests_enabled
+from test.solidlsp.conftest import format_symbol_for_assert, has_malformed_name, request_all_symbols
+
+pytestmark = [
+    pytest.mark.nim,
+    pytest.mark.skipif(
+        not language_server_tests_enabled(LanguageServerId.NIM),
+        reason="Nim tests are disabled (nimlangserver not available)",
+    ),
+]
+
+
+class TestNimDocumentSymbols:
+    """Document symbol retrieval, which nimsuggest supports reliably."""
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.NIM], indirect=True)
+    def test_ls_is_running(self, language_server: SolidLanguageServer) -> None:
+        assert language_server.is_running()
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.NIM], indirect=True)
+    def test_document_symbols_main(self, language_server: SolidLanguageServer) -> None:
+        file_path = os.path.join("src", "main.nim")
+        all_symbols, _roots = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+
+        symbol_names = {s.get("name") for s in all_symbols if s.get("name")}
+        for expected in ("Calculator", "User", "add", "multiply", "greet", "isAdult"):
+            assert expected in symbol_names, f"{expected} not found in main.nim symbols. Found: {sorted(symbol_names)}"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.NIM], indirect=True)
+    def test_document_symbols_utils(self, language_server: SolidLanguageServer) -> None:
+        file_path = os.path.join("src", "utils.nim")
+        all_symbols, _roots = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+
+        symbol_names = {s.get("name") for s in all_symbols if s.get("name")}
+        assert "calculateArea" in symbol_names, f"calculateArea not found. Found: {sorted(symbol_names)}"
+        assert "formatGreeting" in symbol_names, f"formatGreeting not found. Found: {sorted(symbol_names)}"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.NIM], indirect=True)
+    def test_full_symbol_tree(self, language_server: SolidLanguageServer) -> None:
+        symbols = language_server.request_full_symbol_tree()
+        for name in ("Calculator", "User", "add", "calculateArea", "formatGreeting"):
+            assert SymbolUtils.symbol_tree_contains_name(symbols, name), f"{name} not found in symbol tree"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.NIM], indirect=True)
+    def test_bare_symbol_names(self, language_server: SolidLanguageServer) -> None:
+        all_symbols = request_all_symbols(language_server)
+        malformed_symbols = [s for s in all_symbols if has_malformed_name(s)]
+        if malformed_symbols:
+            pytest.fail(
+                f"Found malformed symbols: {[format_symbol_for_assert(sym) for sym in malformed_symbols]}",
+                pytrace=False,
+            )
+
+
+class TestNimReferences:
+    """Reference finding and go-to-definition."""
+
+    @staticmethod
+    def _symbol_selection_start(language_server: SolidLanguageServer, file_path: str, name: str) -> dict:
+        all_symbols, _roots = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+        symbol = next((s for s in all_symbols if s.get("name") == name), None)
+        assert symbol is not None, f"{name} not found in {file_path}"
+        sel_range = symbol.get("selectionRange", symbol.get("range"))
+        assert sel_range is not None, f"{name} has no range information"
+        return sel_range["start"]
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.NIM], indirect=True)
+    def test_references_within_file(self, language_server: SolidLanguageServer) -> None:
+        """Calculator is used by both proc receivers and the instantiation in main.nim."""
+        file_path = os.path.join("src", "main.nim")
+        start = self._symbol_selection_start(language_server, file_path, "Calculator")
+
+        refs = language_server.request_references(file_path, start["line"], start["character"])
+        assert isinstance(refs, list)
+
+        ref_files = {os.path.basename(ref.get("relativePath") or ref.get("uri", "")) for ref in refs}
+        assert ref_files == {"main.nim"}, f"Within-file Calculator references should all be in main.nim, got {ref_files}"
+        # Two proc receivers (add/multiply) plus the Calculator() instantiation.
+        assert len(refs) >= 3, f"Expected at least 3 Calculator references in main.nim, found {len(refs)}"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.NIM], indirect=True)
+    def test_goto_definition_cross_file(self, language_server: SolidLanguageServer) -> None:
+        """Proc greet in main.nim calls formatGreeting, which is defined in utils.nim."""
+        main_path = os.path.join("src", "main.nim")
+
+        with language_server.open_file(main_path), language_server.open_file(os.path.join("src", "utils.nim")):
+            call_line, call_col = self._find_identifier(main_path, "formatGreeting")
+            definitions = language_server.request_definition(main_path, call_line, call_col)
+
+            assert isinstance(definitions, list) and len(definitions) > 0, "Should find a definition for formatGreeting"
+            target = definitions[0]
+            assert target.get("uri", "").endswith("utils.nim"), "formatGreeting should be defined in utils.nim"
+            assert target["range"]["start"]["line"] == 5, "formatGreeting should be defined on line 6 (0-indexed: 5)"
+
+    @staticmethod
+    def _find_identifier(rel_path: str, identifier: str) -> tuple[int, int]:
+        repo_root = os.path.join(os.path.dirname(__file__), "..", "..", "resources", "repos", "nim", "test_repo")
+        with open(os.path.join(repo_root, rel_path), encoding="utf-8") as f:
+            for line_idx, line in enumerate(f):
+                col = line.find(identifier)
+                if col != -1:
+                    # Point a couple of characters into the identifier so nimsuggest resolves it.
+                    return line_idx, col + 2
+        raise AssertionError(f"{identifier} not found in {rel_path}")


### PR DESCRIPTION
Adds experimental Nim support so Serena can index `.nim`/`.nims`/`.nimble` projects, picking up the request in #645.

The server wraps [nimlangserver](https://github.com/nim-lang/langserver), the maintained Nim language server, which drives one nimsuggest process per project. It follows the same bring-your-own-binary model as the Crystal and Zig servers: `_find_nimlangserver` looks on PATH and falls back to `~/.nimble/bin` (where `nimble install nimlangserver` puts it), and it also checks for a Nim toolchain since nimsuggest needs `nim` to compile the project. One Nim-specific wrinkle: nimlangserver pulls its settings with a `workspace/configuration` request on startup and expects a JSON array back, so there's a small handler that returns one empty object per requested item. Without it nimsuggest logs a config parse error and restarts.

I marked it experimental, since it has a couple of rough edges. nimsuggest compiles the project lazily, so the first lookup in a session can be slow, and its find-references doesn't resolve cross-file usages reliably. Document symbols and go-to-definition, including across files, do work well.

Tested against nimlangserver 1.14 / nim 2.2 on Linux with a small fixture project under `test/resources/repos/nim`. `uv run pytest -m nim` passes all 7 tests: document symbols in both files, the full symbol tree, within-file references (Calculator's usages in `main.nim`), and cross-file go-to-definition (`greet` resolving `formatGreeting` in another module). The tests skip when nimlangserver isn't on PATH, same gating the other externally-installed servers use, so CI without a Nim toolchain just skips them.

Fresh implementation; the earlier attempts (#658, #1150, #1186) are all closed.

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.
