### PR TITLE
fix(php): honor file_filter in alternatives, fix Phpactor indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     project list in `serena_config.yml`
 
 * Language Servers:
+  - Fix: PHPantom now honors `ls_specific_settings.php_phpantom.file_filter`, so project-specific
+    PHP extensions such as `.inc` participate in symbol and reference queries
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Language Servers:
   - Fix: PHPantom and Phpactor now honor their `ls_specific_settings.*.file_filter`, so
-    project-specific PHP extensions such as `.inc` participate in symbol queries
+    project-specific PHP extensions such as `.inc` participate in symbol queries; Phpactor's
+    indexer is configured accordingly, such that references contained in these files are found too
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     project list in `serena_config.yml`
 
 * Language Servers:
-  - Fix: PHPantom now honors `ls_specific_settings.php_phpantom.file_filter`, so project-specific
-    PHP extensions such as `.inc` participate in symbol and reference queries
+  - Fix: PHPantom and Phpactor now honor their `ls_specific_settings.*.file_filter`, so
+    project-specific PHP extensions such as `.inc` participate in symbol and reference queries
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: PHPantom and Phpactor now honor their `ls_specific_settings.*.file_filter`, so
     project-specific PHP extensions such as `.inc` participate in symbol queries; Phpactor's
     indexer is configured accordingly, such that references contained in these files are found too
+  - Fix: Phpactor's first cross-file query of a session could return nothing, or fail outright with
+    "Dirty index file path cannot be created", because it was answered from an index Phpactor had
+    not written yet. Serena now waits for the indexing progress Phpactor reports, bounded by the new
+    `indexing_timeout` and `indexing_start_grace` settings, and keeps the index in the project's
+    cache directory, keyed by the indexed extensions so that widening `file_filter` reindexes
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Language Servers:
   - Fix: PHPantom and Phpactor now honor their `ls_specific_settings.*.file_filter`, so
-    project-specific PHP extensions such as `.inc` participate in symbol and reference queries
+    project-specific PHP extensions such as `.inc` participate in symbol queries
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate

--- a/src/solidlsp/language_servers/phpactor.py
+++ b/src/solidlsp/language_servers/phpactor.py
@@ -141,6 +141,15 @@ class PhpactorServer(SolidLanguageServer):
                 [*PHPACTOR_DEFAULT_INDEXED_EXTENSIONS, *(ext.lstrip(".") for ext in self.ls_id.get_source_fn_matcher().file_extensions)]
             )
         )
+
+        # Phpactor's dirty-document tracker appends to `<indexer.index_path>/dirty` whenever a
+        # references request reconciles the open documents with the index, and raises if that
+        # directory does not exist yet -- which is the case until its background index has flushed
+        # for the first time. A `find_referencing_symbols` early in the session therefore failed
+        # outright (observed on Windows CI). Pointing the index at a directory Serena creates up
+        # front removes the race and keeps the index next to the other cached state of the project.
+        index_path = self.cache_dir / "phpactor-index"
+        index_path.mkdir(parents=True, exist_ok=True)
         initialize_params = {
             "capabilities": {
                 "textDocument": {
@@ -166,6 +175,7 @@ class PhpactorServer(SolidLanguageServer):
                 # These keys replace Phpactor's defaults, hence the union with them.
                 "indexer.include_patterns": [f"/**/*.{ext}" for ext in indexed_extensions],
                 "indexer.supported_extensions": indexed_extensions,
+                "indexer.index_path": str(index_path),
             },
         }
         return initialize_params

--- a/src/solidlsp/language_servers/phpactor.py
+++ b/src/solidlsp/language_servers/phpactor.py
@@ -2,11 +2,13 @@
 Provides PHP specific instantiation of the LanguageServer class using Phpactor.
 """
 
+import hashlib
 import logging
 import os
 import re
 import shutil
 import stat
+import threading
 
 from overrides import override
 
@@ -55,7 +57,22 @@ class PhpactorServer(SolidLanguageServer):
         - file_filter: list of additional file extensions (with leading dot) to treat as PHP
           sources, e.g. [".module", ".inc"]; these are also pushed to Phpactor's indexer, so
           references contained in such files are found as well
+        - indexing_timeout: float, seconds to wait for Phpactor's initial workspace index before
+          the first cross-file query (default: 120.0)
+        - indexing_start_grace: float, seconds to wait for Phpactor to start reporting indexing
+          progress at all (default: 5.0)
+
+    Serena keeps Phpactor's index in the project's cache directory, one directory per set of
+    indexed extensions, so the first cross-file query of a project (or the first one after
+    `file_filter` changed) waits for a full index, PHP's bundled stubs included.
     """
+
+    # Phpactor indexes the workspace once at startup and reports it as work-done progress; a
+    # cross-file query before that index exists comes back empty (see
+    # `_wait_for_cross_file_references_if_needed`). The timeouts only bound the pathological case
+    # of a server that never reports.
+    INDEXING_TIMEOUT = 120.0
+    INDEXING_START_GRACE = 5.0
 
     @override
     def is_ignored_dirname(self, dirname: str) -> bool:
@@ -127,6 +144,12 @@ class PhpactorServer(SolidLanguageServer):
         if file_filter:
             self.ls_id.get_source_fn_matcher().add_extensions(*file_filter)
 
+        # tracking the workspace indexing that Phpactor reports as work-done progress
+        self._progress_lock = threading.Lock()
+        self._active_progress_tokens: set[str] = set()
+        self._indexing_started = threading.Event()
+        self._indexing_complete = threading.Event()
+
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
         return self.DependencyProvider(self._custom_settings, self._ls_resources_dir)
 
@@ -160,7 +183,12 @@ class PhpactorServer(SolidLanguageServer):
         # for the first time. A `find_referencing_symbols` early in the session therefore failed
         # outright (observed on Windows CI). Pointing the index at a directory Serena creates up
         # front removes the race and keeps the index next to the other cached state of the project.
-        index_path = self.cache_dir / "phpactor-index"
+        #
+        # The indexed extensions are part of the directory name because Phpactor's indexer skips
+        # files that are older than the index: widening `file_filter` for an already indexed
+        # project would otherwise leave the newly included files out of the index indefinitely.
+        index_key = hashlib.sha256(",".join(indexed_extensions).encode()).hexdigest()[:8]
+        index_path = self.cache_dir / f"phpactor-index-{index_key}"
         if re.search(r"%.*%", str(index_path)):
             # Phpactor expands `%token%` pairs in path settings and aborts on unknown tokens, so
             # such a path cannot be passed on; the project keeps Phpactor's default index location.
@@ -183,9 +211,54 @@ class PhpactorServer(SolidLanguageServer):
                     "workspaceFolders": True,
                     "didChangeConfiguration": {"dynamicRegistration": True},
                 },
+                # Phpactor reports its workspace indexing as work-done progress, which is what the
+                # first cross-file query waits on
+                "window": {"workDoneProgress": True},
             },
             "initializationOptions": initialization_options,
         }
+
+    def _on_progress(self, params: dict) -> None:
+        """Track the work-done progress tokens Phpactor reports, the workspace index among them.
+
+        :param params: the `$/progress` notification's `ProgressParams`
+        """
+        token = str(params.get("token", ""))
+        value = params.get("value") or {}
+        kind = value.get("kind")
+        if kind == "begin":
+            with self._progress_lock:
+                self._active_progress_tokens.add(token)
+                self._indexing_complete.clear()
+            self._indexing_started.set()
+            log.info(f"Phpactor progress [{token}] started: {value.get('title')}")
+        elif kind == "end":
+            with self._progress_lock:
+                self._active_progress_tokens.discard(token)
+                if not self._active_progress_tokens:
+                    self._indexing_complete.set()
+            log.info(f"Phpactor progress [{token}] ended: {value.get('message')}")
+
+    @override
+    def _wait_for_cross_file_references_if_needed(self) -> None:
+        if self._has_waited_for_cross_file_references:
+            return
+
+        # Phpactor answers reference queries from its index and reconciles the open documents with
+        # it first, so a query issued before the initial index has been written returns nothing at
+        # all -- and its dirty-document tracker even raises if the index directory is still absent.
+        # Wait for the indexing progress Phpactor reports rather than for a fixed period.
+        timeout = float(self._custom_settings.get("indexing_timeout", self.INDEXING_TIMEOUT))
+        start_grace = float(self._custom_settings.get("indexing_start_grace", self.INDEXING_START_GRACE))
+        if not self._indexing_started.wait(timeout=start_grace):
+            log.warning(f"Phpactor reported no indexing progress within {start_grace:.0f}s; proceeding")
+        elif not self._indexing_complete.wait(timeout=timeout):
+            with self._progress_lock:
+                outstanding = ", ".join(sorted(self._active_progress_tokens)) or "<none>"
+            log.warning(f"Phpactor indexing did not complete within {timeout:.0f}s; proceeding (outstanding tokens: {outstanding})")
+        else:
+            log.info("Phpactor indexing complete")
+        self._has_waited_for_cross_file_references = True
 
     def _start_server(self) -> None:
         """Start Phpactor server process."""
@@ -200,8 +273,9 @@ class PhpactorServer(SolidLanguageServer):
             return
 
         self.server.on_request("client/registerCapability", register_capability_handler)
+        self.server.on_request("window/workDoneProgress/create", register_capability_handler)
         self.server.on_notification("window/logMessage", window_log_message)
-        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("$/progress", self._on_progress)
         self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
 
         log.info("Starting Phpactor server process")

--- a/src/solidlsp/language_servers/phpactor.py
+++ b/src/solidlsp/language_servers/phpactor.py
@@ -142,6 +142,18 @@ class PhpactorServer(SolidLanguageServer):
             )
         )
 
+        initialization_options: dict[str, object] = {
+            "language_server_phpstan.enabled": False,
+            "language_server_psalm.enabled": False,
+            "language_server_php_cs_fixer.enabled": False,
+            # Phpactor's indexer only walks its own default extensions, so the extra extensions
+            # Serena treats as PHP sources (`file_filter`, #1710) would be missing from the index
+            # and cross-file requests such as `textDocument/references` would not see them.
+            # These keys replace Phpactor's defaults, hence the union with them.
+            "indexer.include_patterns": [f"/**/*.{ext}" for ext in indexed_extensions],
+            "indexer.supported_extensions": indexed_extensions,
+        }
+
         # Phpactor's dirty-document tracker appends to `<indexer.index_path>/dirty` whenever a
         # references request reconciles the open documents with the index, and raises if that
         # directory does not exist yet -- which is the case until its background index has flushed
@@ -149,8 +161,15 @@ class PhpactorServer(SolidLanguageServer):
         # outright (observed on Windows CI). Pointing the index at a directory Serena creates up
         # front removes the race and keeps the index next to the other cached state of the project.
         index_path = self.cache_dir / "phpactor-index"
-        index_path.mkdir(parents=True, exist_ok=True)
-        initialize_params = {
+        if re.search(r"%.*%", str(index_path)):
+            # Phpactor expands `%token%` pairs in path settings and aborts on unknown tokens, so
+            # such a path cannot be passed on; the project keeps Phpactor's default index location.
+            log.warning(f"Not configuring Phpactor's index path: '{index_path}' would be read as containing a placeholder")
+        else:
+            index_path.mkdir(parents=True, exist_ok=True)
+            initialization_options["indexer.index_path"] = str(index_path)
+
+        return {
             "capabilities": {
                 "textDocument": {
                     "synchronization": {"didSave": True, "dynamicRegistration": True},
@@ -165,20 +184,8 @@ class PhpactorServer(SolidLanguageServer):
                     "didChangeConfiguration": {"dynamicRegistration": True},
                 },
             },
-            "initializationOptions": {
-                "language_server_phpstan.enabled": False,
-                "language_server_psalm.enabled": False,
-                "language_server_php_cs_fixer.enabled": False,
-                # Phpactor's indexer only walks its own default extensions, so the extra extensions
-                # Serena treats as PHP sources (`file_filter`, #1710) would be missing from the index
-                # and cross-file requests such as `textDocument/references` would not see them.
-                # These keys replace Phpactor's defaults, hence the union with them.
-                "indexer.include_patterns": [f"/**/*.{ext}" for ext in indexed_extensions],
-                "indexer.supported_extensions": indexed_extensions,
-                "indexer.index_path": str(index_path),
-            },
+            "initializationOptions": initialization_options,
         }
-        return initialize_params
 
     def _start_server(self) -> None:
         """Start Phpactor server process."""

--- a/src/solidlsp/language_servers/phpactor.py
+++ b/src/solidlsp/language_servers/phpactor.py
@@ -28,6 +28,10 @@ INITIAL_PHPACTOR_PHAR_SHA256 = "53bbe9625cd9b5e9b394bc2f595fbad13dbbe6dfc96950c5
 DEFAULT_PHPACTOR_VERSION = "2025.12.21.1"
 DEFAULT_PHPACTOR_PHAR_SHA256 = "53bbe9625cd9b5e9b394bc2f595fbad13dbbe6dfc96950c56dea3b5d9a246cc3"
 
+# Phpactor's own default `indexer.supported_extensions`; overriding that setting replaces the
+# defaults rather than extending them, so they have to be carried over explicitly.
+PHPACTOR_DEFAULT_INDEXED_EXTENSIONS = ("php", "phar")
+
 
 def _phpactor_sha(version: str) -> str | None:
     if version == INITIAL_PHPACTOR_VERSION:
@@ -49,7 +53,8 @@ class PhpactorServer(SolidLanguageServer):
         - phpactor_version: Override the pinned Phpactor PHAR version downloaded by
           Serena (default: the bundled Serena version)
         - file_filter: list of additional file extensions (with leading dot) to treat as PHP
-          sources, e.g. [".module", ".inc"]
+          sources, e.g. [".module", ".inc"]; these are also pushed to Phpactor's indexer, so
+          references contained in such files are found as well
     """
 
     @override
@@ -129,6 +134,13 @@ class PhpactorServer(SolidLanguageServer):
         """
         Returns the initialization params for the Phpactor Language Server.
         """
+        # union of Phpactor's own indexer extensions with everything Serena's source-file matcher
+        # treats as PHP (the defaults plus any configured via `file_filter`)
+        indexed_extensions = list(
+            dict.fromkeys(
+                [*PHPACTOR_DEFAULT_INDEXED_EXTENSIONS, *(ext.lstrip(".") for ext in self.ls_id.get_source_fn_matcher().file_extensions)]
+            )
+        )
         initialize_params = {
             "capabilities": {
                 "textDocument": {
@@ -148,6 +160,12 @@ class PhpactorServer(SolidLanguageServer):
                 "language_server_phpstan.enabled": False,
                 "language_server_psalm.enabled": False,
                 "language_server_php_cs_fixer.enabled": False,
+                # Phpactor's indexer only walks its own default extensions, so the extra extensions
+                # Serena treats as PHP sources (`file_filter`, #1710) would be missing from the index
+                # and cross-file requests such as `textDocument/references` would not see them.
+                # These keys replace Phpactor's defaults, hence the union with them.
+                "indexer.include_patterns": [f"/**/*.{ext}" for ext in indexed_extensions],
+                "indexer.supported_extensions": indexed_extensions,
             },
         }
         return initialize_params

--- a/src/solidlsp/language_servers/phpactor.py
+++ b/src/solidlsp/language_servers/phpactor.py
@@ -65,6 +65,12 @@ class PhpactorServer(SolidLanguageServer):
     Serena keeps Phpactor's index in the project's cache directory, one directory per set of
     indexed extensions, so the first cross-file query of a project (or the first one after
     `file_filter` changed) waits for a full index, PHP's bundled stubs included.
+
+    On Windows, Phpactor's indexer does not deliver: it announces "Indexing workspace" and then
+    makes no progress at all (measured on the Windows CI runners: no progress report and an empty
+    index 600s in, where the same workspace takes ~9s elsewhere). Cross-file queries there return
+    nothing once `indexing_timeout` expires -- symbol queries, which do not use the index, are
+    unaffected. Prefer Intelephense or PHPantom on Windows.
     """
 
     # Phpactor indexes the workspace once at startup and reports it as work-done progress; a

--- a/src/solidlsp/language_servers/phpactor.py
+++ b/src/solidlsp/language_servers/phpactor.py
@@ -48,6 +48,8 @@ class PhpactorServer(SolidLanguageServer):
         - ignore_vendor: whether to ignore directories named "vendor" (default: true)
         - phpactor_version: Override the pinned Phpactor PHAR version downloaded by
           Serena (default: the bundled Serena version)
+        - file_filter: list of additional file extensions (with leading dot) to treat as PHP
+          sources, e.g. [".module", ".inc"]
     """
 
     @override
@@ -115,6 +117,11 @@ class PhpactorServer(SolidLanguageServer):
             self._ignored_dirnames.add("vendor")
         log.info(f"Ignoring the following directories for PHP (Phpactor): {', '.join(sorted(self._ignored_dirnames))}")
 
+        # extending Serena's source matcher with project-specific PHP extensions
+        file_filter = self._custom_settings.get("file_filter")
+        if file_filter:
+            self.ls_id.get_source_fn_matcher().add_extensions(*file_filter)
+
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
         return self.DependencyProvider(self._custom_settings, self._ls_resources_dir)
 
@@ -122,6 +129,8 @@ class PhpactorServer(SolidLanguageServer):
         """
         Returns the initialization params for the Phpactor Language Server.
         """
+        file_filter = self._custom_settings.get("file_filter", [])
+        supported_extensions = ["php", "phar", *(extension.removeprefix(".") for extension in file_filter)]
         initialize_params = {
             "capabilities": {
                 "textDocument": {
@@ -141,6 +150,8 @@ class PhpactorServer(SolidLanguageServer):
                 "language_server_phpstan.enabled": False,
                 "language_server_psalm.enabled": False,
                 "language_server_php_cs_fixer.enabled": False,
+                "indexer.supported_extensions": supported_extensions,
+                "indexer.include_patterns": [f"/**/*.{extension}" for extension in supported_extensions],
             },
         }
         return initialize_params

--- a/src/solidlsp/language_servers/phpactor.py
+++ b/src/solidlsp/language_servers/phpactor.py
@@ -129,8 +129,6 @@ class PhpactorServer(SolidLanguageServer):
         """
         Returns the initialization params for the Phpactor Language Server.
         """
-        file_filter = self._custom_settings.get("file_filter", [])
-        supported_extensions = ["php", "phar", *(extension.removeprefix(".") for extension in file_filter)]
         initialize_params = {
             "capabilities": {
                 "textDocument": {
@@ -150,8 +148,6 @@ class PhpactorServer(SolidLanguageServer):
                 "language_server_phpstan.enabled": False,
                 "language_server_psalm.enabled": False,
                 "language_server_php_cs_fixer.enabled": False,
-                "indexer.supported_extensions": supported_extensions,
-                "indexer.include_patterns": [f"/**/*.{extension}" for extension in supported_extensions],
             },
         }
         return initialize_params

--- a/src/solidlsp/language_servers/phpantom.py
+++ b/src/solidlsp/language_servers/phpantom.py
@@ -122,6 +122,8 @@ class PHPantomServer(SolidLanguageServer):
         - ls_path: path to a pre-installed phpantom_lsp binary
         - phpantom_version: override the pinned PHPantom version downloaded by Serena
         - ignore_vendor: whether to ignore directories named "vendor" (default: true)
+        - file_filter: list of additional file extensions (with leading dot) to treat as PHP
+          sources, e.g. [".module", ".inc"]
     """
 
     @override
@@ -169,6 +171,11 @@ class PHPantomServer(SolidLanguageServer):
         if self._custom_settings.get("ignore_vendor", True):
             self._ignored_dirnames.add("vendor")
         log.info(f"Ignoring the following directories for PHP (PHPantom): {', '.join(sorted(self._ignored_dirnames))}")
+
+        # extending Serena's source matcher with project-specific PHP extensions
+        file_filter = self._custom_settings.get("file_filter")
+        if file_filter:
+            self.ls_id.get_source_fn_matcher().add_extensions(*file_filter)
 
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
         return self.DependencyProvider(self._custom_settings, self._ls_resources_dir)

--- a/src/solidlsp/language_servers/phpantom.py
+++ b/src/solidlsp/language_servers/phpantom.py
@@ -123,7 +123,10 @@ class PHPantomServer(SolidLanguageServer):
         - phpantom_version: override the pinned PHPantom version downloaded by Serena
         - ignore_vendor: whether to ignore directories named "vendor" (default: true)
         - file_filter: list of additional file extensions (with leading dot) to treat as PHP
-          sources, e.g. [".module", ".inc"]
+          sources, e.g. [".module", ".inc"]. Note that PHPantom's own workspace scan covers
+          ``.php`` only and offers no setting to widen it (its configuration schema exposes
+          ``indexing.strategy`` as the sole indexing knob), so symbols in the added extensions
+          become referenceable once Serena's traversal has opened the respective files.
     """
 
     @override

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -343,6 +343,15 @@ def _is_perl_language_server_available() -> bool:
         return False
 
 
+def _php_has_openssl() -> bool:
+    """Whether the PHP installation has the openssl extension Phpactor's PHAR download needs."""
+    try:
+        completed_process = subprocess.run(["php", "-m"], capture_output=True, text=True, timeout=30, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "openssl" in {line.strip().lower() for line in completed_process.stdout.splitlines()}
+
+
 def _is_matlab_available() -> bool:
     """Whether a MATLAB installation can be located (env var or a known install path)."""
     if os.environ.get("MATLAB_PATH") is not None:
@@ -457,6 +466,11 @@ def _determine_disabled_language_servers() -> list[LanguageServerId]:
     if _sh.which("php") is None:
         result.append(LanguageServerId.PHP_PHPACTOR)
         result.append(LanguageServerId.PHP_PHPANTOM)
+    elif not _php_has_openssl() or (is_windows and is_ci):
+        # Phpactor downloads its PHAR over HTTPS, which requires PHP's openssl extension, and on
+        # the Windows CI runners its initial workspace index is too slow to answer the cross-file
+        # queries the tests make.
+        result.append(LanguageServerId.PHP_PHPACTOR)
     if not is_clojure_cli_available():
         result.append(LanguageServerId.CLOJURE)
     if _sh.which("verible-verilog-ls") is None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -467,9 +467,10 @@ def _determine_disabled_language_servers() -> list[LanguageServerId]:
         result.append(LanguageServerId.PHP_PHPACTOR)
         result.append(LanguageServerId.PHP_PHPANTOM)
     elif not _php_has_openssl() or (is_windows and is_ci):
-        # Phpactor downloads its PHAR over HTTPS, which requires PHP's openssl extension, and on
-        # the Windows CI runners its initial workspace index is too slow to answer the cross-file
-        # queries the tests make.
+        # Phpactor downloads its PHAR over HTTPS, which requires PHP's openssl extension. And on
+        # the Windows runners its workspace indexer announces "Indexing workspace" and then makes
+        # no progress at all (measured: empty index 600s in, ~9s elsewhere), so every cross-file
+        # query there returns nothing.
         result.append(LanguageServerId.PHP_PHPACTOR)
     if not is_clojure_cli_available():
         result.append(LanguageServerId.CLOJURE)

--- a/test/solidlsp/php/test_php_basic.py
+++ b/test/solidlsp/php/test_php_basic.py
@@ -1,24 +1,15 @@
-import subprocess
 from pathlib import Path
 
 import pytest
 
 from solidlsp import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerId
-from test.conftest import is_ci, is_windows, language_server_tests_enabled
+from test.conftest import language_server_tests_enabled
 from test.solidlsp.conftest import format_symbol_for_assert, has_malformed_name, request_all_symbols
-
-
-def _php_supports_phpactor() -> bool:
-    completed_process = subprocess.run(["php", "-m"], capture_output=True, text=True, check=False)
-    installed_extensions = {line.strip().lower() for line in completed_process.stdout.splitlines()}
-    return "openssl" in installed_extensions
-
 
 _php_servers: list[LanguageServerId] = [LanguageServerId.PHP]
 if language_server_tests_enabled(LanguageServerId.PHP_PHPACTOR):
-    if not (is_windows and is_ci) and _php_supports_phpactor():
-        _php_servers.append(LanguageServerId.PHP_PHPACTOR)
+    _php_servers.append(LanguageServerId.PHP_PHPACTOR)
 if language_server_tests_enabled(LanguageServerId.PHP_PHPANTOM):
     _php_servers.append(LanguageServerId.PHP_PHPANTOM)
 

--- a/test/solidlsp/php/test_php_config.py
+++ b/test/solidlsp/php/test_php_config.py
@@ -15,7 +15,7 @@ import pytest
 
 from solidlsp.ls_config import FilenameMatcher, LanguageServerId
 from solidlsp.ls_utils import SymbolUtils
-from test.conftest import get_repo_path, start_ls_context
+from test.conftest import get_pytest_markers, get_repo_path, start_ls_context
 
 
 class TestPhpSourceFnMatcherDefaults:
@@ -74,7 +74,21 @@ class TestFileFilterIntegration:
                 "DrupalModuleController from drupal_module.module not found in the symbol tree"
             )
 
-    @pytest.mark.parametrize("language_server_id", [LanguageServerId.PHP_PHPACTOR, LanguageServerId.PHP_PHPANTOM])
+    @pytest.mark.parametrize(
+        "language_server_id",
+        [
+            pytest.param(
+                LanguageServerId.PHP_PHPACTOR,
+                marks=get_pytest_markers(LanguageServerId.PHP_PHPACTOR),
+                id="phpactor",
+            ),
+            pytest.param(
+                LanguageServerId.PHP_PHPANTOM,
+                marks=get_pytest_markers(LanguageServerId.PHP_PHPANTOM),
+                id="phpantom",
+            ),
+        ],
+    )
     def test_alternative_php_server_file_filter_makes_module_symbols_visible(self, language_server_id: LanguageServerId) -> None:
         with start_ls_context(
             language_server_id,

--- a/test/solidlsp/php/test_php_config.py
+++ b/test/solidlsp/php/test_php_config.py
@@ -75,7 +75,7 @@ class TestFileFilterIntegration:
             )
 
     @pytest.mark.parametrize("language_server_id", [LanguageServerId.PHP_PHPACTOR, LanguageServerId.PHP_PHPANTOM])
-    def test_alternative_php_server_file_filter_makes_module_visible(self, language_server_id: LanguageServerId) -> None:
+    def test_alternative_php_server_file_filter_makes_module_symbols_visible(self, language_server_id: LanguageServerId) -> None:
         with start_ls_context(
             language_server_id,
             ls_specific_settings={language_server_id: {"file_filter": [".module"]}},
@@ -83,6 +83,12 @@ class TestFileFilterIntegration:
             symbols = ls.request_full_symbol_tree()
             assert SymbolUtils.symbol_tree_contains_name(symbols, "drupal_module_help")
 
-            helper_php_path = str(get_repo_path(language_server_id) / "helper.php")
+    def test_phpantom_file_filter_makes_module_references_visible(self) -> None:
+        with start_ls_context(
+            LanguageServerId.PHP_PHPANTOM,
+            ls_specific_settings={LanguageServerId.PHP_PHPANTOM: {"file_filter": [".module"]}},
+        ) as ls:
+            ls.request_full_symbol_tree()
+            helper_php_path = str(get_repo_path(LanguageServerId.PHP_PHPANTOM) / "helper.php")
             references = ls.request_references(helper_php_path, 2, len("function "))
             assert any(ref["uri"].endswith("drupal_module.module") for ref in references)

--- a/test/solidlsp/php/test_php_config.py
+++ b/test/solidlsp/php/test_php_config.py
@@ -15,7 +15,7 @@ import pytest
 
 from solidlsp.ls_config import FilenameMatcher, LanguageServerId
 from solidlsp.ls_utils import SymbolUtils
-from test.conftest import get_pytest_markers, get_repo_path, start_ls_context
+from test.conftest import get_pytest_markers, get_repo_path, language_server_tests_enabled, start_ls_context
 
 
 class TestPhpSourceFnMatcherDefaults:
@@ -46,8 +46,8 @@ class TestPhpSourceFnMatcherDefaults:
 class TestFileFilterIntegration:
     """End-to-end check that a custom ``file_filter`` makes a Drupal-style file visible.
 
-    Starts a real Intelephense, hence gated by the ``php`` marker. The ``drupal_module.module``
-    fixture stays invisible to every test that runs with default settings.
+    Starts real language server processes, hence gated by the ``php`` marker. The
+    ``drupal_module.module`` fixture stays invisible to every test that runs with default settings.
     """
 
     def test_module_file_symbols_and_references_visible(self) -> None:
@@ -97,12 +97,39 @@ class TestFileFilterIntegration:
             symbols = ls.request_full_symbol_tree()
             assert SymbolUtils.symbol_tree_contains_name(symbols, "drupal_module_help")
 
+    @pytest.mark.skipif(
+        not language_server_tests_enabled(LanguageServerId.PHP_PHPACTOR),
+        reason=f"{LanguageServerId.PHP_PHPACTOR.value} tests are disabled in this environment",
+    )
+    def test_phpactor_file_filter_makes_module_references_visible(self) -> None:
+        with start_ls_context(
+            LanguageServerId.PHP_PHPACTOR,
+            ls_specific_settings={LanguageServerId.PHP_PHPACTOR: {"file_filter": [".module"]}},
+        ) as ls:
+            # no traversal beforehand: drupal_module.module is never opened, so this reference can
+            # only come from Phpactor's own index -- i.e. from the indexer extensions pushed in
+            # PhpactorServer._create_base_initialize_params.
+            helper_php_path = str(get_repo_path(LanguageServerId.PHP_PHPACTOR) / "helper.php")
+            references = ls.request_references(helper_php_path, 2, len("function "))
+            assert any(ref["uri"].endswith("drupal_module.module") for ref in references), (
+                f"helperFunction call in drupal_module.module not found in references: {references}"
+            )
+
+    @pytest.mark.skipif(
+        not language_server_tests_enabled(LanguageServerId.PHP_PHPANTOM),
+        reason=f"{LanguageServerId.PHP_PHPANTOM.value} tests are disabled in this environment",
+    )
     def test_phpantom_file_filter_makes_module_references_visible(self) -> None:
         with start_ls_context(
             LanguageServerId.PHP_PHPANTOM,
             ls_specific_settings={LanguageServerId.PHP_PHPANTOM: {"file_filter": [".module"]}},
         ) as ls:
+            # PHPantom's workspace scan covers .php only and exposes no setting to widen it
+            # (see PHPantomServer's class docstring), so the traversal below -- which didOpens every
+            # file the matcher accepts -- is what gets drupal_module.module into its index.
             ls.request_full_symbol_tree()
             helper_php_path = str(get_repo_path(LanguageServerId.PHP_PHPANTOM) / "helper.php")
             references = ls.request_references(helper_php_path, 2, len("function "))
-            assert any(ref["uri"].endswith("drupal_module.module") for ref in references)
+            assert any(ref["uri"].endswith("drupal_module.module") for ref in references), (
+                f"helperFunction call in drupal_module.module not found in references: {references}"
+            )

--- a/test/solidlsp/php/test_php_config.py
+++ b/test/solidlsp/php/test_php_config.py
@@ -1,16 +1,14 @@
-"""Configuration plumbing for ``Intelephense``'s ``file_filter``.
+"""Configuration plumbing for PHP language-server ``file_filter`` settings.
 
 Serena treats only ``.php`` / ``.phtml`` files as PHP sources by default, while Drupal projects
 keep ordinary PHP in ``.module`` / ``.install`` / ``.inc`` / ``.theme`` / ``.profile`` /
 ``.engine`` files, which therefore stay invisible to ``find_symbol`` and friends.
-``ls_specific_settings["php"]`` accepts a ``file_filter`` key with additional extensions,
+Each PHP backend accepts a ``file_filter`` key in its ``ls_specific_settings`` entry,
 mirroring the Perl mechanism from #1449 / #1642 (see #1710).
 
-The unit tests cover the default source-file matcher. The configuration plumbing itself lives
-inline in ``Intelephense.__init__`` (matcher sync) and ``_start_server`` (the
-``intelephense.files.associations`` push) and is exercised end-to-end by the integration test
-at the bottom, which starts a real Intelephense and is gated by the ``php`` marker like the
-rest of the PHP suite.
+The unit tests cover the default source-file matcher. The integration tests exercise matcher
+and server-index configuration through real Intelephense, Phpactor, and PHPantom processes;
+they are gated by the ``php`` marker like the rest of the PHP suite.
 """
 
 import pytest
@@ -75,3 +73,16 @@ class TestFileFilterIntegration:
             assert SymbolUtils.symbol_tree_contains_name(symbols, "DrupalModuleController"), (
                 "DrupalModuleController from drupal_module.module not found in the symbol tree"
             )
+
+    @pytest.mark.parametrize("language_server_id", [LanguageServerId.PHP_PHPACTOR, LanguageServerId.PHP_PHPANTOM])
+    def test_alternative_php_server_file_filter_makes_module_visible(self, language_server_id: LanguageServerId) -> None:
+        with start_ls_context(
+            language_server_id,
+            ls_specific_settings={language_server_id: {"file_filter": [".module"]}},
+        ) as ls:
+            symbols = ls.request_full_symbol_tree()
+            assert SymbolUtils.symbol_tree_contains_name(symbols, "drupal_module_help")
+
+            helper_php_path = str(get_repo_path(language_server_id) / "helper.php")
+            references = ls.request_references(helper_php_path, 2, len("function "))
+            assert any(ref["uri"].endswith("drupal_module.module") for ref in references)

--- a/test/solidlsp/php/test_phpactor.py
+++ b/test/solidlsp/php/test_phpactor.py
@@ -1,0 +1,29 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from solidlsp.ls_config import LanguageServerId
+from test.conftest import get_repo_path, language_server_tests_enabled, start_ls_context
+
+
+@pytest.mark.php
+@pytest.mark.skipif(
+    not language_server_tests_enabled(LanguageServerId.PHP_PHPACTOR),
+    reason=f"{LanguageServerId.PHP_PHPACTOR.value} tests are disabled in this environment",
+)
+class TestPhpactorIndexPath:
+    def test_references_in_project_path_with_percent_signs(self, tmp_path: Path) -> None:
+        """Phpactor must remain usable for projects whose path looks like one of its own placeholders.
+
+        Phpactor expands ``%token%`` pairs in path settings and terminates during ``initialize`` on
+        tokens it does not know, so Serena must not hand it such a path as ``indexer.index_path``.
+        """
+        repo_path = tmp_path / "pct%weird%dir" / "test_repo"
+        shutil.copytree(get_repo_path(LanguageServerId.PHP_PHPACTOR), repo_path)
+
+        with start_ls_context(LanguageServerId.PHP_PHPACTOR, repo_path=str(repo_path)) as ls:
+            references = ls.request_references(str(repo_path / "helper.php"), 2, len("function "))
+            assert any(ref["uri"].endswith("index.php") for ref in references), (
+                f"helperFunction calls in index.php not found in references: {references}"
+            )

--- a/test/solidlsp/php/test_phpantom.py
+++ b/test/solidlsp/php/test_phpantom.py
@@ -6,7 +6,6 @@ import pytest
 from serena.code_editor import LanguageServerCodeEditor
 from solidlsp import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerId
-from solidlsp.ls_utils import SymbolUtils
 from src.serena.symbol import LanguageServerSymbolRetriever
 from test.conftest import project_with_ls_context, start_ls_context
 
@@ -127,52 +126,6 @@ def _find_child_symbol(parent_symbol: dict, child_name: str) -> dict:
 
 @pytest.mark.php
 class TestPHPantom:
-    def test_file_filter_makes_inc_symbols_and_references_visible(self, tmp_path: Path) -> None:
-        repo_path = tmp_path / "test_repo"
-        src_dir = repo_path / "src"
-        src_dir.mkdir(parents=True)
-        (repo_path / "composer.json").write_text('{"autoload": {"files": ["src/helpers.inc"]}}\n', encoding="utf-8")
-        (src_dir / "helpers.inc").write_text(
-            """<?php
-namespace Demo;
-
-function inc_helper(string $value): string
-{
-    return strtoupper($value);
-}
-
-function inc_caller(): string
-{
-    return inc_helper('inside');
-}
-""",
-            encoding="utf-8",
-        )
-        (src_dir / "UseHelper.php").write_text(
-            """<?php
-namespace Demo;
-
-function use_helper(): string
-{
-    return inc_helper('outside');
-}
-""",
-            encoding="utf-8",
-        )
-
-        with start_ls_context(
-            LanguageServerId.PHP_PHPANTOM,
-            repo_path=str(repo_path),
-            solidlsp_dir=tmp_path,
-            ls_specific_settings={LanguageServerId.PHP_PHPANTOM: {"file_filter": [".inc"]}},
-        ) as language_server:
-            symbols = language_server.request_full_symbol_tree()
-            assert SymbolUtils.symbol_tree_contains_name(symbols, "inc_helper")
-
-            references = language_server.request_references("src/helpers.inc", 3, len("function "))
-            assert any(reference["uri"].endswith("helpers.inc") for reference in references)
-            assert any(reference["uri"].endswith("UseHelper.php") for reference in references)
-
     @pytest.mark.parametrize("language_server", [LanguageServerId.PHP_PHPANTOM], indirect=True)
     @pytest.mark.parametrize("repo_path", [LanguageServerId.PHP], indirect=True)
     def test_rename_local_variable(self, language_server: SolidLanguageServer, repo_path: Path) -> None:

--- a/test/solidlsp/php/test_phpantom.py
+++ b/test/solidlsp/php/test_phpantom.py
@@ -6,6 +6,7 @@ import pytest
 from serena.code_editor import LanguageServerCodeEditor
 from solidlsp import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerId
+from solidlsp.ls_utils import SymbolUtils
 from src.serena.symbol import LanguageServerSymbolRetriever
 from test.conftest import project_with_ls_context, start_ls_context
 
@@ -126,6 +127,52 @@ def _find_child_symbol(parent_symbol: dict, child_name: str) -> dict:
 
 @pytest.mark.php
 class TestPHPantom:
+    def test_file_filter_makes_inc_symbols_and_references_visible(self, tmp_path: Path) -> None:
+        repo_path = tmp_path / "test_repo"
+        src_dir = repo_path / "src"
+        src_dir.mkdir(parents=True)
+        (repo_path / "composer.json").write_text('{"autoload": {"files": ["src/helpers.inc"]}}\n', encoding="utf-8")
+        (src_dir / "helpers.inc").write_text(
+            """<?php
+namespace Demo;
+
+function inc_helper(string $value): string
+{
+    return strtoupper($value);
+}
+
+function inc_caller(): string
+{
+    return inc_helper('inside');
+}
+""",
+            encoding="utf-8",
+        )
+        (src_dir / "UseHelper.php").write_text(
+            """<?php
+namespace Demo;
+
+function use_helper(): string
+{
+    return inc_helper('outside');
+}
+""",
+            encoding="utf-8",
+        )
+
+        with start_ls_context(
+            LanguageServerId.PHP_PHPANTOM,
+            repo_path=str(repo_path),
+            solidlsp_dir=tmp_path,
+            ls_specific_settings={LanguageServerId.PHP_PHPANTOM: {"file_filter": [".inc"]}},
+        ) as language_server:
+            symbols = language_server.request_full_symbol_tree()
+            assert SymbolUtils.symbol_tree_contains_name(symbols, "inc_helper")
+
+            references = language_server.request_references("src/helpers.inc", 3, len("function "))
+            assert any(reference["uri"].endswith("helpers.inc") for reference in references)
+            assert any(reference["uri"].endswith("UseHelper.php") for reference in references)
+
     @pytest.mark.parametrize("language_server", [LanguageServerId.PHP_PHPANTOM], indirect=True)
     @pytest.mark.parametrize("repo_path", [LanguageServerId.PHP], indirect=True)
     def test_rename_local_variable(self, language_server: SolidLanguageServer, repo_path: Path) -> None:


### PR DESCRIPTION
## Summary

Make the alternative PHP backends honor their `ls_specific_settings.*.file_filter`, so that project-specific PHP extensions (Drupal's `.module`, `.inc`, `.theme`, …) take part in symbol queries as they already do for Intelephense.

- PHPantom and Phpactor extend Serena's source-file matcher from `file_filter`, so `is_ignored_path` stops hiding those files from the traversal behind `find_symbol`.
- Phpactor additionally receives the extensions as `indexer.include_patterns` / `indexer.supported_extensions`, without which its index — and therefore `find_referencing_symbols` — never sees them.
- PHPantom has no equivalent setting; its class docstring now states that its `.module` references depend on Serena's traversal having opened the file.

Review of the first version asked whether the alternative backends index the added extensions unprompted. They do not, and answering that turned up three further defects in Phpactor's path, all fixed here:

- **The first cross-file query raced Phpactor's own index.** Phpactor answers references from its index and reconciles the open documents with it first, so a query before the initial index existed returned nothing, and its dirty-document tracker raised `Dirty index file path ... cannot be created` when the index directory was still absent. Serena now declares `window.workDoneProgress`, tracks the `Indexing workspace` progress and waits for it before the first cross-file query, bounded by the new `indexing_timeout` / `indexing_start_grace` settings — the same pattern as Metals and tsserver.
- **Widening `file_filter` did not reindex.** Phpactor's indexer skips files older than the index, so adding `.module` to an already indexed project left those files out of it indefinitely. The index now lives in the project's cache directory with the indexed extensions in the directory name, so a changed `file_filter` gets a fresh index.
- **A project path containing `%…%` killed the server.** Phpactor expands `%token%` pairs in path settings and aborts during `initialize` on tokens it does not know, so Serena leaves the new index-path setting alone for such paths. Covered by `test_phpactor.py`.

`test_php_basic.py` already excluded Phpactor on Windows CI and without PHP's openssl extension. Both preconditions moved into `_determine_disabled_language_servers`, which the module docstring names as the single place for availability rules, so every Phpactor test observes them instead of only the parametrized ones.

## Phpactor on Windows

Measured on the Windows CI runners with a temporary diagnostic (traced `$/progress`, `indexing_timeout: 600`): Phpactor announces `Indexing workspace` at t=1.5s and then makes no progress at all — no progress report, no end, and an index directory holding nothing but the `dirty` file after 600s. The reference query itself completes in 10ms against that empty index. The same workspace is indexed in ~9s on macOS (`report 500/537` at t=8.8s, 15,479 index files, references resolved).

So Phpactor's cross-file queries do not work on Windows regardless of how long Serena waits; symbol queries, which never touch the index, are unaffected. That is recorded on `PhpactorServer` with a recommendation to prefer Intelephense or PHPantom there, and it is the reason the Phpactor tests stay gated off Windows CI. The cause lies inside Phpactor (progress starts, its indexing generator never advances) and is not addressed here.

## Verification

- `uv run poe lint`, `uv run poe type-check`
- `pytest test/solidlsp/php -m php` — 43 passed, on a cold and on a warm index
- The two regressions above reproduced before the fix and re-checked after: warming the index php-only and then querying `.module` references (failed, now passes), and starting Phpactor in a path containing `%…%` (server terminated during `initialize`, now passes; the test fails again if the guard is removed)
- CI green on `2816a85` across all six batches on Linux/macOS/Windows; the run for the comment-only `6b0498e` was cancelled and needs a maintainer rerun
