### PR TITLE
fix: abort agent-supplied regexes that backtrack catastrophically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Status of the `main` branch. Changes prior to the next official version change w
 * General:
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
+  - Fix: a regular expression supplied by the agent that backtracks catastrophically (easily written
+    by accident, since DOTALL is enabled by default and thus makes `.*` span newlines) froze the
+    whole process rather than just the tool application that issued it: `re` neither releases the GIL
+    nor runs signal handlers while matching, so the tool timeout could report a failure but not stop
+    the match, and every subsequent tool application queued behind the runaway one. Such expressions
+    are now matched with the `regex` module under a time limit (10 seconds by default, configurable
+    via `SERENA_REGEX_TIMEOUT_SECONDS`), which aborts them with an error explaining the likely cause
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)

--- a/src/serena/util/regex_timeout.py
+++ b/src/serena/util/regex_timeout.py
@@ -1,0 +1,153 @@
+"""
+Time-bounded matching for regular expressions that originate from the agent.
+
+Several tools accept a regular expression written by the agent (`search_for_pattern`,
+`replace_content`, `replace_in_files`, `find_declaration`, `find_implementations`), and such an
+expression can backtrack catastrophically. The standard library's `re` module offers no way out of
+it: it neither releases the GIL nor runs signal handlers while matching. A single pathological
+expression therefore freezes the entire Serena process rather than just the tool application that
+issued it - tools are executed one at a time, so every subsequent tool application waits behind the
+runaway match, and the tool timeout can report a failure to the client but cannot stop a match that
+is already running. Killing the process is the only remedy left.
+
+The `regex` module (already a dependency) checks the clock while matching and can therefore be
+interrupted, so agent-supplied expressions are matched through the helpers below, which abort the
+match and explain the likely cause instead of taking the process down with them.
+"""
+
+import logging
+import os
+import re
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any, TypeAlias
+
+import regex
+
+log = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+"""
+The time limit for a single matching operation. Well-formed expressions match in milliseconds even
+across large repositories, so the limit only has to be small enough to keep the server responsive
+and large enough not to interfere with legitimate work.
+"""
+
+TIMEOUT_ENV_VAR = "SERENA_REGEX_TIMEOUT_SECONDS"
+
+# The `regex` module ships no type information. Its match objects are structurally identical to
+# those of `re` and are described accordingly; its compiled patterns are not, because they accept
+# the `timeout` argument that `re.Pattern` does not have.
+Match: TypeAlias = re.Match[str]
+
+
+def get_timeout_seconds() -> float:
+    """
+    :return: the time limit for a single matching operation, which is `DEFAULT_TIMEOUT_SECONDS`
+        unless the environment variable `SERENA_REGEX_TIMEOUT_SECONDS` provides a positive number.
+    """
+    raw_value = os.environ.get(TIMEOUT_ENV_VAR, "").strip()
+    if not raw_value:
+        return DEFAULT_TIMEOUT_SECONDS
+    try:
+        timeout_seconds = float(raw_value)
+    except ValueError:
+        log.warning("Ignoring %s=%r: not a number", TIMEOUT_ENV_VAR, raw_value)
+        return DEFAULT_TIMEOUT_SECONDS
+    if timeout_seconds <= 0:
+        log.warning("Ignoring %s=%r: must be positive", TIMEOUT_ENV_VAR, raw_value)
+        return DEFAULT_TIMEOUT_SECONDS
+    return timeout_seconds
+
+
+class RegexTimeoutError(ValueError):
+    """
+    Raised when matching an agent-supplied regular expression exceeded the time limit, which
+    virtually always means that the expression backtracks catastrophically rather than that the
+    input is large.
+    """
+
+    def __init__(self, pattern: str, timeout_seconds: float) -> None:
+        super().__init__(
+            f"The regular expression did not complete within {timeout_seconds:g} seconds and was aborted: {pattern!r}. "
+            "This indicates catastrophic backtracking rather than a large amount of input. "
+            "Note that '.' matches newlines as well, because the DOTALL flag is enabled by default: "
+            r"write '[^\n]*' where you mean 'the remainder of the line', and do not apply a quantifier to a group "
+            r"that can span newlines (e.g. '(?:.*\n){0,40}'), because the number of ways in which such an "
+            "expression can match grows exponentially with the size of the input. "
+            "To include a few lines around a match, use the context parameters of the tool rather than encoding "
+            "the window in the expression itself."
+        )
+        self.pattern = pattern
+        self.timeout_seconds = timeout_seconds
+
+
+class TimeLimitedPattern:
+    """
+    A compiled regular expression whose matching operations are aborted with a
+    :class:`RegexTimeoutError` when they exceed the given time limit.
+    """
+
+    def __init__(self, compiled_pattern: Any, pattern: str, timeout_seconds: float) -> None:
+        """
+        :param compiled_pattern: the expression as compiled by the `regex` module
+        :param pattern: the expression as written by the agent, for use in error messages
+        :param timeout_seconds: the time limit for a single matching operation
+        """
+        self._compiled_pattern = compiled_pattern
+        self._pattern = pattern
+        self._timeout_seconds = timeout_seconds
+
+    @property
+    def pattern(self) -> str:
+        return self._pattern
+
+    def finditer(self, content: str) -> list[Match]:
+        """
+        :param content: the text to search
+        :return: all non-overlapping matches; a list rather than a lazy iterator, such that the time
+            limit covers the entire scan instead of a single step of it
+        """
+        with self._time_limit():
+            return list(self._compiled_pattern.finditer(content, timeout=self._timeout_seconds))
+
+    def search(self, content: str) -> Match | None:
+        """
+        :param content: the text to search
+        :return: the first match or None
+        """
+        with self._time_limit():
+            return self._compiled_pattern.search(content, timeout=self._timeout_seconds)
+
+    def subn(self, repl: Callable[[Match], str], content: str) -> tuple[str, int]:
+        """
+        :param repl: the replacement function
+        :param content: the text in which to perform the replacement
+        :return: the updated text and the number of replacements performed
+        """
+        with self._time_limit():
+            return self._compiled_pattern.subn(repl, content, timeout=self._timeout_seconds)
+
+    @contextmanager
+    def _time_limit(self) -> Iterator[None]:
+        try:
+            yield
+        except TimeoutError as e:
+            raise RegexTimeoutError(self._pattern, self._timeout_seconds) from e
+
+
+def compile_pattern(pattern: str, flags: int = 0, timeout_seconds: float | None = None) -> TimeLimitedPattern:
+    """
+    Compiles an agent-supplied regular expression for time-bounded matching.
+
+    :param pattern: the regular expression
+    :param flags: the flags to compile it with
+    :param timeout_seconds: the time limit for a single matching operation; the configured default
+        applies if this is None
+    :return: the compiled expression
+    """
+    return TimeLimitedPattern(
+        regex.compile(pattern, flags),
+        pattern,
+        get_timeout_seconds() if timeout_seconds is None else timeout_seconds,
+    )

--- a/src/serena/util/text_utils.py
+++ b/src/serena/util/text_utils.py
@@ -11,6 +11,7 @@ from joblib import Parallel, delayed
 from sensai.util.string import ToStringMixin
 
 from serena.util.file_proxy import FileCollection, FileProxy
+from serena.util.regex_timeout import Match, RegexTimeoutError, TimeLimitedPattern, compile_pattern
 from solidlsp.ls_utils import TextUtils
 
 log = logging.getLogger(__name__)
@@ -136,6 +137,8 @@ def search_text(
     :param multiline: whether to apply multi-line matching, enabling the flags re.DOTALL and re.MULTILINE
     :return: List of `TextSearchMatch` objects
     :raises: ValueError if the pattern is not valid
+    :raises RegexTimeoutError: if matching the pattern exceeded the time limit, which indicates
+        catastrophic backtracking
     """
     if source_file_path and content is None:
         with open(source_file_path) as f:
@@ -150,7 +153,7 @@ def search_text(
 
     # For multiline matches, optionally use DOTALL so '.' matches newlines
     flags = (re.MULTILINE | re.DOTALL) if multiline else 0
-    compiled_pattern = re.compile(pattern, flags)
+    compiled_pattern = compile_pattern(pattern, flags)
     # Search across the entire content as a single string
     for match in compiled_pattern.finditer(content):
         start_pos = match.start()
@@ -334,6 +337,11 @@ def search_files(
             if len(search_results) > 0:
                 log.debug(f"Found {len(search_results)} matches in {relative_path}")
             return {"path": relative_path, "results": search_results, "error": None}
+        except RegexTimeoutError:
+            # a pattern that backtracks catastrophically is a problem with the pattern rather than
+            # with this particular file, so it must reach the caller instead of being counted as a
+            # skipped file (which is only logged and would thus be reported as "no matches")
+            raise
         except Exception as e:
             log.debug(f"Error processing {relative_path}: {e}")
             return {"path": relative_path, "results": [], "error": str(e)}
@@ -399,17 +407,16 @@ class ContentReplacer:
         self.regex_multiline = regex_multiline
 
     @staticmethod
-    def _create_replacement_function(regex_pattern: str, repl_template: str, regex_flags: int) -> Callable[[re.Match], str]:
+    def _create_replacement_function(pattern: TimeLimitedPattern, repl_template: str) -> Callable[[Match], str]:
         """
         Creates a replacement function that validates for ambiguity and handles backreferences.
 
-        :param regex_pattern: The regex pattern being used for matching
+        :param pattern: The compiled pattern being used for matching
         :param repl_template: The replacement template with $!1, $!2, etc. for backreferences
-        :param regex_flags: The flags to use when searching (e.g., re.DOTALL | re.MULTILINE)
-        :return: A function suitable for use with re.sub() or re.subn()
+        :return: A function suitable for use with TimeLimitedPattern.subn()
         """
 
-        def validate_and_replace(match: re.Match) -> str:
+        def validate_and_replace(match: Match) -> str:
             matched_text = match.group(0)
 
             # For multi-line match, check if the same pattern matches again within the already-matched text,
@@ -420,7 +427,7 @@ class ContentReplacer:
             # this will match the entire span above, while only the suffix may have been intended.
             # (See test case for a practical example.)
             # To detect this, we check if the same pattern matches again within the matched text,
-            if "\n" in matched_text and re.search(regex_pattern, matched_text[1:], flags=regex_flags):
+            if "\n" in matched_text and pattern.search(matched_text[1:]) is not None:
                 raise ValueError(
                     "Match is ambiguous: the search pattern matches multiple overlapping occurrences. "
                     "Please revise the search pattern to be more specific to avoid ambiguity, "
@@ -463,12 +470,13 @@ class ContentReplacer:
             raise ValueError(f"Invalid mode: '{self.mode}', expected 'literal' or 'regex'.")
 
         regex_flags = (re.MULTILINE | re.DOTALL) if self.regex_multiline else 0
+        compiled_pattern = compile_pattern(regex, regex_flags)
 
         # create replacement function with validation and backreference handling
-        repl_fn = self._create_replacement_function(regex, repl, regex_flags=regex_flags)
+        repl_fn = self._create_replacement_function(compiled_pattern, repl)
 
         # perform replacement
-        updated_content, n = re.subn(regex, repl_fn, content, flags=regex_flags)
+        updated_content, n = compiled_pattern.subn(repl_fn, content)
 
         if n == 0:
             raise ValueError("Error: No matches of search expression found.")
@@ -525,8 +533,8 @@ class MultiFileContentReplacer:
         self.mode = mode
         self._flags = (re.MULTILINE | re.DOTALL) if regex_multiline else 0
 
-    def _compile(self, needle: str) -> re.Pattern:
-        return re.compile(re.escape(needle) if self.mode == "literal" else needle, flags=self._flags)
+    def _compile(self, needle: str) -> TimeLimitedPattern:
+        return compile_pattern(re.escape(needle) if self.mode == "literal" else needle, flags=self._flags)
 
     @classmethod
     def _digest(cls, matched_text: str) -> str:
@@ -537,7 +545,7 @@ class MultiFileContentReplacer:
         return f"{relative_path}:{index_in_file}@{cls._digest(matched_text)}"
 
     @staticmethod
-    def _expand_backreferences(match: re.Match, repl_template: str) -> str:
+    def _expand_backreferences(match: Match, repl_template: str) -> str:
         """Expands $!1, $!2, ... in the replacement template (same syntax as :class:`ContentReplacer`)."""
 
         def expand(m: re.Match) -> str:
@@ -659,8 +667,8 @@ def find_text_coordinates(content: str, regex: str, require_unique: bool = False
         if False, returns None if no match is found, and returns the coordinates of the first match if multiple matches are found
     :return: the coordinates of the match or None
     """
-    pattern = re.compile(regex, flags=re.MULTILINE | re.DOTALL)
-    matches = list(pattern.finditer(content))
+    pattern = compile_pattern(regex, flags=re.MULTILINE | re.DOTALL)
+    matches = pattern.finditer(content)
     if len(matches) == 0:
         if require_unique:
             raise ValueError(f"No match found for regex: {regex}")

--- a/test/serena/test_text_utils.py
+++ b/test/serena/test_text_utils.py
@@ -1,9 +1,25 @@
+import re
+import time
 from collections.abc import Callable
 
 import pytest
 
 from serena.util.file_proxy import FileCollection, FileProxy
-from serena.util.text_utils import GlobMatcher, LineType, MultiFileContentReplacer, search_files, search_text
+from serena.util.regex_timeout import (
+    DEFAULT_TIMEOUT_SECONDS,
+    TIMEOUT_ENV_VAR,
+    RegexTimeoutError,
+    compile_pattern,
+    get_timeout_seconds,
+)
+from serena.util.text_utils import (
+    ContentReplacer,
+    GlobMatcher,
+    LineType,
+    MultiFileContentReplacer,
+    search_files,
+    search_text,
+)
 
 
 class TestSearchText:
@@ -656,3 +672,66 @@ class TestMultiFileContentReplacer:
         occ = replacer.find_occurrences([(path, content)], "old_pkg", "new_pkg")[0]
         with pytest.raises(AssertionError):
             replacer.apply_to_content("completely different content", [occ])
+
+
+class TestRegexTimeout:
+    """
+    Matching an expression supplied by the agent has to be abortable: without a time limit, an
+    expression that backtracks catastrophically takes the whole process down with it, because `re`
+    neither releases the GIL nor runs signal handlers while matching.
+    """
+
+    # the nested quantifier spans newlines (DOTALL is enabled by default), so the number of ways in
+    # which this expression can match grows exponentially with the size of the input
+    CATASTROPHIC_PATTERN = r"^func .*\n(?:.*\n){0,40}?.*never_matches_anything"
+    CONTENT = "func f() {\n" + "    body line\n" * 800
+    TIMEOUT_SECONDS = 0.5
+
+    def _assert_aborted(self, call: Callable[[], object]) -> None:
+        started = time.monotonic()
+        with pytest.raises(RegexTimeoutError) as exc_info:
+            call()
+        assert time.monotonic() - started < 30, "the time limit was not enforced"
+        # the message has to explain the way out, since the agent cannot otherwise tell what went wrong
+        assert "DOTALL" in str(exc_info.value)
+
+    def test_finditer_is_aborted(self):
+        pattern = compile_pattern(self.CATASTROPHIC_PATTERN, re.MULTILINE | re.DOTALL, timeout_seconds=self.TIMEOUT_SECONDS)
+        self._assert_aborted(lambda: pattern.finditer(self.CONTENT))
+
+    def test_search_text_is_aborted(self, monkeypatch):
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, str(self.TIMEOUT_SECONDS))
+        self._assert_aborted(lambda: search_text(self.CATASTROPHIC_PATTERN, content=self.CONTENT))
+
+    def test_search_files_does_not_report_a_timeout_as_absence_of_matches(self, monkeypatch):
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, str(self.TIMEOUT_SECONDS))
+        file_collection = MockFileCollection(["module.py"], mock_reader=lambda _path: self.CONTENT)
+        self._assert_aborted(lambda: search_files(file_collection, pattern=self.CATASTROPHIC_PATTERN))
+
+    def test_replacement_is_aborted(self, monkeypatch):
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, str(self.TIMEOUT_SECONDS))
+        replacer = ContentReplacer(mode="regex", allow_multiple_occurrences=True)
+        self._assert_aborted(lambda: replacer.replace(self.CONTENT, self.CATASTROPHIC_PATTERN, "x"))
+
+    def test_multi_file_replacement_is_aborted(self, monkeypatch):
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, str(self.TIMEOUT_SECONDS))
+        replacer = MultiFileContentReplacer(mode="regex")
+        self._assert_aborted(lambda: replacer.find_occurrences([("module.py", self.CONTENT)], self.CATASTROPHIC_PATTERN, "x"))
+
+    def test_well_formed_pattern_is_unaffected(self):
+        matches = search_text(r"^[^\n]*body line[^\n]*$", content=self.CONTENT)
+        assert len(matches) == 800
+
+    @pytest.mark.parametrize(
+        "env_value, expected",
+        [
+            ("", DEFAULT_TIMEOUT_SECONDS),
+            ("2.5", 2.5),
+            ("0", DEFAULT_TIMEOUT_SECONDS),
+            ("-1", DEFAULT_TIMEOUT_SECONDS),
+            ("not a number", DEFAULT_TIMEOUT_SECONDS),
+        ],
+    )
+    def test_timeout_is_configurable(self, monkeypatch, env_value, expected):
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, env_value)
+        assert get_timeout_seconds() == expected


### PR DESCRIPTION
## The problem

A regular expression written by the agent can backtrack catastrophically, and `search_for_pattern` makes it easy to do by accident: `multiline=True` is the default, so `re.DOTALL` is on, `.` matches newlines, and `.*` is therefore not "the rest of the line" but "any span up to any newline in the file". A quantifier applied to a group containing such a span makes the number of ways to match grow exponentially.

What follows is not a slow tool application but a frozen server:

- `re` neither releases the GIL nor runs signal handlers while matching, so the match cannot be interrupted from inside the process;
- tool applications are executed one at a time by the task executor, so every subsequent one queues behind the runaway match;
- `tool_timeout` reports a failure to the client but does not stop the match that is already running;
- `search_files` parallelises with joblib's threading backend, which does not help against the GIL.

Killing the process is the only remedy left, after which the client has to reconnect to the server.

Reproduction (Serena 1.7.1.dev0, a 1546-line source file):

```
search_for_pattern(
    substring_pattern=r"^func .*\n(?:.*\n){0,40}?.*someIdentifier",
    relative_path="internal/chat/chat.go",
)
```

The task starts and never finishes; the process holds a core at 100% indefinitely, and the log shows `Processing 1 files.` with no completion line.

## The fix

Expressions that come from the agent are matched through a new `serena.util.regex_timeout`, which uses the `regex` module — already a dependency of Serena — with its `timeout` argument. `regex` checks the clock while matching and is therefore interruptible.

The affected entry points, all in `serena/util/text_utils.py`:

| function | tool |
| --- | --- |
| `search_text` | `search_for_pattern` |
| `ContentReplacer.replace` | `replace_content` |
| `MultiFileContentReplacer.find_occurrences` | `replace_in_files` |
| `find_text_coordinates` | the `regex` argument of `find_declaration` / `find_implementations` |

On expiry, `RegexTimeoutError` is raised with a message that names the likely cause and the way out (`[^\n]*` instead of `.*`, no quantifier over a newline-spanning group, context parameters instead of encoding the window in the expression), so the agent can correct the expression on its own.

Two details worth pointing out for review:

- In `search_files`, the timeout is deliberately re-raised instead of being recorded as a skipped file: skipped files are only logged at debug level, so the agent would have seen the failure as an absence of matches.
- `ContentReplacer` now compiles the expression once and passes the compiled object to the ambiguity check, which previously re-compiled the same expression for every match.

The limit defaults to 10 seconds and can be changed with `SERENA_REGEX_TIMEOUT_SECONDS`. Well-formed expressions are unaffected: a project-wide search over 117 files takes ~50 ms.

Note on compatibility: `regex` operates in its `re`-compatible mode (VERSION0) by default, so accepted syntax and match semantics are unchanged. It ships no type information, hence the `Any` annotation for the compiled pattern in `TimeLimitedPattern`; its match objects are structurally identical to `re`'s and are annotated as such.

## Testing

`TestRegexTimeout` in `test/serena/test_text_utils.py` covers all four entry points, the configuration of the limit, and that a well-formed expression is unaffected. The pathological pattern used there does not terminate within 8 seconds under plain `re`, and aborts in 0.5 seconds with the change.

`poe format`, `poe type-check` and `test/serena/test_text_utils.py` (114 tests) pass. The remaining failures in the full `test/serena` run on my machine are unrelated to this change: language servers that are not installed here (C#, PowerShell, Kotlin), and `test_memories_manager.py`, which reads the real `~/.serena/memories` unless `SERENA_HOME` is set — with an isolated `SERENA_HOME` all 112 of its tests pass.