### PR TITLE
Add Odin language server support via ols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Status of the `main` branch. Changes prior to the next official version change w
     project list in `serena_config.yml`
 
 * Language Servers:
+  - Add experimental Odin support via ols (`.odin`); requires the `ols` binary and an `odin` compiler on PATH (#594)
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Serena incorporates a powerful abstraction layer for the integration of language
 The underlying language servers are typically open-source projects or at least freely available for use.
 
 When using Serena's language server backend, we provide **support for over 40 programming languages**, including
-Ada / SPARK, AL, Angular, Ansible, Bash, BSL, C#, C/C++, Clojure, Crystal, CUE, Dart, Deno, Elixir, Elm, Erlang, Fortran, F#, GDScript, Gleam, GLSL, Go, Groovy, Haskell, Haxe, HLSL, HTML, Java, JavaScript, JSON, Julia, Kotlin, LaTeX, Lean 4, Lua, Luau, Markdown, MATLAB, mSL, Nextflow, Nix, OCaml, Pascal, Perl, PHP, PowerShell, Python, QML, R, Rego, Ruby, Rust, Scala, SCSS / Sass / CSS, Solidity, Svelte, Swift, SystemVerilog, Terraform, TOML, TypeScript, Vue, WGSL, Wolfram Language, YAML, and Zig.
+Ada / SPARK, AL, Angular, Ansible, Bash, BSL, C#, C/C++, Clojure, Crystal, CUE, Dart, Deno, Elixir, Elm, Erlang, Fortran, F#, GDScript, Gleam, GLSL, Go, Groovy, Haskell, Haxe, HLSL, HTML, Java, JavaScript, JSON, Julia, Kotlin, LaTeX, Lean 4, Lua, Luau, Markdown, MATLAB, mSL, Nextflow, Nix, OCaml, Odin, Pascal, Perl, PHP, PowerShell, Python, QML, R, Rego, Ruby, Rust, Scala, SCSS / Sass / CSS, Solidity, Svelte, Swift, SystemVerilog, Terraform, TOML, TypeScript, Vue, WGSL, Wolfram Language, YAML, and Zig.
 
 ### The Serena JetBrains Plugin
 

--- a/docs/01-about/020_programming-languages.md
+++ b/docs/01-about/020_programming-languages.md
@@ -126,6 +126,12 @@ Some languages require additional installations or setup steps, as noted.
   (requires nixd installation)
 * **OCaml**
   (requires opam and ocaml-lsp-server to be installed manually; see the [OCaml Setup Guide](../03-special-guides/ocaml_setup_guide_for_serena.md))
+* **Odin** (experimental)  
+  (requires the [ols](https://github.com/DanielGavin/ols) binary — grab a prebuilt one from its releases page or build it
+  with `odin build src -out:ols` — plus an `odin` compiler on PATH, which ols uses to resolve the core/vendor collections;
+  covers `.odin` files. ols reads collection settings from an `ols.json` at the workspace root; without one it still resolves
+  document symbols and go-to-definition for files inside the workspace. It indexes the workspace in the background, so the
+  first cross-file lookup of a session can be slow)
 * **Pascal**  
   (uses Pascal/Lazarus, which is automatically downloaded; set `PP` and `FPCDIR` environment variables for source navigation)
 * **Perl**  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,7 @@ markers = [
   "snapshot: snapshot tests for symbolic editing operations",
   "ruby: language server running for Ruby (uses ruby-lsp)",
   "zig: language server running for Zig",
+  "odin: language server running for Odin",
   "lua: language server running for Lua",
   "luau: language server running for Luau",
   "nextflow: language server running for Nextflow",

--- a/src/serena/resources/project.template.yml
+++ b/src/serena/resources/project.template.yml
@@ -10,13 +10,13 @@ project_name: "project_name"
 #   haxe                   hlsl                   html                   java                   json
 #   julia                  kotlin                 latex                  lean4                  lua
 #   luau                   markdown               matlab                 msl                    nextflow
-#   nix                    ocaml                  pascal                 perl                   php
-#   php_phpactor           php_phpantom           powershell             python                 python_basedpyright
-#   python_jedi            python_pyrefly         python_ty              qml                    r
-#   rego                   ruby                   ruby_solargraph        rust                   scala
-#   scss                   solidity               svelte                 swift                  systemverilog
-#   terraform              toml                   typescript             typescript_vts         vue
-#   wolfram                yaml                   zig
+#   nix                    ocaml                  odin                   pascal                 perl
+#   php                    php_phpactor           php_phpantom           powershell             python
+#   python_basedpyright    python_jedi            python_pyrefly         python_ty              qml
+#   r                      rego                   ruby                   ruby_solargraph        rust
+#   scala                  scss                   solidity               svelte                 swift
+#   systemverilog          terraform              toml                   typescript             typescript_vts
+#   vue                    wolfram                yaml                   zig
 #   (This list may be outdated; generated with scripts/print_language_list.py;
 #   For the current list, see values of the LanguageServerId enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)

--- a/src/solidlsp/language_servers/odin_language_server.py
+++ b/src/solidlsp/language_servers/odin_language_server.py
@@ -1,0 +1,157 @@
+"""
+Provides Odin specific instantiation of the LanguageServer class using ols.
+"""
+
+import logging
+import shutil
+
+from overrides import override
+
+from solidlsp.ls import SolidLanguageServer
+from solidlsp.ls_config import LanguageServerConfig
+from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
+from solidlsp.settings import SolidLSPSettings
+
+log = logging.getLogger(__name__)
+
+
+class OdinLanguageServer(SolidLanguageServer):
+    """
+    Odin specific instantiation of the LanguageServer class using ols.
+
+    ols (https://github.com/DanielGavin/ols) is the community language server for
+    Odin. It indexes the workspace itself, but relies on the Odin compiler to
+    resolve the built-in ``core`` and ``vendor`` collections, so both the ``ols``
+    binary and an ``odin`` compiler need to be on PATH. Prebuilt ols binaries are
+    published on its releases page; Odin is available from https://odin-lang.org.
+
+    Odin support is experimental. ols reads collection settings from an ``ols.json``
+    file at the workspace root; without one it still resolves symbols and
+    definitions for files inside the workspace, which is what the symbol tooling
+    relies on.
+    """
+
+    def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
+        ols_path = self._find_ols()
+        self._check_odin_compiler()
+
+        super().__init__(
+            config,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=ols_path, cwd=repository_root_path),
+            "odin",
+            solidlsp_settings,
+        )
+
+    @staticmethod
+    def _find_ols() -> str:
+        """
+        Find the ols executable on PATH.
+
+        :return: path to the ols executable
+        :raises RuntimeError: if ols is not found
+        """
+        path = shutil.which("ols")
+        if path is None:
+            raise RuntimeError(
+                "ols (Odin language server) is not installed or not in PATH.\n"
+                "Grab a prebuilt binary from https://github.com/DanielGavin/ols/releases (or build it\n"
+                "with 'odin build src -out:ols') and make sure the 'ols' binary is on your PATH."
+            )
+        return path
+
+    @staticmethod
+    def _check_odin_compiler() -> None:
+        """
+        Ensure the Odin compiler ols leans on for core/vendor collections is available.
+
+        :raises RuntimeError: if odin is not found
+        """
+        if shutil.which("odin") is None:
+            raise RuntimeError(
+                "ols requires the Odin compiler to resolve the core/vendor collections, but 'odin'\n"
+                "was not found on PATH. Install Odin from https://odin-lang.org/docs/install/ and make\n"
+                "sure the 'odin' binary is on your PATH."
+            )
+
+    def _create_base_initialize_params(self) -> dict:
+        """
+        Return the initialize params for the Odin language server (server-specific keys only).
+        """
+        return {
+            "locale": "en",
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {"didSave": True, "dynamicRegistration": True},
+                    "definition": {"dynamicRegistration": True, "linkSupport": True},
+                    "references": {"dynamicRegistration": True},
+                    "documentSymbol": {
+                        "dynamicRegistration": True,
+                        "hierarchicalDocumentSymbolSupport": True,
+                        "symbolKind": {"valueSet": list(range(1, 27))},
+                    },
+                    "completion": {
+                        "dynamicRegistration": True,
+                        "completionItem": {
+                            "snippetSupport": True,
+                            "documentationFormat": ["markdown", "plaintext"],
+                        },
+                    },
+                    "hover": {
+                        "dynamicRegistration": True,
+                        "contentFormat": ["markdown", "plaintext"],
+                    },
+                },
+                "workspace": {
+                    "workspaceFolders": True,
+                    "didChangeConfiguration": {"dynamicRegistration": True},
+                    "configuration": True,
+                },
+            },
+            # ols reads collections and settings from an ols.json in the workspace; the defaults
+            # (index the workspace, discover the odin compiler on PATH) are what we want here.
+            "initializationOptions": {},
+        }
+
+    def _start_server(self) -> None:
+        """Start the Odin language server (ols) process."""
+
+        def register_capability_handler(_params: dict) -> None:
+            return
+
+        def window_log_message(msg: dict) -> None:
+            log.info(f"LSP: window/logMessage: {msg}")
+
+        def do_nothing(_params: dict) -> None:
+            return
+
+        self.server.on_request("client/registerCapability", register_capability_handler)
+        self.server.on_notification("window/logMessage", window_log_message)
+        self.server.on_notification("window/showMessage", window_log_message)
+        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+
+        log.info("Starting Odin language server (ols) process")
+        self.server.start()
+        initialize_params = self._create_initialize_params()
+
+        log.info("Sending initialize request from LSP client to LSP server and awaiting response")
+        init_response = self.server.send.initialize(initialize_params)
+
+        capabilities = init_response["capabilities"]
+        log.info(f"Odin language server capabilities: {list(capabilities.keys())}")
+        assert "textDocumentSync" in capabilities, "textDocumentSync capability missing"
+        assert "documentSymbolProvider" in capabilities, "documentSymbolProvider capability missing"
+
+        self.server.notify.initialized({})
+
+    @override
+    def _get_wait_time_for_cross_file_referencing(self) -> float:
+        # ols builds its workspace index in the background; give it time to finish before
+        # cross-file queries so it can resolve symbols across files in the package.
+        return 5.0
+
+    @override
+    def is_ignored_dirname(self, dirname: str) -> bool:
+        # ols writes its index cache into a .ols-cache dir; build artifacts land in build/out.
+        return super().is_ignored_dirname(dirname) or dirname in [".ols-cache", "build", "out"]

--- a/src/solidlsp/ls_config.py
+++ b/src/solidlsp/ls_config.py
@@ -115,6 +115,13 @@ class LanguageServerId(str, Enum):
     CRYSTAL = "crystal"
     CUE = "cue"
     ZIG = "zig"
+    ODIN = "odin"
+    """Odin language server using ols (DanielGavin/ols).
+    Supports .odin files. Requires the `ols` binary plus an `odin` compiler on PATH
+    (ols leans on the compiler to resolve the core/vendor collections).
+    Experimental: ols indexes the workspace in the background, so the first cross-file
+    lookup of a session can be slow.
+    """
     LUA = "lua"
     LUAU = "luau"
     """Luau Language Server for Roblox's Luau language (typed Lua 5.1 superset).
@@ -346,6 +353,7 @@ class LanguageServerId(str, Enum):
             self.SCSS,
             self.ANGULAR,
             self.DENO,
+            self.ODIN,
         }
 
     def is_programming_language(self) -> bool:
@@ -510,6 +518,8 @@ class LanguageServerId(str, Enum):
                 return FilenameMatcher(".toml")
             case self.ZIG:
                 return FilenameMatcher(".zig", ".zon")
+            case self.ODIN:
+                return FilenameMatcher(".odin")
             case self.LUA:
                 return FilenameMatcher(".lua")
             case self.LUAU:
@@ -778,6 +788,10 @@ class LanguageServerId(str, Enum):
                 from solidlsp.language_servers.zls import ZigLanguageServer
 
                 return ZigLanguageServer
+            case self.ODIN:
+                from solidlsp.language_servers.odin_language_server import OdinLanguageServer
+
+                return OdinLanguageServer
             case self.NIX:
                 from solidlsp.language_servers.nixd_ls import NixLanguageServer
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -471,6 +471,10 @@ def _determine_disabled_language_servers() -> list[LanguageServerId]:
         result.append(LanguageServerId.LEAN4)
     if _sh.which("crystalline") is None:
         result.append(LanguageServerId.CRYSTAL)
+    # ols indexes the workspace but leans on the odin compiler for the core/vendor collections,
+    # so both need to be present for the Odin tests to run.
+    if _sh.which("ols") is None or _sh.which("odin") is None:
+        result.append(LanguageServerId.ODIN)
     if _sh.which("julia") is None:  # LanguageServer.jl is auto-installed by the LS when julia is present
         result.append(LanguageServerId.JULIA)
     if _sh.which("nixd") is None:

--- a/test/resources/repos/odin/test_repo/.gitignore
+++ b/test/resources/repos/odin/test_repo/.gitignore
@@ -1,0 +1,4 @@
+.ols-cache/
+build/
+out/
+*.bin

--- a/test/resources/repos/odin/test_repo/ols.json
+++ b/test/resources/repos/odin/test_repo/ols.json
@@ -1,0 +1,6 @@
+{
+	"collections": [{ "name": "src", "path": "src" }],
+	"enable_document_symbols": true,
+	"enable_hover": true,
+	"enable_references": true
+}

--- a/test/resources/repos/odin/test_repo/src/main.odin
+++ b/test/resources/repos/odin/test_repo/src/main.odin
@@ -1,0 +1,36 @@
+package main
+
+import "core:fmt"
+
+Calculator :: struct {}
+
+User :: struct {
+	name: string,
+	age:  int,
+}
+
+add :: proc(self: Calculator, a, b: int) -> int {
+	return a + b
+}
+
+multiply :: proc(self: Calculator, a, b: int) -> int {
+	return a * b
+}
+
+greet :: proc(self: User) -> string {
+	return format_greeting(self.name, self.age)
+}
+
+is_adult :: proc(self: User) -> bool {
+	return self.age >= 18
+}
+
+main :: proc() {
+	calc := Calculator{}
+	fmt.println("Result:", add(calc, 5, 3))
+
+	user := User{name = "Alice", age = 30}
+	fmt.println(greet(user))
+
+	fmt.println("Circle area:", calculate_area(5.0))
+}

--- a/test/resources/repos/odin/test_repo/src/utils.odin
+++ b/test/resources/repos/odin/test_repo/src/utils.odin
@@ -1,0 +1,12 @@
+package main
+
+import "core:fmt"
+import "core:math"
+
+calculate_area :: proc(radius: f64) -> f64 {
+	return math.PI * radius * radius
+}
+
+format_greeting :: proc(name: string, age: int) -> string {
+	return fmt.aprintf("Hello, my name is %s and I am %d years old.", name, age)
+}

--- a/test/solidlsp/odin/test_odin_basic.py
+++ b/test/solidlsp/odin/test_odin_basic.py
@@ -1,0 +1,122 @@
+"""
+Basic integration tests for the Odin language server (ols) functionality.
+
+These validate document symbols, the full symbol tree, within-file references and
+cross-file go-to-definition using the Odin test repository.
+
+ols indexes the workspace in the background, so the first cross-file query of a
+session can be slow. The test repo keeps main.odin and utils.odin in the same
+package, so cross-file navigation is resolved through the workspace index.
+"""
+
+import os
+
+import pytest
+
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import LanguageServerId
+from solidlsp.ls_utils import SymbolUtils
+from test.conftest import language_server_tests_enabled
+from test.solidlsp.conftest import format_symbol_for_assert, has_malformed_name, request_all_symbols
+
+pytestmark = [
+    pytest.mark.odin,
+    pytest.mark.skipif(
+        not language_server_tests_enabled(LanguageServerId.ODIN),
+        reason="Odin tests are disabled (ols or odin not available)",
+    ),
+]
+
+
+class TestOdinDocumentSymbols:
+    """Document symbol retrieval, which ols supports reliably."""
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ODIN], indirect=True)
+    def test_ls_is_running(self, language_server: SolidLanguageServer) -> None:
+        assert language_server.is_running()
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ODIN], indirect=True)
+    def test_document_symbols_main(self, language_server: SolidLanguageServer) -> None:
+        file_path = os.path.join("src", "main.odin")
+        all_symbols, _roots = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+
+        symbol_names = {s.get("name") for s in all_symbols if s.get("name")}
+        for expected in ("Calculator", "User", "add", "multiply", "greet", "is_adult"):
+            assert expected in symbol_names, f"{expected} not found in main.odin symbols. Found: {sorted(symbol_names)}"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ODIN], indirect=True)
+    def test_document_symbols_utils(self, language_server: SolidLanguageServer) -> None:
+        file_path = os.path.join("src", "utils.odin")
+        all_symbols, _roots = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+
+        symbol_names = {s.get("name") for s in all_symbols if s.get("name")}
+        assert "calculate_area" in symbol_names, f"calculate_area not found. Found: {sorted(symbol_names)}"
+        assert "format_greeting" in symbol_names, f"format_greeting not found. Found: {sorted(symbol_names)}"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ODIN], indirect=True)
+    def test_full_symbol_tree(self, language_server: SolidLanguageServer) -> None:
+        symbols = language_server.request_full_symbol_tree()
+        for name in ("Calculator", "User", "add", "calculate_area", "format_greeting"):
+            assert SymbolUtils.symbol_tree_contains_name(symbols, name), f"{name} not found in symbol tree"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ODIN], indirect=True)
+    def test_bare_symbol_names(self, language_server: SolidLanguageServer) -> None:
+        all_symbols = request_all_symbols(language_server)
+        malformed_symbols = [s for s in all_symbols if has_malformed_name(s)]
+        if malformed_symbols:
+            pytest.fail(
+                f"Found malformed symbols: {[format_symbol_for_assert(sym) for sym in malformed_symbols]}",
+                pytrace=False,
+            )
+
+
+class TestOdinReferences:
+    """Reference finding and go-to-definition."""
+
+    @staticmethod
+    def _symbol_selection_start(language_server: SolidLanguageServer, file_path: str, name: str) -> dict:
+        all_symbols, _roots = language_server.request_document_symbols(file_path).get_all_symbols_and_roots()
+        symbol = next((s for s in all_symbols if s.get("name") == name), None)
+        assert symbol is not None, f"{name} not found in {file_path}"
+        sel_range = symbol.get("selectionRange", symbol.get("range"))
+        assert sel_range is not None, f"{name} has no range information"
+        return sel_range["start"]
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ODIN], indirect=True)
+    def test_references_within_file(self, language_server: SolidLanguageServer) -> None:
+        """Calculator is used as a proc parameter type and instantiated within main.odin."""
+        file_path = os.path.join("src", "main.odin")
+        start = self._symbol_selection_start(language_server, file_path, "Calculator")
+
+        refs = language_server.request_references(file_path, start["line"], start["character"])
+        assert isinstance(refs, list)
+
+        ref_files = {os.path.basename(ref.get("relativePath") or ref.get("uri", "")) for ref in refs}
+        assert ref_files == {"main.odin"}, f"Within-file Calculator references should all be in main.odin, got {ref_files}"
+        # ols excludes the declaration; the two proc receivers (add/multiply) plus the Calculator{} literal remain.
+        assert len(refs) >= 2, f"Expected at least 2 Calculator references in main.odin, found {len(refs)}"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ODIN], indirect=True)
+    def test_goto_definition_cross_file(self, language_server: SolidLanguageServer) -> None:
+        """Proc greet in main.odin calls format_greeting, which is defined in utils.odin."""
+        main_path = os.path.join("src", "main.odin")
+
+        with language_server.open_file(main_path), language_server.open_file(os.path.join("src", "utils.odin")):
+            call_line, call_col = self._find_identifier(main_path, "format_greeting")
+            definitions = language_server.request_definition(main_path, call_line, call_col)
+
+            assert isinstance(definitions, list) and len(definitions) > 0, "Should find a definition for format_greeting"
+            target = definitions[0]
+            assert target.get("uri", "").endswith("utils.odin"), "format_greeting should be defined in utils.odin"
+            assert target["range"]["start"]["line"] == 9, "format_greeting should be defined on line 10 (0-indexed: 9)"
+
+    @staticmethod
+    def _find_identifier(rel_path: str, identifier: str) -> tuple[int, int]:
+        repo_root = os.path.join(os.path.dirname(__file__), "..", "..", "resources", "repos", "odin", "test_repo")
+        with open(os.path.join(repo_root, rel_path), encoding="utf-8") as f:
+            for line_idx, line in enumerate(f):
+                col = line.find(identifier)
+                if col != -1:
+                    # Point a couple of characters into the identifier so ols resolves it.
+                    return line_idx, col + 2
+        raise AssertionError(f"{identifier} not found in {rel_path}")


### PR DESCRIPTION
Adds Odin support through [ols](https://github.com/DanielGavin/ols), closing the gap from #594.

Follows the add-a-language guide. The `OdinLanguageServer` finds the `ols` binary on PATH and hands it a standard LSP init; ols indexes the workspace itself but leans on the `odin` compiler to resolve the `core`/`vendor` collections, so the server checks for both up front and raises a pointed error telling you what to install if either is missing. It's registered as an experimental language matching `.odin`, and I refreshed the enum, the `ls_config` matcher/class hooks, the docs, the README list, `project.template.yml` (regenerated with `print_language_list.py`) and the changelog. `conftest` skips the Odin tests when `ols` or `odin` aren't present, same as the other native-toolchain languages.

The test repo keeps `main.odin` and `utils.odin` in one package so cross-file navigation goes through ols's workspace index without needing an import graph. Tests cover document symbols in both files, the full symbol tree, within-file references (Calculator used as a proc receiver type and instantiated in `main`), and cross-file go-to-definition (`greet` -> `format_greeting` in `utils.odin`).

Ran the suite locally against a prebuilt ols (`dev-2026-06`) plus the Odin nightly compiler on Linux x86_64: all 7 pass, and they skip cleanly when the binaries aren't on PATH. One thing worth flagging for review — ols returns references with the declaration excluded, so the within-file test asserts on the usage sites rather than expecting the definition back. I didn't wire a CI job to install ols/odin (they aren't in the pytest marker matrix), matching how the other experimental language servers are handled; happy to add one if you'd prefer it running in CI.
