### PR TITLE
fix: preserve section separators when editing Markdown symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Status of the `main` branch. Changes prior to the next official version change w
 * General:
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
+  - Fix: `replace_symbol_body` and `insert_after_symbol` corrupted Markdown documents. A section's
+    body range extends to the start of the next heading, so replacing a body dropped the blank line
+    that separates the sections, and inserting after a section landed inside the following one
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)

--- a/src/serena/code_editor.py
+++ b/src/serena/code_editor.py
@@ -44,8 +44,14 @@ class CodeEditor(Generic[TSymbol], ABC):
             """
 
         @abstractmethod
-        def delete_text_between_positions(self, start_pos: PositionInFile, end_pos: PositionInFile) -> None:
-            pass
+        def delete_text_between_positions(self, start_pos: PositionInFile, end_pos: PositionInFile) -> str:
+            """
+            Deletes the text between the given positions.
+
+            :param start_pos: the start position (inclusive)
+            :param end_pos: the end position (exclusive)
+            :return: the deleted text
+            """
 
         @abstractmethod
         def insert_text_at_position(self, pos: PositionInFile, text: str) -> None:
@@ -120,8 +126,15 @@ class CodeEditor(Generic[TSymbol], ABC):
             # and whitespace before/after should remain the same, so we strip it entirely
             body = body.strip()
 
-            edited_file.delete_text_between_positions(start_pos, end_pos)
-            edited_file.insert_text_at_position(start_pos, body)
+            deleted_text = edited_file.delete_text_between_positions(start_pos, end_pos)
+
+            # restore the whitespace which the original body range ended with: for some languages,
+            # the range extends to the start of the next sibling symbol (e.g. Markdown sections,
+            # which reach the next heading), and dropping the separator it contains would glue that
+            # symbol onto the last line of the new body
+            trailing_whitespace = deleted_text[len(deleted_text.rstrip()) :]
+
+            edited_file.insert_text_at_position(start_pos, body + trailing_whitespace)
 
     @staticmethod
     def _count_leading_newlines(text: Iterable) -> int:
@@ -158,9 +171,12 @@ class CodeEditor(Generic[TSymbol], ABC):
 
         pos = symbol.get_body_end_position_or_raise()
 
-        # start at the beginning of the next line
+        # start at the beginning of the line following the symbol; if the body range already ends at
+        # the start of a line, it ends *on* the following symbol's line (for some languages, e.g.
+        # Markdown, the range reaches the next heading), and skipping a further line would insert
+        # inside that symbol
         col = 0
-        line = pos.line + 1
+        line = pos.line if pos.col == 0 else pos.line + 1
 
         # make sure a suitable number of leading empty lines is used (at least 0/1 depending on the symbol type,
         # otherwise as many as the caller wanted to insert)
@@ -176,6 +192,11 @@ class CodeEditor(Generic[TSymbol], ABC):
         # make sure the one line break succeeding the original symbol, which we repurposed as prefix via
         # `line += 1`, is replaced
         body = body.rstrip("\r\n") + "\n"
+
+        # add the separator which was not repurposed above, because no line break succeeded the
+        # body range
+        if line == pos.line:
+            body += "\n"
 
         with self.edited_file_context(relative_file_path) as edited_file:
             edited_file.insert_text_at_position(PositionInFile(line, col), body)
@@ -292,8 +313,10 @@ class LanguageServerCodeEditor(CodeEditor[LanguageServerSymbol]):
         def set_contents(self, contents: str) -> None:
             self._file_buffer.contents = contents
 
-        def delete_text_between_positions(self, start_pos: PositionInFile, end_pos: PositionInFile) -> None:
-            self._lang_server.delete_text_between_positions(self.relative_path, start_pos.to_lsp_position(), end_pos.to_lsp_position())
+        def delete_text_between_positions(self, start_pos: PositionInFile, end_pos: PositionInFile) -> str:
+            return self._lang_server.delete_text_between_positions(
+                self.relative_path, start_pos.to_lsp_position(), end_pos.to_lsp_position()
+            )
 
         def insert_text_at_position(self, pos: PositionInFile, text: str) -> None:
             self._lang_server.insert_text_at_position(self.relative_path, pos.line, pos.col, text)
@@ -433,10 +456,11 @@ class JetBrainsCodeEditor(CodeEditor[JetBrainsSymbol]):
         def set_contents(self, contents: str) -> None:
             self._content = contents
 
-        def delete_text_between_positions(self, start_pos: PositionInFile, end_pos: PositionInFile) -> None:
-            self._content, _ = TextUtils.delete_text_between_positions(
+        def delete_text_between_positions(self, start_pos: PositionInFile, end_pos: PositionInFile) -> str:
+            self._content, deleted_text = TextUtils.delete_text_between_positions(
                 self._content, start_pos.line, start_pos.col, end_pos.line, end_pos.col
             )
+            return deleted_text
 
         def insert_text_at_position(self, pos: PositionInFile, text: str) -> None:
             self._content, _, _ = TextUtils.insert_text_at_position(self._content, pos.line, pos.col, text)

--- a/test/resources/repos/markdown/test_repo/.serena/project.yml
+++ b/test/resources/repos/markdown/test_repo/.serena/project.yml
@@ -1,0 +1,5 @@
+# Markdown is excluded from language auto-detection, so the language server has
+# to be requested explicitly for this repository.
+project_name: "markdown_test_repo"
+language_servers:
+  - markdown

--- a/test/serena/__snapshots__/test_symbol_editing.ambr
+++ b/test/serena/__snapshots__/test_symbol_editing.ambr
@@ -1745,6 +1745,64 @@
   
   '''
 # ---
+# name: test_replace_body[test_case2]
+  '''
+  # User Guide
+  
+  This guide provides detailed instructions for using the test repository.
+  
+  ## Getting Started
+  
+  Welcome to the user guide. This document covers:
+  
+  - Basic concepts
+  - Advanced features
+  - Troubleshooting
+  
+  ### Basic Concepts
+  
+  The fundamental concepts you need to understand:
+  
+  #### Headers and Structure
+  
+  Markdown documents use headers to create structure. Headers are created using `#` symbols.
+  
+  #### Links and References
+  
+  Internal links can reference other documents:
+  
+  - [Back to README](README.md)
+  - [See API documentation](api.md)
+  
+  ### Advanced Features
+  
+  For advanced users, we provide:
+  
+  1. Custom extensions
+  2. Plugin support
+  3. Theme customization
+  
+  ## Configuration
+  
+  Configuration options are stored in `config.yaml` and are reloaded on change.
+  
+  ## Troubleshooting
+  
+  If you encounter issues:
+  
+  1. Check the [README](README.md) first
+  2. Review [common issues](CONTRIBUTING.md)
+  3. Contact support
+  
+  ## Next Steps
+  
+  After reading this guide, check out:
+  
+  - [API Reference](api.md)
+  - [Contributing Guidelines](CONTRIBUTING.md)
+  
+  '''
+# ---
 # name: test_replace_body_vue[test_case0]
   '''
   <script setup lang="ts">

--- a/test/serena/test_symbol_editing.py
+++ b/test/serena/test_symbol_editing.py
@@ -398,6 +398,19 @@ TYPESCRIPT_REPLACED_BODY = """function printValue() {
 """
 
 
+MARKDOWN_TEST_FILE = "guide.md"
+
+MARKDOWN_REPLACED_BODY = """## Configuration
+
+Configuration options are stored in `config.yaml` and are reloaded on change.
+"""
+
+NEW_MARKDOWN_SECTION = """## Deployment
+
+Deployment is covered in the operations handbook.
+"""
+
+
 class ReplaceBodyTest(EditingTest):
     def __init__(self, ls_id: LanguageServerId, rel_path: str, symbol_name: str, new_body: str):
         super().__init__(ls_id, rel_path)
@@ -429,10 +442,18 @@ class ReplaceBodyTest(EditingTest):
             ),
             marks=pytest.mark.typescript,
         ),
+        pytest.param(
+            ReplaceBodyTest(
+                LanguageServerId.MARKDOWN,
+                MARKDOWN_TEST_FILE,
+                "User Guide/Configuration",
+                MARKDOWN_REPLACED_BODY,
+            ),
+            marks=pytest.mark.markdown,
+        ),
     ],
 )
 def test_replace_body(test_case: ReplaceBodyTest, snapshot: SnapshotAssertion):
-    # assert "a" in snapshot
     test_case.run_test(content_after_ground_truth=snapshot)
 
 
@@ -586,18 +607,35 @@ class InsertAndDeleteSymbolTest(EditingTest):
         assert not code_diff.has_changes
 
 
-def test_insert_and_delete_no_change():
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            InsertAndDeleteSymbolTest(
+                LanguageServerId.PYTHON,
+                PYTHON_TEST_REL_FILE_PATH,
+                "VariableContainer/modify_instance_var",
+                "VariableContainer/inserted_function",
+                "    def inserted_function():\n        pass",
+            ),
+            marks=pytest.mark.python,
+        ),
+        pytest.param(
+            InsertAndDeleteSymbolTest(
+                LanguageServerId.MARKDOWN,
+                MARKDOWN_TEST_FILE,
+                "User Guide/Configuration",
+                "User Guide/Deployment",
+                NEW_MARKDOWN_SECTION,
+            ),
+            marks=pytest.mark.markdown,
+        ),
+    ],
+)
+def test_insert_and_delete_no_change(test_case: InsertAndDeleteSymbolTest):
     """
     Tests that inserting and immediately deleting a symbol results in no change to the file content.
     """
-    insertion = "    def inserted_function():\n        pass"
-    test_case = InsertAndDeleteSymbolTest(
-        LanguageServerId.PYTHON,
-        PYTHON_TEST_REL_FILE_PATH,
-        "VariableContainer/modify_instance_var",
-        "VariableContainer/inserted_function",
-        insertion,
-    )
     test_case.run_test(None)
 
 


### PR DESCRIPTION
`replace_symbol_body` and `insert_after_symbol` corrupt Markdown documents.

A section's body range reaches the start of the next heading, so it contains the blank line separating the two sections. `replace_body` strips the replacement and writes it into that range, which drops the separator: the next heading ends up appended to the last line of the new body, where it is no longer a heading. `insert_after_symbol` inserts at the line following the body end, but for such a range that line is already the next section's heading line, so the insertion lands inside that section.

Both are single-call corruptions, reproduced on a three-section file.

The fix keeps the whitespace the deleted range ended with in `replace_body`, and makes `insert_after_symbol` insert at the body end position when that position is already at column 0. For languages whose body ranges end at the symbol's last character, neither path changes; the existing Python and TypeScript snapshots are untouched.

Markdown cases were added to `test_replace_body` and `test_insert_and_delete_no_change`; both fail without the fix. The Markdown test repository gained a project configuration, because Markdown is excluded from language auto-detection and these tests go through `Project.load`.