### PR TITLE
fix: stop duplicating a comment block that follows a nested mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Status of the `main` branch. Changes prior to the next official version change w
 * General:
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
+  - Fix: a comment block following a nested mapping in a configuration file was duplicated on every
+    save, so `serena_config.yml` grew by one copy of the same block per project registration (one
+    config in the field had accumulated thirty copies, 369 lines for 225 lines of content). ruamel
+    attaches such a block to the last entry of the nested mapping, where the comment normalisation —
+    which only inspects top-level keys — left it untouched; it was then written back out alongside
+    the copy transferred onto the top-level key it actually documents. Nested mappings are now
+    treated like nested sequences already were
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)

--- a/src/serena/util/yaml.py
+++ b/src/serena/util/yaml.py
@@ -136,17 +136,28 @@ def normalise_yaml_comments(commented_map: CommentedMap, comment_normalisation: 
 
     def remove_nested_comments() -> None:
         """
-        Removes nested comments, particularly of sequences, which incorrectly capture comments
-        that are actually intended for top-level keys.
+        Removes nested comments, particularly of sequences and nested mappings, which incorrectly
+        capture comments that are actually intended for top-level keys.
+
+        Nested mappings matter as much as sequences here: ruamel attaches a comment block that
+        follows a nested mapping to that mapping's last entry, at any depth. Such a comment survives
+        the normalisation above (which only ever looks at top-level keys), is written back out on
+        save, and is then joined by the comment that the caller transfers onto the top-level key it
+        was actually meant for — so the block is duplicated once per save.
         """
+
+        def remove(node: Any) -> None:
+            if not isinstance(node, CommentedSeq | CommentedMap):
+                return
+            items = node.ca.items
+            if isinstance(items, dict):
+                for i in list(items.keys()):
+                    items[i] = [None] * 4
+            for value in node.values() if isinstance(node, CommentedMap) else node:
+                remove(value)
+
         for key in commented_map.keys():
-            entry = commented_map[key]
-            if isinstance(entry, CommentedSeq):
-                items = entry.ca.items
-                if isinstance(items, dict):
-                    items_keys = list(items.keys())
-                    for i in items_keys:
-                        items[i] = [None] * 4
+            remove(commented_map[key])
 
     match comment_normalisation:
         case YamlCommentNormalisation.NONE:

--- a/test/serena/util/test_yaml.py
+++ b/test/serena/util/test_yaml.py
@@ -12,7 +12,7 @@ import threading
 
 from ruamel.yaml import YAML
 
-from serena.util.yaml import load_yaml, save_yaml
+from serena.util.yaml import YamlCommentNormalisation, load_yaml, save_yaml, transfer_yaml_comments
 
 
 def _read_text(path: str) -> str:
@@ -78,3 +78,85 @@ def test_concurrent_saves_never_corrupt(tmp_path):
     loaded = load_yaml(path)
     assert "projects" in loaded
     assert all(isinstance(p, str) for p in loaded["projects"])
+
+
+# The comment block that the template documents for ``ignored_paths``; in a user's config it ends up
+# following the nested ``ls_specific_settings`` mapping, which is where ruamel attaches it.
+_IGNORED_PATHS_COMMENT = "# list of paths to ignore across all projects."
+
+_TEMPLATE = f"""\
+ls_specific_settings: {{}}
+
+{_IGNORED_PATHS_COMMENT}
+# Same syntax as gitignore, so you can use * and **.
+ignored_paths: []
+
+# whether to log verbosely
+log_level: 20
+"""
+
+_USER_CONFIG = f"""\
+ls_specific_settings:
+  java:
+    use_system_java_home: true
+
+{_IGNORED_PATHS_COMMENT}
+# Same syntax as gitignore, so you can use * and **.
+ignored_paths: []
+
+# whether to log verbosely
+log_level: 20
+"""
+
+
+def _save_like_serena_config_does(path: str, template_path: str) -> None:
+    """One save cycle of the global configuration: load, take the template's comments, write back."""
+    config = load_yaml(path, comment_normalisation=YamlCommentNormalisation.LEADING_WITH_CONVERSION_FROM_TRAILING)
+    template = load_yaml(template_path, comment_normalisation=YamlCommentNormalisation.LEADING)
+    transfer_yaml_comments(template, config, YamlCommentNormalisation.LEADING, force_update_all=True)
+    save_yaml(path, config)
+
+
+def test_comment_after_nested_mapping_is_not_duplicated_on_save(tmp_path):
+    """A comment block following a nested mapping must not be duplicated by each save.
+
+    Regression: ruamel attaches such a block to the *last entry of the nested mapping*, at any
+    depth. The normalisation only ever inspects top-level keys, so the block survived untouched,
+    was written back out, and was then joined by the copy that the caller transfers onto the
+    top-level key the block actually documents. Every save added one more copy: a config in the
+    field had accumulated thirty of them, growing by one per project registration.
+    """
+    template_path = str(tmp_path / "template.yml")
+    config_path = str(tmp_path / "config.yml")
+    with open(template_path, "w", encoding="utf-8") as f:
+        f.write(_TEMPLATE)
+    with open(config_path, "w", encoding="utf-8") as f:
+        f.write(_USER_CONFIG)
+
+    _save_like_serena_config_does(config_path, template_path)
+    assert _read_text(config_path).count(_IGNORED_PATHS_COMMENT) == 1
+
+    # and it stays at one, however many times the configuration is saved
+    for _ in range(3):
+        _save_like_serena_config_does(config_path, template_path)
+    assert _read_text(config_path).count(_IGNORED_PATHS_COMMENT) == 1
+
+    # the settings themselves are untouched
+    loaded = load_yaml(config_path)
+    assert loaded["ls_specific_settings"]["java"]["use_system_java_home"] is True
+    assert loaded["log_level"] == 20
+
+
+def test_saving_is_idempotent_for_a_config_with_nested_mappings(tmp_path):
+    """Two consecutive saves produce byte-identical files: nothing accumulates."""
+    template_path = str(tmp_path / "template.yml")
+    config_path = str(tmp_path / "config.yml")
+    with open(template_path, "w", encoding="utf-8") as f:
+        f.write(_TEMPLATE)
+    with open(config_path, "w", encoding="utf-8") as f:
+        f.write(_USER_CONFIG)
+
+    _save_like_serena_config_does(config_path, template_path)
+    once = _read_text(config_path)
+    _save_like_serena_config_does(config_path, template_path)
+    assert _read_text(config_path) == once


### PR DESCRIPTION
## The symptom

`~/.serena/serena_config.yml` grows. A configuration on my machine had accumulated **thirty copies** of the same comment block — 369 lines holding 225 lines of content — and gained one more on every project registration, since registering a project rewrites the file.

Reproduced from a clean file: one `serena start-mcp-server --project <new path>` takes the block count from 1 to 2, and so on.

## The cause

Two mechanisms that are individually correct, with a gap between them.

ruamel attaches a comment block that follows a nested mapping to the **last entry of that mapping**, at any depth. In a configuration like

```yaml
ls_specific_settings:
  java:
    use_system_java_home: true

# list of paths to ignore across all projects.
# Same syntax as gitignore, so you can use * and **.
ignored_paths: []
```

the block is attached to `ls_specific_settings.java.use_system_java_home`, not to `ignored_paths`. Verified by inspecting the parsed `CommentedMap`: the token sits at `ls_specific_settings.java['use_system_java_home']`, comment slot 2 (post-value).

`normalise_yaml_comments` only ever inspects top-level keys, so it neither moves the block up nor removes it, and `save_yaml` writes it back out verbatim. `SerenaConfig.save` then calls

```python
transfer_yaml_comments(template_yaml, commented_yaml, YamlCommentNormalisation.LEADING, force_update_all=True)
```

which puts the template's text onto `ignored_paths` as its leading comment. The saved file now contains the block twice — and the second copy is again parsed as belonging to the nested mapping next time, so the count grows by one per save.

`remove_nested_comments` exists for exactly this class of stray and states the assumption plainly ("we assume that only top-level keys are supposed to be commented"), but it only handled `CommentedSeq`:

```python
for key in commented_map.keys():
    entry = commented_map[key]
    if isinstance(entry, CommentedSeq):
        ...
```

## The change

`remove_nested_comments` now walks nested mappings and sequences alike, at any depth.

## Trade-off worth stating

A comment the user writes *inside* a nested mapping is now dropped on the next save — exactly as one written inside a nested sequence already was. That follows the assumption the function already declares, and it is what makes the fix small.

The alternative is to **move** such a block up to the following top-level key instead of removing it, which preserves user comments and is more faithful, but is a larger change to the normalisation (finding the next top-level key, deciding leading vs trailing). If you prefer that shape, say so and I will rework it.

## Testing

Two tests in `test/serena/util/test_yaml.py` exercising one full save cycle of the global configuration (load → transfer template comments with `force_update_all` → save):

- the block appears exactly once after the first save and stays at one over three more saves, with the settings themselves unchanged;
- two consecutive saves produce byte-identical files.

Both fail on `main` and pass with the change. `poe format`, `poe type-check`, and `test/serena/util` + `test/serena/config` + `test/serena/test_project_server.py` (151 tests) pass.

Verified end to end as well: with the patch applied to an installed Serena, registering a new project rewrites the config and the block count stays at 1.