### PR TITLE
fix(nextflow): retry failed workspace scan flushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     project list in `serena_config.yml`
 
 * Language Servers:
+  - Fix: Nextflow workspace scans were marked flushed even when both flush requests failed, preventing
+    later reference queries from retrying (#1871)
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate

--- a/src/solidlsp/language_servers/nextflow_language_server.py
+++ b/src/solidlsp/language_servers/nextflow_language_server.py
@@ -320,12 +320,16 @@ class NextflowLanguageServer(SolidLanguageServer):
             "textDocument": {"uri": self._resolve_file_uri(relative_file_path)},
             "position": {"line": 0, "character": 0},
         }
+        flushed = False
         for _ in range(2):
             try:
                 self.server.send.completion(params)
+                flushed = True
             except Exception as e:
                 log.debug("Completion request used to flush the Nextflow workspace scan failed: %s", e)
-        self._workspace_scan_flushed = True
+        self._workspace_scan_flushed = flushed
+        if not flushed:
+            log.warning("Could not flush the Nextflow workspace scan after two completion requests; will retry later")
 
     @override
     def _send_references_request(self, relative_file_path: str, line: int, column: int) -> list[lsp_types.Location] | None:

--- a/test/solidlsp/nextflow/test_nextflow_scan_flush.py
+++ b/test/solidlsp/nextflow/test_nextflow_scan_flush.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from solidlsp.language_servers.nextflow_language_server import NextflowLanguageServer
+
+
+def _make_server(completion_side_effect=None) -> tuple[NextflowLanguageServer, Mock]:
+    server = object.__new__(NextflowLanguageServer)
+    server._workspace_scan_flushed = False
+    server._resolve_file_uri = lambda relative_path: f"file:///{relative_path}"
+    completion = Mock(side_effect=completion_side_effect)
+    server.server = SimpleNamespace(send=SimpleNamespace(completion=completion))
+    return server, completion
+
+
+def test_flush_failure_does_not_mark_scan_as_flushed() -> None:
+    server, completion = _make_server(RuntimeError("server is still starting"))
+
+    server._flush_deferred_workspace_scan("main.nf")
+
+    assert completion.call_count == 2
+    assert server._workspace_scan_flushed is False
+
+
+def test_flush_retries_after_previous_failure() -> None:
+    server, completion = _make_server(RuntimeError("server is still starting"))
+
+    server._flush_deferred_workspace_scan("main.nf")
+    server._flush_deferred_workspace_scan("main.nf")
+
+    assert completion.call_count == 4
+    assert server._workspace_scan_flushed is False
+
+
+def test_one_successful_flush_marks_scan_as_flushed() -> None:
+    server, completion = _make_server([RuntimeError("temporary failure"), {}])
+
+    server._flush_deferred_workspace_scan("main.nf")
+    server._flush_deferred_workspace_scan("main.nf")
+
+    assert completion.call_count == 2
+    assert server._workspace_scan_flushed is True


### PR DESCRIPTION
Fixes #1871

Nextflow marked its deferred workspace scan as flushed even when both synchronous completion requests failed. Subsequent reference queries therefore skipped every retry and could use an incomplete AST cache. Mark the scan flushed only after at least one request succeeds, retain retry behavior after total failure, and log the non-success.

Added deterministic regression tests for all-fail retry and partial success.

Validation:
- `uv run pytest test/solidlsp/nextflow/test_nextflow_scan_flush.py test/solidlsp/nextflow/test_nextflow_basic.py -q`
- `ruff format --check src scripts test`
- `ruff check src scripts test`
- `ty check src/serena src/solidlsp`
- `ty check test --exclude test/resources`