### PR TITLE
fix(mcp): run blocking tool calls off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Status of the `main` branch. Changes prior to the next official version change w
 * General:
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
+  - Fix: a heavy or cold tool call (LSP subprocess round-trips, symbol-tree walks) ran synchronously on
+    the MCP server's single event loop, so it blocked health probes and other sessions' `initialize`
+    handshakes for its whole duration under the streamable-HTTP transport. Tool execution now runs in
+    a worker thread (#1890)
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)

--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -2,6 +2,7 @@
 The Serena Model Context Protocol (MCP) Server
 """
 
+import functools
 import sys
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
@@ -9,6 +10,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
+import anyio.to_thread
 import docstring_parser
 from mcp.server.fastmcp import server
 from mcp.server.fastmcp.exceptions import ToolError
@@ -60,7 +62,9 @@ class SerenaFastMCPTool(FastMCPTool):
         func_name = tool.get_name()
         func_doc = tool.get_apply_docstring() or ""
         func_arg_metadata = tool.get_apply_fn_metadata(structured_output=structured_output)
-        is_async = False
+        # apply_ex does blocking LSP work; run it on a worker thread so it can't stall the
+        # event loop that also serves the MCP transport (health probes, other sessions).
+        is_async = True
         parameters = func_arg_metadata.arg_model.model_json_schema()
         if openai_tool_compatible:
             parameters = SerenaMCPFactory._sanitize_for_openai_tools(parameters)
@@ -94,9 +98,9 @@ class SerenaFastMCPTool(FastMCPTool):
                 param_desc = f"{param_doc.description.strip().strip('.') + '.'}"
                 properties["description"] = param_desc[0].upper() + param_desc[1:]
 
-        def execute_fn(**kwargs) -> str:
+        async def execute_fn(**kwargs) -> str:
             try:
-                return tool.apply_ex(log_call=True, catch_exceptions=False, **kwargs)
+                return await anyio.to_thread.run_sync(functools.partial(tool.apply_ex, log_call=True, catch_exceptions=False, **kwargs))
             except ToolCallError as e:
                 raise ToolError(e.get_error_message()) from e
 

--- a/test/serena/test_mcp.py
+++ b/test/serena/test_mcp.py
@@ -1,5 +1,8 @@
 """Tests for the mcp.py module in serena."""
 
+import asyncio
+import time
+
 import pytest
 from mcp.server.fastmcp.tools.base import Tool as MCPTool
 
@@ -75,10 +78,48 @@ def test_make_tool_execution() -> None:
     mock_tool = BasicTool()
     mcp_tool = make_tool(mock_tool)
 
-    # Execute the MCP tool function
-    result = mcp_tool.fn(name="Alice", age=30)
+    # Execute the MCP tool function (now offloaded to a worker thread, so it's a coroutine)
+    result = asyncio.run(mcp_tool.fn(name="Alice", age=30))
 
     assert result == "Hello Alice, you are 30 years old!"
+
+
+def test_make_tool_execution_does_not_block_event_loop() -> None:
+    """A blocking apply_ex must run off the event loop, so it can't starve other coroutines on it."""
+
+    class SlowTool(BaseMockTool):
+        def apply(self) -> str:
+            """A slow test function.
+
+            :return: A constant result
+            """
+            return "done"
+
+        def apply_ex(self, log_call: bool = True, catch_exceptions: bool = True, **kwargs) -> str:
+            time.sleep(0.3)
+            return self.apply()
+
+    mcp_tool = make_tool(SlowTool())
+    probe_steps = 0
+
+    async def probe() -> None:
+        nonlocal probe_steps
+        while probe_steps < 10:
+            await asyncio.sleep(0.01)
+            probe_steps += 1
+
+    async def race() -> str:
+        result, _ = await asyncio.gather(mcp_tool.fn(), probe())
+        return result
+
+    start = time.monotonic()
+    result = asyncio.run(race())
+    elapsed = time.monotonic() - start
+
+    # a blocked loop would serialize call + probe (~0.4s); concurrent stays near max(0.3, 0.1)s
+    assert result == "done"
+    assert probe_steps == 10
+    assert elapsed < 0.35
 
 
 def test_make_tool_no_params() -> None:


### PR DESCRIPTION
## Root cause

`SerenaFastMCPTool` builds every Serena MCP tool with `is_async=False` and a synchronous
`execute_fn` that calls `tool.apply_ex` directly (`src/serena/mcp.py`). The pinned SDK
(`mcp==1.28.1`) invokes that as `fn(**kwargs)` inside the single asyncio event loop that also
serves the streamable-HTTP transport (`func_metadata.py`'s `call_fn_with_arg_validation`: `if
fn_is_async: await fn(...) else: fn(...)`, with no thread offload anywhere in the call chain).

`apply_ex` is blocking: LSP subprocess round-trips and symbol-tree walks. A heavy or cold call
therefore runs synchronously inside that loop, starving every other coroutine on it, including
health-probe handling and new-session `initialize` handshakes, for the call's entire duration.
This matches the issue's repro: `curl --max-time 2` timing out and handshakes going from ~80ms
to multiple seconds.

## Fix

`execute_fn` now runs `tool.apply_ex` in a worker thread via `anyio.to_thread.run_sync`
(already a transitive dependency of the SDK, and the pattern the SDK itself uses in
`resources/types.py`), and `is_async` is set to `True` so the SDK awaits it instead of calling
it inline.

## Verification

- New regression test `test_make_tool_execution_does_not_block_event_loop` races a 0.3s
  blocking mock tool against a 10-step probe coroutine on the same event loop: fails on `main`
  (the raw `fn()` call isn't even awaitable, so `asyncio.gather` raises `TypeError` before the
  probe can run), passes on this branch.
- `test/serena/test_mcp.py` full file: 65 passed (Docker, Python 3.11, `uv sync --extra dev
  --locked`).
- `ruff format --check`, `ruff check`, `ty check src/serena src/solidlsp`, `ty check test
  --exclude test/resources`, and `codespell` on the changed files all pass.
- Not verified: a live Serena server behind streamable-HTTP under the full multi-second
  `find_symbol` workload from the issue; the mechanism above reproduces the same shape
  (synchronous execution stalls the loop) against the real pinned SDK, but I did not measure
  the issue's literal "~30x slower" figure end to end.

Fixes #1890
