### PR TITLE
fix: persist remove_project to serena_config.yml

### DIFF
--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -958,6 +958,8 @@ class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
     the path to the configuration file to which updates of the configuration shall be saved;
     if None, the configuration is not saved to disk
     """
+    _loaded_project_roots: set[str] = field(default_factory=set)
+    """Project roots present when this instance was loaded from disk."""
 
     # *** static members ***
 
@@ -1095,6 +1097,7 @@ class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
                 project_config=project_config,
             )
             instance.projects.append(project)
+        instance._loaded_project_roots = {str(p.project_root) for p in instance.projects}
 
         # determine language backend
         language_backend = get_dataclass_default(SerenaConfig, "language_backend")
@@ -1302,10 +1305,14 @@ class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
         if self.config_file_path is None:
             return
         persisted = SerenaConfig.from_config_file()
+        current_paths = {str(p.project_root) for p in self.projects}
+        removed_paths = self._loaded_project_roots - current_paths
         combined_projects = []
         handled_project_paths = set()
         for p in persisted.projects + self.projects:
             str_path = str(p.project_root)
+            if str_path in removed_paths:
+                continue
             if str_path not in handled_project_paths:
                 combined_projects.append(p)
                 handled_project_paths.add(str_path)

--- a/test/serena/config/test_serena_config.py
+++ b/test/serena/config/test_serena_config.py
@@ -604,6 +604,22 @@ class TestSerenaConfigLoadSave:
 
         assert len(resulting_config.projects) == 4
 
+    def test_remove_project_persists_across_reload(self):
+        """remove_project must drop the project from disk, not only from in-memory state."""
+        p1 = self._make_project_dir("project1", 'project_name: "project1"\nlanguages: ["python"]\n')
+        p2 = self._make_project_dir("project2", 'project_name: "project2"\nlanguages: ["python"]\n')
+        self._write_master_config([p1, p2])
+
+        config = SerenaConfig.from_config_file(generate_if_missing=False)
+        assert sorted(p.project_name for p in config.projects) == ["project1", "project2"]
+
+        config.remove_project("project2")
+        assert [p.project_name for p in config.projects] == ["project1"]
+
+        reloaded = SerenaConfig.from_config_file(generate_if_missing=False)
+        reloaded_names = sorted(p.project_name for p in reloaded.projects)
+        assert reloaded_names == ["project1"], f"remove_project('project2') did not persist; reloaded projects: {reloaded_names}"
+
 
 class TestGetRegisteredProjectWithDanglingProject:
     """A registered project whose root directory was deleted (e.g. a removed git


### PR DESCRIPTION
## Summary

`remove_project` dropped the project from in-memory state, then `_persist_projects` unioned the on-disk list with that state. The removed project was copied back from disk and reappeared on the next `SerenaConfig.from_config_file()` load.

Skip roots this instance loaded and no longer has. Parallel adds from other processes are unchanged.

Fixes #1895.

## Tests

```
uv run pytest test/serena/config/test_serena_config.py::TestSerenaConfigLoadSave -vv
```
