### PR TITLE
feat(hooks): support ZCode client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: Parallel agents auto-registering projects could overwrite each other's changes to the global
     project list in `serena_config.yml`
 
+* Hooks:
+  - Add ZCode (`zcode`) as a supported hooks client, with documented user-level configuration for
+    activation, symbolic-tool reminders, cleanup, and auto-approval (#1837)
+
 * Language Servers:
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made

--- a/docs/02-usage/030_clients.md
+++ b/docs/02-usage/030_clients.md
@@ -700,6 +700,77 @@ CodeBuddy supports the same hook system as Claude Code. To set up hooks, add the
   permission mode (`acceptEdits` or `auto`), so blanket approvals cover Serena's destructive
   tools (e.g. `replace_symbol_body`, `rename_symbol`) instead of prompting on every call.
 
+## ZCode
+
+[ZCode](https://zcode.z.ai/en) supports Serena through its MCP configuration and local process hooks.
+Connect Serena using the MCP configuration documented by ZCode; the hook commands below are independent
+of whether Serena is connected through HTTP or another supported MCP transport.
+
+### Hooks
+
+ZCode reads user-level hooks from `~/.zcode/cli/config.json`. Add the following under `hooks` and
+start a new ZCode session after changing the file:
+
+```json
+{
+  "hooks": {
+    "enabled": true,
+    "events": {
+      "SessionStart": [
+        {
+          "matcher": "startup|clear|compact",
+          "hooks": [
+            {
+              "type": "process",
+              "command": "serena-hooks",
+              "args": ["activate", "--client", "zcode"]
+            }
+          ]
+        }
+      ],
+      "PreToolUse": [
+        {
+          "matcher": "Read|Bash",
+          "hooks": [
+            {
+              "type": "process",
+              "command": "serena-hooks",
+              "args": ["remind", "--client", "zcode"]
+            }
+          ]
+        },
+        {
+          "matcher": "mcp__serena__*",
+          "hooks": [
+            {
+              "type": "process",
+              "command": "serena-hooks",
+              "args": ["auto-approve", "--client", "zcode"]
+            }
+          ]
+        }
+      ],
+      "Stop": [
+        {
+          "hooks": [
+            {
+              "type": "process",
+              "command": "serena-hooks",
+              "args": ["cleanup", "--client", "zcode"]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+ZCode sends one JSON line to each process hook and accepts Serena's `hookSpecificOutput` format,
+so the existing `activate`, `remind`, `cleanup`, and `auto-approve` commands can be reused directly.
+The current ZCode release does not execute project-level hook configuration; use the user-level file
+above or distribute hooks through a ZCode plugin.
+
 ## Other Clients
 
 For other clients, follow the [general instructions](#clients-general-instructions) above to set up Serena as an MCP server.

--- a/src/serena/hooks.py
+++ b/src/serena/hooks.py
@@ -26,6 +26,7 @@ class HookClient(Enum):
     VSCODE = "vscode"
     CODEX = "codex"
     GROK = "grok"
+    ZCODE = "zcode"
 
 
 class Hook(ABC):

--- a/test/serena/test_hooks.py
+++ b/test/serena/test_hooks.py
@@ -95,9 +95,30 @@ class TestHookClientDetection:
             hook = PreToolUseRemindAboutSymbolicToolsHook(HookClient.GROK)
         assert hook._client == HookClient.GROK
 
+    def test_zcode_client_uses_compatible_hook_protocol(self, tmp_path: Path):
+        payload = _base_input("mcp__serena__find_symbol")
+        with patch("sys.stdin", _make_stdin(payload)), patch("serena.hooks.serena_home_dir", str(tmp_path)):
+            hook = PreToolUseRemindAboutSymbolicToolsHook(HookClient("zcode"))
+            hook.execute()
+
+        output = PreToolUseHook.OutputData(
+            permission_decision="allow",
+            permission_decision_reason="allowed",
+            additional_context="context",
+        ).to_json_string(HookClient.ZCODE)
+        result = json.loads(output)
+        assert result["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert result["hookSpecificOutput"]["permissionDecision"] == "allow"
+        assert result["hookSpecificOutput"]["additionalContext"] == "context"
+
 
 class TestPreToolUseRemindAboutSerenaHook:
     """Tests for the PreToolUse hook that nudges the agent toward symbolic tools."""
+
+    def test_zcode_is_available_as_cli_client_choice(self):
+        result = CliRunner().invoke(hook_commands, ["remind", "--help"])
+        assert result.exit_code == 0
+        assert "zcode" in result.output
 
     def test_missing_tool_name_raises(self, tmp_path: Path):
         stdin_data = {"session_id": "s1"}


### PR DESCRIPTION
Fixes #1837

Add `zcode` to Serena hooks clients so ZCode users can run the existing `activate`, `remind`, `cleanup`, and `auto-approve` commands. ZCode uses the compatible local process JSON hook protocol and accepts Serena’s `hookSpecificOutput` response format.

Document the user-level `~/.zcode/cli/config.json` setup, including the current limitation that project-level ZCode hooks are not executed. Add regression coverage for the enum, CLI choice, and output protocol.

Validation:
- `uv run pytest test/serena/test_hooks.py -q`
- `ruff format --check src scripts test`
- `ruff check src scripts test`
- `ty check src/serena src/solidlsp`
- `ty check test --exclude test/resources`
- `uv run poe doc-build`