### PR TITLE
fix(hooks): emit Codex cleanup JSON response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Status of the `main` branch. Changes prior to the next official version change w
     independently via the `window/logMessage` notification tsserver already sends, and the
     affected wait now raises instead of reporting success (#1814)
 
+* CLI:
+  - Fix: Codex cleanup hooks now always emit a valid non-blocking Stop-hook JSON response, including
+    when the session input is incomplete (#1533)
+
 * Dependencies:
   - Remove the redundant `dotenv` dependency; the `dotenv` module is provided by `python-dotenv`
 

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -370,10 +370,11 @@ Then create `~/.codex/hooks.json` with the following content:
 ```
 
 The `SessionEnd` cleanup hook requires Codex 0.145.0 or newer. Older Codex versions only support
-`Stop` for cleanup, which currently has a [known compatibility issue](https://github.com/oraios/serena/issues/1533).
-If you still configure it, replace `SessionEnd` with `Stop` in the example above. Configure cleanup
-under exactly one of these events, never both: `Stop` runs after every turn, while `SessionEnd` runs
-when Codex tears down the root thread.
+`Stop` for cleanup. `serena-hooks cleanup --client=codex` emits a valid non-blocking
+`{"continue":true}` response on stdout for either event; cleanup diagnostics are written to stderr.
+If you use an older Codex version, replace `SessionEnd` with `Stop` in the example above. Configure
+cleanup under exactly one of these events, never both: `Stop` runs after every turn, while `SessionEnd`
+runs when Codex tears down the root thread.
 
 The hooks will:
 

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -609,7 +609,17 @@ class HookCommands(AutoRegisteringGroup):
     @click.command("cleanup", help="Set this as hook at session end all hook data for the current session")
     @_client_option
     def cleanup(client: str) -> None:
-        SessionEndCleanupHook(HookClient(client)).execute()
+        hook_client = HookClient(client)
+        if hook_client == HookClient.CODEX:
+            try:
+                SessionEndCleanupHook(hook_client).execute()
+            except Exception as exc:
+                # Codex parses every byte on stdout as Stop-hook JSON. Keep cleanup failures
+                # diagnostic-only and still return the non-blocking, valid response.
+                click.echo(f"serena-hooks cleanup failed: {exc}", err=True)
+            click.echo(json.dumps({"continue": True}, separators=(",", ":")))
+            return
+        SessionEndCleanupHook(hook_client).execute()
 
     @staticmethod
     @click.command(

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -980,6 +980,37 @@ class TestHookCli:
         assert result.exit_code == 0
         assert not session_dir.exists()
 
+    def test_cleanup_command_codex_emits_stop_json(self, tmp_path: Path):
+        session_id = "cli-codex-cleanup"
+        session_dir = tmp_path / "hook_data" / session_id
+        session_dir.mkdir(parents=True)
+        (session_dir / "somefile").write_text("data")
+
+        runner = CliRunner()
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            result = runner.invoke(
+                hook_commands,
+                ["cleanup", "--client", "codex"],
+                input=json.dumps({"session_id": session_id, "stop_hook_active": False}),
+            )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"continue": True}
+        assert not session_dir.exists()
+
+    def test_cleanup_command_codex_handles_missing_session_id(self, tmp_path: Path):
+        runner = CliRunner()
+        with patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            result = runner.invoke(
+                hook_commands,
+                ["cleanup", "--client", "codex"],
+                input=json.dumps({"stop_hook_active": False}),
+            )
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {"continue": True}
+        assert "Session ID is required" in result.stderr
+
     def test_remind_command(self, tmp_path: Path):
         """Invoke the remind command enough times to trigger a deny."""
         runner = CliRunner()


### PR DESCRIPTION
Fixes #1533

Codex Stop hooks require valid JSON on stdout, but `serena-hooks cleanup --client=codex` previously emitted empty stdout on normal input and a traceback when `session_id` was missing. Codex cleanup now always emits the non-blocking `{"continue":true}` response on stdout; cleanup diagnostics remain on stderr, and other clients retain their existing behavior.

Added CLI regression tests for normal and incomplete Codex hook input and documented the contract.

Validation:
- `uv run pytest test/serena/test_hooks.py -q`
- `ruff format --check src scripts test`
- `ruff check src scripts test`
- `ty check src/serena src/solidlsp`
- `ty check test --exclude test/resources`
- `uv run poe doc-build`