### PR TITLE
fix(mcp): report Serena's version in the initialize handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
   - Fix: `read_only` restriction in project definition was not applied to base tool set when in single-project context (#1938)
+  - Fix: the MCP `initialize` handshake reported `serverInfo.version` as the version of the installed
+    `mcp` SDK rather than Serena's own, so a client that logs, displays or compares the server version
+    saw a string that never matches a Serena release (#1889)
 
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)

--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -20,6 +20,7 @@ from mcp.types import ToolAnnotations
 from pydantic_settings import SettingsConfigDict
 from sensai.util import logging
 
+from serena import __version__
 from serena.agent import (
     SerenaAgent,
 )
@@ -390,6 +391,9 @@ class SerenaMCPFactory:
             port=port,
             instructions=instructions,
         )
+        # noinspection PyProtectedMember
+        # FastMCP passes no version to the low-level server, whose serverInfo then falls back to the mcp package's version.
+        mcp._mcp_server.version = __version__
         return mcp
 
     @asynccontextmanager

--- a/test/serena/test_mcp.py
+++ b/test/serena/test_mcp.py
@@ -298,3 +298,32 @@ def test_make_tool_all_tools(tool_class) -> None:
 
     # The description should be a string (either from docstring or default)
     assert isinstance(mcp_tool.description, str)
+
+
+def test_create_mcp_server_reports_serena_version(monkeypatch) -> None:
+    """Test that the initialize handshake reports Serena's version, not the mcp SDK's."""
+    from importlib.metadata import version as installed_version
+
+    from mcp.server.fastmcp.server import Settings
+
+    from serena import __version__
+    from serena.config.serena_config import SerenaConfig
+
+    class AgentlessFactory(SerenaMCPFactory):
+        """Builds the server without a SerenaAgent, so only the FastMCP construction is exercised."""
+
+        def _create_serena_agent(self, serena_config, modes=None, project_activation_error=None):
+            return MockAgent()
+
+        def _get_initial_instructions(self) -> str:
+            return "test instructions"
+
+    monkeypatch.setattr(SerenaConfig, "from_config_file", classmethod(lambda cls, **kwargs: object()))
+    # create_mcp_server rebinds this class attribute of the SDK; restore it afterwards.
+    monkeypatch.setattr(Settings, "model_config", Settings.model_config)
+
+    mcp = AgentlessFactory(transport="stdio").create_mcp_server()
+    options = mcp._mcp_server.create_initialization_options()
+
+    assert options.server_version == __version__
+    assert options.server_version != installed_version("mcp")


### PR DESCRIPTION
## Problem

The MCP `initialize` handshake answers `serverInfo.version` with the version of the installed `mcp` SDK rather than Serena's own. On current `main` a client sees `1.28.1`, which has never been a Serena release.

## Root cause

`mcp.server.lowlevel.Server.create_initialization_options()` computes `server_version = self.version if self.version else pkg_version("mcp")`, so an unset `version` falls back to the SDK's own package version. `FastMCP.__init__` builds that low-level server with `name`, `instructions`, `website_url`, `icons` and `lifespan`, and never passes a version, so `self.version` stays `None` on every FastMCP-based server. `create_mcp_server` supplies `name` and `website_url` but has no way to supply a version: `version` is not a parameter of `FastMCP.__init__` in the pinned `mcp==1.28.1`, and passing it raises `TypeError`.

## Fix

Set the low-level server's version after construction:

```python
mcp._mcp_server.version = __version__
```

Two points I did not want to settle on my own:

- This reaches into `_mcp_server`, a private attribute. It is the only way to supply a version through `FastMCP` at `mcp==1.28.1`, which `pyproject.toml` pins exactly, so it cannot drift under a floating dependency. The cleaner long-term shape is a `version` passthrough in FastMCP upstream. If you would rather wait for that, say so and I will close this.
- I used `__version__` (`1.7.1.dev0`) rather than `serena_version()`, which appends the git short sha and `-dirty`. `get_current_config` already reports the plain version, and `serverInfo.version` is what clients compare against releases. Happy to switch if you prefer the git-suffixed string.

## Verification

- New test in `test/serena/test_mcp.py` fails on `main` with `AssertionError: assert '1.28.1' == '1.7.1.dev0'` and passes here. It builds the server through the real `create_mcp_server` and asserts on `create_initialization_options()`, the function that produces the wire value.
- Live handshake in a clean `python:3.11-slim` container at HEAD `7fcbca7e`, streamable-http on `127.0.0.1:47321`: before, `"version":"1.28.1"`; after, `"version":"1.7.1.dev0"`.
- `poe lint`, `poe type-check` and `codespell` pass; the `catch-all` pytest batch runs 1279 passed / 5 failed on Python 3.11 in that container, and those same 5 (the `show_fatal_exception_safe` GUI tests and two process-group cleanup tests) fail identically on unmodified HEAD there, so they are environmental rather than mine.
- Not checked: client-side behaviour that keys on the old value, and the `mcp` 2.x upgrades in #1777 and #1882, which restructure this construction site.

Fixes #1889

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.
