### PR TITLE
fix(mcp): report Serena version in initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Status of the `main` branch. Changes prior to the next official version change will appear here.
 
 * General:
+  - Fix: MCP `initialize` now reports Serena's version instead of the installed mcp SDK version (#1889)
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
 

--- a/src/serena/mcp.py
+++ b/src/serena/mcp.py
@@ -20,6 +20,7 @@ from mcp.types import ToolAnnotations
 from pydantic_settings import SettingsConfigDict
 from sensai.util import logging
 
+from serena import __version__
 from serena.agent import (
     SerenaAgent,
 )
@@ -390,6 +391,9 @@ class SerenaMCPFactory:
             port=port,
             instructions=instructions,
         )
+        # FastMCP currently falls back to the installed mcp SDK version when no version is set.
+        # Set the low-level server value explicitly so MCP clients identify Serena correctly.
+        mcp._mcp_server.version = __version__
         return mcp
 
     @asynccontextmanager

--- a/test/serena/test_mcp.py
+++ b/test/serena/test_mcp.py
@@ -3,8 +3,10 @@
 import pytest
 from mcp.server.fastmcp.tools.base import Tool as MCPTool
 
+from serena import __version__
 from serena.agent import Tool, ToolRegistry
 from serena.config.context_mode import SerenaAgentContext
+from serena.config.serena_config import SerenaConfig
 from serena.mcp import SerenaMCPFactory
 
 make_tool = SerenaMCPFactory.make_mcp_tool
@@ -48,6 +50,24 @@ class BasicTool(BaseMockTool):
     ) -> str:
         """Mock implementation of apply_ex."""
         return self.apply(**kwargs)
+
+
+def test_create_mcp_server_reports_serena_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MCP initialize must report Serena's version, not the installed mcp SDK version."""
+
+    class MinimalAgent:
+        def create_connection_prompt(self) -> str:
+            return ""
+
+    monkeypatch.setattr(SerenaConfig, "from_config_file", classmethod(lambda cls: SerenaConfig()))
+    factory = SerenaMCPFactory(transport="stdio")
+    monkeypatch.setattr(factory, "_create_serena_agent", lambda *args, **kwargs: MinimalAgent())
+
+    mcp_server = factory.create_mcp_server()
+    initialization_options = mcp_server._mcp_server.create_initialization_options()
+
+    assert initialization_options.server_name == "Serena"
+    assert initialization_options.server_version == __version__
 
 
 def test_make_tool_basic() -> None:


### PR DESCRIPTION
Fixes #1889

MCP initialize currently reports the installed mcp SDK version as `serverInfo.version`. Set the low-level MCP server version explicitly to Serena's package version so clients identify the correct server version.

Added a regression test covering the MCP initialization options and updated the changelog.

Validation:
- uv run pytest test/serena/test_mcp.py -q
- uv run poe lint
- uv run poe type-check
