### PR TITLE
fix: let the remind hook see shell-based searching and reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Status of the `main` branch. Changes prior to the next official version change w
 * General:
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
+  - Fix: the `serena-hooks remind` PreToolUse hook was blind to shell-based searching and reading for
+    the `claude-code` and `codebuddy` clients: only the built-in `Grep`/`Read` tools were counted,
+    while `Bash(grep …)`, `Bash(cat …)` and `Bash(sed -n …)` were not counted at all. The hook thus
+    nudged the agent that reaches for the built-in tool and ignored the one that had already drifted
+    to the shell - the very behaviour it exists to catch. Shell commands are now classified for these
+    clients exactly as they already were for `codex` and `grok`
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -274,12 +274,14 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
     #: are caught alongside ``read_file``, while ``write_file``/``edit_file`` are not.
     _READ_FILE_VERB_SUBSTRINGS: frozenset[str] = frozenset(("read", "view", "open", "show"))
 
-    #: Shell commands that perform grep-like search; used to classify Codex/Grok
-    #: shell-command tool calls whose ``cmd`` or ``command`` field starts with one of these.
+    #: Shell commands that perform grep-like search; used to classify shell-command tool
+    #: calls (Claude Code's ``Bash``, Codex/Grok shell tools) whose ``cmd`` or ``command``
+    #: field starts with one of these.
     _GREP_SHELL_COMMANDS: frozenset[str] = frozenset(("grep", "rg", "ag", "ack", "fgrep", "egrep", "search_for_pattern"))
 
-    #: Shell commands that perform file-read operations; used to classify Codex/Grok
-    #: shell-command tool calls whose ``cmd`` or ``command`` field starts with one of these.
+    #: Shell commands that perform file-read operations; used to classify shell-command tool
+    #: calls (Claude Code's ``Bash``, Codex/Grok shell tools) whose ``cmd`` or ``command``
+    #: field starts with one of these.
     _READ_SHELL_COMMANDS: frozenset[str] = frozenset(("cat", "head", "tail", "sed", "less", "more", "bat", "get-content", "gc"))
 
     #: file suffixes for source-like files where symbolic tools are usually more
@@ -381,7 +383,13 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
 
     def is_grep_call(self) -> bool:
         if self._client in (HookClient.CLAUDE_CODE, HookClient.CODEBUDDY):
-            return self._tool_name == "grep" or "search_for_pattern" in self._tool_name
+            return (
+                self._tool_name == "grep"
+                or "search_for_pattern" in self._tool_name
+                # a shell call is the drift this hook exists to catch: `Bash(grep -rn ...)`
+                # searches exactly like the built-in tool while bypassing its name
+                or (self._is_shell_command_call() and self._command_name in self._GREP_SHELL_COMMANDS)
+            )
         if self._client == HookClient.GROK:
             return self._tool_name == "grep" or (self._is_shell_command_call() and self._command_name in self._GREP_SHELL_COMMANDS)
         if self._client == HookClient.CODEX and self._is_shell_command_call():
@@ -391,7 +399,14 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
 
     def is_read_call(self) -> bool:
         if self._client in (HookClient.CLAUDE_CODE, HookClient.CODEBUDDY):
-            return self._tool_name == "read" or "read_file" in self._tool_name
+            return (
+                self._tool_name == "read"
+                or "read_file" in self._tool_name
+                # as above: `Bash(cat ...)` / `Bash(sed -n ...)` reads a file just as
+                # the built-in tool does, and is the more likely form once the agent
+                # has learned that the built-in read is discouraged
+                or (self._is_shell_command_call() and self._command_name in self._READ_SHELL_COMMANDS)
+            )
         if self._client == HookClient.GROK:
             return self._tool_name == "read_file" or (self._is_shell_command_call() and self._command_name in self._READ_SHELL_COMMANDS)
         if self._client == HookClient.CODEX and self._is_shell_command_call():
@@ -418,7 +433,8 @@ class PreToolUseRemindAboutSymbolicToolsHook(PreToolUseHook):
         if self._file_path is not None:
             return self._is_code_file_path(self._file_path)
 
-        if self._client in (HookClient.CODEX, HookClient.GROK) and self._command_args_str is not None:
+        # a shell read names its target in the arguments, whichever client issued it
+        if self._command_args_str is not None:
             return any(self._is_code_file_path(argument) for argument in self._iter_shell_path_arguments())
 
         return True

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -118,6 +118,56 @@ class TestPreToolUseRemindAboutSerenaHook:
                 hook = PreToolUseRemindAboutSymbolicToolsHook(HookClient.CLAUDE_CODE)
             assert hook.is_grep_call() == expected, f"is_grep_tool() wrong for {name} (claude-code)"
 
+    def test_grep_tool_detection_claude_code_shell_commands(self, tmp_path: Path):
+        """Claude Code searches through ``Bash`` at least as often as through ``Grep``."""
+        cases = [
+            ("bash", {"command": "grep -rn foo src"}, True),
+            ("bash", {"command": "rg -n foo src"}, True),
+            ("bash", {"command": "/usr/bin/egrep -n foo src"}, True),
+            ("bash", {"command": "go build ./..."}, False),
+            ("bash", {"command": "cat README.md"}, False),
+        ]
+        for tool_name, tool_input, expected in cases:
+            with (
+                patch("sys.stdin", _make_stdin(_base_input(tool_name=tool_name, tool_input=tool_input))),
+                patch("serena.hooks.serena_home_dir", str(tmp_path)),
+            ):
+                hook = PreToolUseRemindAboutSymbolicToolsHook(HookClient.CLAUDE_CODE)
+            assert hook.is_grep_call() == expected, f"is_grep_call() wrong for {tool_input} (claude-code)"
+
+    def test_read_tool_detection_claude_code_shell_commands(self, tmp_path: Path):
+        """Reading through the shell is the likelier drift once the built-in read is discouraged."""
+        cases = [
+            ("bash", {"command": "cat src/foo.py"}, True),
+            ("bash", {"command": "sed -n '1,40p' src/foo.py"}, True),
+            ("bash", {"command": "head -20 README.md"}, True),
+            ("bash", {"command": "grep -rn foo src"}, False),
+            ("bash", {"command": "git status"}, False),
+        ]
+        for tool_name, tool_input, expected in cases:
+            with (
+                patch("sys.stdin", _make_stdin(_base_input(tool_name=tool_name, tool_input=tool_input))),
+                patch("serena.hooks.serena_home_dir", str(tmp_path)),
+            ):
+                hook = PreToolUseRemindAboutSymbolicToolsHook(HookClient.CLAUDE_CODE)
+            assert hook.is_read_call() == expected, f"is_read_call() wrong for {tool_input} (claude-code)"
+
+    def test_shell_read_target_decides_whether_it_is_a_code_file(self, tmp_path: Path):
+        """The target of a shell read is named in its arguments, so it can be classified."""
+        cases = [
+            ({"command": "cat src/foo.py"}, True),
+            ({"command": "sed -n '1,40p' internal/chat/chat.go"}, True),
+            ({"command": "cat README.md"}, False),
+            ({"command": "tail -n 50 /var/log/syslog"}, False),
+        ]
+        for tool_input, expected in cases:
+            with (
+                patch("sys.stdin", _make_stdin(_base_input(tool_name="bash", tool_input=tool_input))),
+                patch("serena.hooks.serena_home_dir", str(tmp_path)),
+            ):
+                hook = PreToolUseRemindAboutSymbolicToolsHook(HookClient.CLAUDE_CODE)
+            assert hook.is_read_code_file_call() == expected, f"is_read_code_file_call() wrong for {tool_input}"
+
     def test_grep_tool_detection_non_claude_code(self, tmp_path: Path):
         """Non-Claude-Code clients fall back to substring matching to cover verbose tool names."""
         for name, expected in [("grep_search", True), ("mcp_grep", True), ("read_file", False), ("serena_find", False)]:


### PR DESCRIPTION
## The problem

`serena-hooks remind` exists to notice when an agent drifts away from the symbolic tools and to nudge it back. For the `claude-code` and `codebuddy` clients it counts only the built-in `Grep` and `Read` tools:

```python
def is_grep_call(self) -> bool:
    if self._client in (HookClient.CLAUDE_CODE, HookClient.CODEBUDDY):
        return self._tool_name == "grep" or "search_for_pattern" in self._tool_name
```

A search issued as `Bash(grep -rn ...)` and a read issued as `Bash(cat ...)` or `Bash(sed -n '1,40p' ...)` are not counted at all.

That is the wrong half of the behaviour. An agent still pressing the built-in `Grep` is at least using a tool the hook can see; an agent that has already moved to the shell is precisely the one the reminder is meant for — and it is invisible to the hook. In practice the shell is where the drift goes: a session told that the built-in read is discouraged reaches for `cat` next, not for `find_symbol`.

The machinery to classify these calls is already present and already used for `codex` and `grok`: `_GREP_SHELL_COMMANDS`, `_READ_SHELL_COMMANDS`, `_is_shell_command_call()`, and the payload parsing that extracts a `cmd`/`command` field (Claude Code's `Bash` tool uses `command`, which is already read in `__init__`).

## The change

`is_grep_call` and `is_read_call` classify shell-command calls for `claude-code` / `codebuddy` the same way they already do for `grok`.

`is_read_code_file_call` gets the same treatment for a related reason: it inspected the shell arguments only for `codex` and `grok`, so a shell read from any other client fell through to the `return True` default and `cat README.md` was counted as reading source. The target of a shell read is named in its arguments regardless of which client issued it, so the client gate around that branch is dropped rather than extended.

## Scope

Deliberately unchanged: only the first token of the command is examined, so `cd sub && grep -rn foo` is still not classified. That limitation is pre-existing and shared with `codex`/`grok`; splitting commands on `&&`, `||`, `;` and `|` would be a sensible follow-up, but it changes classification for the existing clients too and belongs in its own change.

## Testing

Three new cases in `test/serena/test_hooks.py` covering shell search, shell read, and code-file classification of the shell read target, in the same table style as the existing `codex`/`grok` tests. `test/serena/test_hooks.py` (86 tests) and `test/serena/config` (99 tests) pass, as do `poe format` and `poe type-check`.