### PR TITLE
fix(angular-ls): resolve the Angular project before the first query; support additional_workspace_folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Status of the `main` branch. Changes prior to the next official version change w
     indicate it was incomplete. Serena now declares work-done progress support and waits for the work
     Metals reports, bounded by the new `indexing_timeout`, `indexing_start_grace` and
     `indexing_quiet_period` settings
+  - Fix: the Angular language server waited for ngserver's `projectLoadingFinish` after `initialized`,
+    but ngserver loads the project lazily, on the first document open — so the notification could not
+    arrive, every startup burned the full wait, and the first symbol query of a session ran against an
+    unresolved project, silently returning incomplete cross-file references. Serena now opens one `.ts`
+    file to trigger the load before waiting (skipped for projects without a `tsconfig.json`, where
+    ngserver loads nothing)
   - Fix: a `tsserver` crash mid-indexing (e.g. a V8 heap OOM) sent the same `$/progress` "end"
     event as a normal completion, so `find_referencing_symbols` and other cross-file queries
     silently returned an empty result instead of surfacing the crash. The crash is now detected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ Status of the `main` branch. Changes prior to the next official version change w
     unresolved project, silently returning incomplete cross-file references. Serena now opens one `.ts`
     file to trigger the load before waiting (skipped for projects without a `tsconfig.json`, where
     ngserver loads nothing)
+  - The Angular language server now supports `additional_workspace_folders`: the extra folders are
+    activated at startup and the companion TypeScript server is given the same workspace folders,
+    ignore patterns and encoding as the main server, so cross-package queries reach code outside the
+    app. `.ts` references are now the union of what ngserver reports (template usages) and what the
+    companion reports (callers in another project — an extra workspace folder, or a second
+    `tsconfig.json` in a monorepo); neither is complete on its own
+  - Fix: Angular post-edit diagnostics for `.ts` files waited out the 2.5s publish timeout on every
+    edited file, because ngserver publishes diagnostics for `.html` templates only; they are now read
+    from the companion TypeScript server, which does publish them
   - Fix: a `tsserver` crash mid-indexing (e.g. a V8 heap OOM) sent the same `$/progress` "end"
     event as a normal completion, so `find_referencing_symbols` and other cross-file queries
     silently returned an empty result instead of surfacing the crash. The crash is now detected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,9 @@ Status of the `main` branch. Changes prior to the next official version change w
     companion reports (callers in another project — an extra workspace folder, or a second
     `tsconfig.json` in a monorepo); neither is complete on its own
   - Fix: Angular post-edit diagnostics for `.ts` files waited out the 2.5s publish timeout on every
-    edited file, because ngserver publishes diagnostics for `.html` templates only; they are now read
-    from the companion TypeScript server, which does publish them
+    edited file, because ngserver never publishes for an ordinary TypeScript error (it publishes for
+    `.html` templates, and for a `.ts` file whose inline template has an error); they are now read
+    from the companion TypeScript server, which publishes for both
   - Fix: a `tsserver` crash mid-indexing (e.g. a V8 heap OOM) sent the same `$/progress` "end"
     event as a normal completion, so `find_referencing_symbols` and other cross-file queries
     silently returned an empty result instead of surfacing the crash. The crash is now detected

--- a/src/solidlsp/language_servers/angular_language_server.py
+++ b/src/solidlsp/language_servers/angular_language_server.py
@@ -45,6 +45,11 @@ Routing:
     request_hover(.ts)              -> companion TS server
     request_hover(.html)            -> ngserver
     request_rename_symbol_edit      -> companion TS server (.ts), ngserver (.html)
+    published diagnostics (.ts)     -> companion TS server
+    published diagnostics (.html)   -> ngserver
+      ("published diagnostics" = request_published_text_document_diagnostics plus the
+       cached/generation accessors, which must route identically or the generation
+       counter would be read off a different server than the diagnostics.)
 
 Hard project requirements (failure modes if violated):
     * tsconfig.json at the repository root (or above any opened .ts file).
@@ -74,6 +79,7 @@ from solidlsp.language_servers.typescript_language_server import (
 from solidlsp.language_servers.vscode_html_language_server import VsCodeHtmlLanguageServer
 from solidlsp.ls import LanguageServerDependencyProvider, LSPFileBuffer, SolidLanguageServer
 from solidlsp.ls_config import FilenameMatcher, LanguageServerConfig, LanguageServerId
+from solidlsp.ls_exceptions import SolidLSPException
 from solidlsp.lsp_protocol_handler.lsp_types import DocumentSymbol, SymbolInformation
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -218,6 +224,8 @@ class AngularLanguageServer(SolidLanguageServer):
     """
 
     NG_SERVER_READY_TIMEOUT = 30.0
+    # Upper bound on the warm-up seed search once a usable (non-component) seed is already in hand.
+    MAX_SEED_SEARCH_DIRS = 2000
     TS_SERVER_READY_TIMEOUT = 10.0
     HTML_SERVER_READY_TIMEOUT = 10.0
 
@@ -620,6 +628,13 @@ class AngularLanguageServer(SolidLanguageServer):
                 if not self.server_ready.wait(timeout=self.NG_SERVER_READY_TIMEOUT):
                     log.info("Timeout waiting for ngserver project load; proceeding anyway")
                     self.server_ready.set()
+        except SolidLSPException as e:
+            # A terminated ngserver is not a warm-up problem: swallowing it would report a
+            # successful startup and surface the failure from whatever ran next instead.
+            if e.is_language_server_terminated():
+                raise
+            log.warning("ngserver warm-up via %s failed (%s); proceeding anyway", seed, e)
+            self.server_ready.set()
         except Exception as e:
             # The warm-up is an optimisation; a seed file we cannot read is no reason to fail startup.
             log.warning("ngserver warm-up via %s failed (%s); proceeding anyway", seed, e)
@@ -632,25 +647,57 @@ class AngularLanguageServer(SolidLanguageServer):
         Returns None if the directory contains no ``tsconfig.json``: without one ngserver never loads a
         project and so never sends ``projectLoadingFinish``, and opening a file would only burn the
         full ``NG_SERVER_READY_TIMEOUT`` on every startup (measured: 31s vs 1s when skipped).
+
+        The ``tsconfig.json`` may sit anywhere in the tree, not necessarily next to the chosen seed —
+        deliberately looser than the TypeScript sibling, which picks a file adjacent to the tsconfig:
+        ngserver resolves the owning project from the file itself, and in a monorepo the seed and the
+        tsconfig that covers it routinely live in different directories.
         """
         component: str | None = None
         fallback: str | None = None
         has_tsconfig = False
+        scanned_dirs = 0
         for dirpath, dirnames, filenames in os.walk(directory):
-            # prune in place so a big node_modules is never descended into
-            dirnames[:] = [d for d in dirnames if not self.is_ignored_dirname(d)]
+            # prune in place so a big node_modules is never descended into; sort so the seed is the
+            # same file on every machine rather than whatever the filesystem happened to list first
+            dirnames[:] = sorted(d for d in dirnames if not self.is_ignored_dirname(d))
             has_tsconfig = has_tsconfig or "tsconfig.json" in filenames
             for name in sorted(filenames):
                 if not name.endswith(".ts") or name.endswith((".d.ts", ".spec.ts")):
                     continue
                 path = os.path.join(dirpath, name)
-                if name.endswith(".component.ts") and component is None:
-                    component = path
+                if name.endswith(".component.ts"):
+                    if component is None:
+                        component = path
                 elif fallback is None:
                     fallback = path
             if has_tsconfig and component is not None:
                 return component
+            scanned_dirs += 1
+            # ponytail: fixed budget rather than a cleverer search. A repo with no .component.ts
+            # anywhere (a plain-TS workspace folder) would otherwise walk its whole source tree just
+            # to confirm the preference cannot be satisfied; once a fallback exists, that walk buys
+            # nothing after a point. Raise it if a real project's components turn out to sit deeper.
+            if has_tsconfig and fallback is not None and scanned_dirs >= self.MAX_SEED_SEARCH_DIRS:
+                log.info("Seed search stopped after %d directories under %s; using %s", scanned_dirs, directory, fallback)
+                return fallback
         return (component or fallback) if has_tsconfig else None
+
+    @override
+    def _signal_expect_indexing(self) -> None:
+        # `_activate_additional_workspaces` is about to didOpen a file from an extra folder, which is
+        # what makes ngserver load that folder's project. Clear the flag the load will re-raise.
+        self.server_ready.clear()
+
+    @override
+    def _wait_for_additional_workspace_indexing(self) -> None:
+        # Without this the base class returns from `start()` as soon as the didOpens are sent, and the
+        # first query races ngserver's project load — the very bug the startup warm-up fixed.
+        if self.server_ready.wait(timeout=self.NG_SERVER_READY_TIMEOUT):
+            log.info("Additional workspace project load finished")
+        else:
+            log.info("Timeout waiting for additional workspace project load; proceeding anyway")
+            self.server_ready.set()
 
     @override
     def stop(self, shutdown_timeout: float = 5.0) -> None:
@@ -711,8 +758,20 @@ class AngularLanguageServer(SolidLanguageServer):
         if self._ts_server is None or not self._is_typescript_file(relative_file_path):
             return references
 
-        with self._ts_server.open_file(relative_file_path):
-            companion_references = self._ts_server.request_references(relative_file_path, line, column)
+        try:
+            with self._ts_server.open_file(relative_file_path):
+                companion_references = self._ts_server.request_references(relative_file_path, line, column)
+        except SolidLSPException as e:
+            # Termination must propagate so tools_base can restart the LS and retry (as in ls.py).
+            if e.is_language_server_terminated():
+                raise
+            log.warning("Companion TS server failed on references for %s (%s); using ngserver's answer alone", relative_file_path, e)
+            return references
+        except Exception as e:
+            # ngserver's answer is already in hand and is the primary one; a companion failure
+            # degrades cross-project coverage but must not turn a usable result into an error.
+            log.warning("Companion TS server failed on references for %s (%s); using ngserver's answer alone", relative_file_path, e)
+            return references
         seen = {self._location_key(location) for location in references}
         for location in companion_references:
             key = self._location_key(location)
@@ -723,8 +782,16 @@ class AngularLanguageServer(SolidLanguageServer):
 
     @staticmethod
     def _location_key(location: ls_types.Location) -> tuple[str, int, int]:
+        """Identity of a reference, on the one field both servers normalise.
+
+        Not the raw ``uri``: that is whatever each process spelled it, and the two disagree —
+        ``TypeScriptLanguageServer._get_published_diagnostics_uri`` exists precisely because
+        tsserver lower-cases the Windows drive letter. ``absolutePath`` is normalised by
+        ``convert_location_item`` for both, so a same-location pair collapses instead of
+        showing the user the reference twice.
+        """
         start = location["range"]["start"]
-        return location["uri"], start["line"], start["character"]
+        return os.path.normcase(location["absolutePath"]), start["line"], start["character"]
 
     @override
     def request_rename_symbol_edit(self, relative_file_path: str, line: int, column: int, new_name: str) -> ls_types.WorkspaceEdit | None:
@@ -761,8 +828,8 @@ class AngularLanguageServer(SolidLanguageServer):
 
     @override
     def get_published_diagnostics_generation(self, relative_file_path: str) -> int:
-        # Same split as the pull diagnostics below: ngserver publishes for .html only, so the
-        # generation counter that matters for a .ts file is the companion's.
+        # Same split as the published diagnostics below, and it must stay identical: a generation
+        # counter read off ngserver would never advance for the diagnostics the companion published.
         if self._ts_server is not None and self._is_typescript_file(relative_file_path):
             return self._ts_server.get_published_diagnostics_generation(relative_file_path)
         return super().get_published_diagnostics_generation(relative_file_path)
@@ -794,9 +861,11 @@ class AngularLanguageServer(SolidLanguageServer):
         min_severity: int = 4,
         allow_cached: bool = True,
     ) -> list[ls_types.Diagnostic] | None:
-        # ngserver publishes diagnostics for .html templates only; for .ts it publishes nothing at
-        # all, so asking it meant waiting out the timeout on every edited component (measured 2.5s)
-        # before Serena fell back to pull diagnostics. The companion publishes them (measured 1.8s).
+        # ngserver publishes for .html templates, and for a .ts file whose *inline* template has an
+        # error (measured 0.39s) — but never for an ordinary TypeScript error, where it stayed silent
+        # for the full 15s we waited. Asking it therefore burned the whole timeout (2.5s) on every
+        # edited component before Serena fell back to pull diagnostics. The companion covers both
+        # (the @angular/language-service plugin gives it the inline templates) in a measured 1.8s.
         if self._ts_server is not None and self._is_typescript_file(relative_file_path):
             with self._ts_server.open_file(relative_file_path):
                 return self._ts_server.request_published_text_document_diagnostics(

--- a/src/solidlsp/language_servers/angular_language_server.py
+++ b/src/solidlsp/language_servers/angular_language_server.py
@@ -388,6 +388,21 @@ class AngularLanguageServer(SolidLanguageServer):
         return dataclasses.replace(self.config, ls_id=ls_id, trace_lsp_communication=False)
 
     def _start_typescript_server(self) -> None:
+        """Spawn the companion typescript-language-server. Unlike the HTML companion, failure is fatal.
+
+        The asymmetry is deliberate. A missing HTML companion costs one method on one extension
+        (.html documentSymbol, which returns None). A missing TS companion silently changes the
+        answer for every .ts operation, and .ts is most of an Angular project: `request_implementation`
+        hard-returns [] (ngserver answers -32601), and .ts diagnostics fall back to the ngserver
+        routing that this class exists to correct. Serena surfaces those as "nothing found", not as
+        "degraded" — a confidently empty answer is worse than a startup that refuses loudly.
+
+        The request-time routing below guards every companion call with ``self._ts_server is not
+        None``, but those branches are unreachable while the server runs: the field is only cleared
+        here and in ``_stop_typescript_server``, and a restart builds a fresh instance
+        (``ls_manager.restart_language_server``). Making this non-fatal would put ten never-exercised
+        fallbacks on the live path. Revisit if capability loss ever becomes visible to the caller.
+        """
         try:
             ts_config = self._companion_config(LanguageServerId.TYPESCRIPT)
             log.info("Creating companion AngularTypeScriptServer")
@@ -408,9 +423,12 @@ class AngularLanguageServer(SolidLanguageServer):
             self._ts_server_started = True
             log.info("Companion TypeScript server ready")
         except Exception:
+            # Stop before dropping the reference. The companion spawns its node process in
+            # `server.start()` and only *then* initializes, so every failure after that point --
+            # an initialize timeout, or one of the capability asserts on the response -- would
+            # otherwise orphan a live tsserver. Nothing else holds a handle to it once we return.
             log.exception("Error starting companion TypeScript server")
-            self._ts_server = None
-            self._ts_server_started = False
+            self._stop_typescript_server()
             raise
 
     def _stop_typescript_server(self) -> None:
@@ -449,9 +467,10 @@ class AngularLanguageServer(SolidLanguageServer):
             self._html_server_started = True
             log.info("Companion HTML server ready")
         except Exception:
+            # Same spawn-then-initialize leak as the TS companion, and worse here: this failure is
+            # swallowed, so an orphaned process would never be surfaced by a propagating exception.
             log.exception("Error starting companion HTML server; .html documentSymbol will return []")
-            self._html_server = None
-            self._html_server_started = False
+            self._stop_html_server()
 
     def _stop_html_server(self) -> None:
         if self._html_server is not None:

--- a/src/solidlsp/language_servers/angular_language_server.py
+++ b/src/solidlsp/language_servers/angular_language_server.py
@@ -11,7 +11,10 @@ an additional HTML companion because ngserver does not implement
         - handles .ts references (ngserver aggregates template + TS usages in
           one pass; typescript-language-server alone misses template usages
           and often returns partial cross-file .ts references on Angular
-          projects where files aren't pre-opened)
+          projects where files aren't pre-opened). It answers from the project
+          owning the queried file only, so the companion's answer is merged in
+          to cover callers in other projects (additional workspace folders,
+          monorepos with several tsconfigs)
         - exposes Angular-specific custom requests
           (IsInAngularProject, GetComponentsWithTemplateFile, ...)
         - DOES NOT implement ``textDocument/documentSymbol`` at all — returns
@@ -37,7 +40,7 @@ Routing:
     request_document_symbols(.html) -> companion HTML server
     request_definition(.ts)         -> companion TS server
     request_definition(.html)       -> ngserver
-    request_references(.ts)         -> ngserver
+    request_references(.ts)         -> ngserver + companion TS server (union)
     request_references(.html)       -> ngserver
     request_hover(.ts)              -> companion TS server
     request_hover(.html)            -> ngserver
@@ -52,6 +55,7 @@ Hard project requirements (failure modes if violated):
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import os
@@ -366,9 +370,18 @@ class AngularLanguageServer(SolidLanguageServer):
 
         return ng_executable, tsdk_path, ts_ls_executable, angular_plugin_path, install_dir
 
+    def _companion_config(self, ls_id: LanguageServerId) -> LanguageServerConfig:
+        """This server's config, retargeted at a companion.
+
+        The companions serve the same files in the same workspace folders (.ts goes to the TS
+        companion, .html documentSymbol to the HTML one), so they must see the same folder list,
+        ignore patterns and file encoding; only tracing stays off to keep their logs out of ours.
+        """
+        return dataclasses.replace(self.config, ls_id=ls_id, trace_lsp_communication=False)
+
     def _start_typescript_server(self) -> None:
         try:
-            ts_config = LanguageServerConfig(ls_id=LanguageServerId.TYPESCRIPT, trace_lsp_communication=False)
+            ts_config = self._companion_config(LanguageServerId.TYPESCRIPT)
             log.info("Creating companion AngularTypeScriptServer")
             self._ts_server = AngularTypeScriptServer(
                 config=ts_config,
@@ -413,7 +426,7 @@ class AngularLanguageServer(SolidLanguageServer):
         non-fatal: we log and fall back to returning an empty list.
         """
         try:
-            html_config = LanguageServerConfig(ls_id=LanguageServerId.HTML, trace_lsp_communication=False)
+            html_config = self._companion_config(LanguageServerId.HTML)
             log.info("Creating companion VsCodeHtmlLanguageServer")
             self._html_server = VsCodeHtmlLanguageServer(
                 config=html_config,
@@ -575,6 +588,7 @@ class AngularLanguageServer(SolidLanguageServer):
             log.debug("Angular LS initialize response: %s", init_response)
             self.server.notify.initialized({})
             self._warm_up_project()
+            self._activate_additional_workspaces()
         except Exception:
             self._stop_typescript_server()
             self._stop_html_server()
@@ -682,10 +696,35 @@ class AngularLanguageServer(SolidLanguageServer):
         # HTML templates: ngserver knows how to resolve template -> component
         return super().request_definition(relative_file_path, line, column)
 
-    # request_references is intentionally not overridden: ngserver (the parent
-    # process) handles both .ts and .html references and returns the full set,
-    # whereas the TS companion under-reports because it only sees pre-opened
-    # files. See module docstring routing table.
+    @override
+    def request_references(self, relative_file_path: str, line: int, column: int) -> list[ls_types.Location]:
+        """For .ts symbols, the union of ngserver's and the TS companion's references.
+
+        Neither is complete on its own. ngserver aggregates the template usages the companion
+        cannot see (which is why it stays the primary), but it answers from the project owning
+        the queried file alone: usages living in another project — a folder from
+        ``additional_workspace_folders``, or a second ``tsconfig.json`` in a monorepo — are
+        absent from its answer and present in the companion's. Both were verified on the
+        ``cross_package_lib`` fixture.
+        """
+        references = super().request_references(relative_file_path, line, column)
+        if self._ts_server is None or not self._is_typescript_file(relative_file_path):
+            return references
+
+        with self._ts_server.open_file(relative_file_path):
+            companion_references = self._ts_server.request_references(relative_file_path, line, column)
+        seen = {self._location_key(location) for location in references}
+        for location in companion_references:
+            key = self._location_key(location)
+            if key not in seen:
+                seen.add(key)
+                references.append(location)
+        return references
+
+    @staticmethod
+    def _location_key(location: ls_types.Location) -> tuple[str, int, int]:
+        start = location["range"]["start"]
+        return location["uri"], start["line"], start["character"]
 
     @override
     def request_rename_symbol_edit(self, relative_file_path: str, line: int, column: int, new_name: str) -> ls_types.WorkspaceEdit | None:
@@ -719,6 +758,65 @@ class AngularLanguageServer(SolidLanguageServer):
             relative_file_path,
         )
         return []
+
+    @override
+    def get_published_diagnostics_generation(self, relative_file_path: str) -> int:
+        # Same split as the pull diagnostics below: ngserver publishes for .html only, so the
+        # generation counter that matters for a .ts file is the companion's.
+        if self._ts_server is not None and self._is_typescript_file(relative_file_path):
+            return self._ts_server.get_published_diagnostics_generation(relative_file_path)
+        return super().get_published_diagnostics_generation(relative_file_path)
+
+    @override
+    def get_cached_published_text_document_diagnostics(
+        self,
+        relative_file_path: str,
+        start_line: int = 0,
+        end_line: int = -1,
+        min_severity: int = 4,
+    ) -> list[ls_types.Diagnostic] | None:
+        if self._ts_server is not None and self._is_typescript_file(relative_file_path):
+            return self._ts_server.get_cached_published_text_document_diagnostics(
+                relative_file_path, start_line=start_line, end_line=end_line, min_severity=min_severity
+            )
+        return super().get_cached_published_text_document_diagnostics(
+            relative_file_path, start_line=start_line, end_line=end_line, min_severity=min_severity
+        )
+
+    @override
+    def request_published_text_document_diagnostics(
+        self,
+        relative_file_path: str,
+        after_generation: int = -1,
+        timeout: float = 2.5,
+        start_line: int = 0,
+        end_line: int = -1,
+        min_severity: int = 4,
+        allow_cached: bool = True,
+    ) -> list[ls_types.Diagnostic] | None:
+        # ngserver publishes diagnostics for .html templates only; for .ts it publishes nothing at
+        # all, so asking it meant waiting out the timeout on every edited component (measured 2.5s)
+        # before Serena fell back to pull diagnostics. The companion publishes them (measured 1.8s).
+        if self._ts_server is not None and self._is_typescript_file(relative_file_path):
+            with self._ts_server.open_file(relative_file_path):
+                return self._ts_server.request_published_text_document_diagnostics(
+                    relative_file_path,
+                    after_generation=after_generation,
+                    timeout=timeout,
+                    start_line=start_line,
+                    end_line=end_line,
+                    min_severity=min_severity,
+                    allow_cached=allow_cached,
+                )
+        return super().request_published_text_document_diagnostics(
+            relative_file_path,
+            after_generation=after_generation,
+            timeout=timeout,
+            start_line=start_line,
+            end_line=end_line,
+            min_severity=min_severity,
+            allow_cached=allow_cached,
+        )
 
     @override
     def request_text_document_diagnostics(

--- a/src/solidlsp/language_servers/angular_language_server.py
+++ b/src/solidlsp/language_servers/angular_language_server.py
@@ -213,7 +213,7 @@ class AngularLanguageServer(SolidLanguageServer):
         * ``npm_registry``: optional alternative npm registry URL.
     """
 
-    NG_SERVER_READY_TIMEOUT = 10.0
+    NG_SERVER_READY_TIMEOUT = 30.0
     TS_SERVER_READY_TIMEOUT = 10.0
     HTML_SERVER_READY_TIMEOUT = 10.0
 
@@ -574,15 +574,7 @@ class AngularLanguageServer(SolidLanguageServer):
             init_response = self.server.send.initialize(init_params)
             log.debug("Angular LS initialize response: %s", init_response)
             self.server.notify.initialized({})
-            # ngserver loads the Angular compiler asynchronously after `initialized`. Wait briefly
-            # for projectLoadingFinish, then proceed regardless — operations queue inside ngserver.
-            # ngserver eagerly resolves the project once projectLoadingFinish fires; we previously
-            # ran a proactive .ts didOpen/didClose pass but empirical testing on real Angular
-            # projects (181 .ts / 85 .html) showed it added ~4s to cold start without improving
-            # first-query correctness or latency, so it has been removed.
-            if not self.server_ready.wait(timeout=self.NG_SERVER_READY_TIMEOUT):
-                log.info("Timeout waiting for ngserver project load; proceeding anyway")
-                self.server_ready.set()
+            self._warm_up_project()
         except Exception:
             self._stop_typescript_server()
             self._stop_html_server()
@@ -591,6 +583,60 @@ class AngularLanguageServer(SolidLanguageServer):
             except Exception as e:
                 log.warning("Error stopping ngserver during startup-failure cleanup: %s", e)
             raise
+
+    def _warm_up_project(self) -> None:
+        """
+        Resolve the Angular project before the first query.
+
+        ngserver does not load the project on `initialized` — it loads it lazily, on the first document
+        open. Without this, `projectLoadingFinish` arrives only when a real query happens (on one real
+        app: never sooner than 71s after startup, median ~8 minutes), so the *first* symbol query runs
+        against an unresolved project and cross-file references come back silently incomplete. Opening
+        one .ts file up front triggers the load, which is what makes the wait below meaningful.
+        """
+        seed = self._find_representative_source_file(self.repository_root_path)
+        if seed is None:
+            log.info("No TypeScript project to warm ngserver up with; skipping the project load wait")
+            self.server_ready.set()
+            return
+
+        log.info("Opening %s to trigger the ngserver project load", seed)
+        try:
+            with self.open_file(os.path.relpath(seed, self.repository_root_path)):
+                if not self.server_ready.wait(timeout=self.NG_SERVER_READY_TIMEOUT):
+                    log.info("Timeout waiting for ngserver project load; proceeding anyway")
+                    self.server_ready.set()
+        except Exception as e:
+            # The warm-up is an optimisation; a seed file we cannot read is no reason to fail startup.
+            log.warning("ngserver warm-up via %s failed (%s); proceeding anyway", seed, e)
+            self.server_ready.set()
+
+    @override
+    def _find_representative_source_file(self, directory: str) -> str | None:
+        """The cheapest .ts file that makes ngserver resolve the project: prefer a component, else any.
+
+        Returns None if the directory contains no ``tsconfig.json``: without one ngserver never loads a
+        project and so never sends ``projectLoadingFinish``, and opening a file would only burn the
+        full ``NG_SERVER_READY_TIMEOUT`` on every startup (measured: 31s vs 1s when skipped).
+        """
+        component: str | None = None
+        fallback: str | None = None
+        has_tsconfig = False
+        for dirpath, dirnames, filenames in os.walk(directory):
+            # prune in place so a big node_modules is never descended into
+            dirnames[:] = [d for d in dirnames if not self.is_ignored_dirname(d)]
+            has_tsconfig = has_tsconfig or "tsconfig.json" in filenames
+            for name in sorted(filenames):
+                if not name.endswith(".ts") or name.endswith((".d.ts", ".spec.ts")):
+                    continue
+                path = os.path.join(dirpath, name)
+                if name.endswith(".component.ts") and component is None:
+                    component = path
+                elif fallback is None:
+                    fallback = path
+            if has_tsconfig and component is not None:
+                return component
+        return (component or fallback) if has_tsconfig else None
 
     @override
     def stop(self, shutdown_timeout: float = 5.0) -> None:

--- a/test/resources/repos/angular/cross_package_lib/external-greeter.ts
+++ b/test/resources/repos/angular/cross_package_lib/external-greeter.ts
@@ -1,0 +1,10 @@
+// A package OUTSIDE the Angular app, wired up in tests via additional_workspace_folders.
+// It implements the app's Greeter interface, so references to that interface only reach
+// this file if the language server actually loaded this folder's project.
+import { Greeter } from '../test_repo/src/app/greeter.interface';
+
+export class ExternalGreeter implements Greeter {
+    greet(name?: string): string {
+        return `Salut, ${name ?? 'monde'}!`;
+    }
+}

--- a/test/resources/repos/angular/cross_package_lib/tsconfig.json
+++ b/test/resources/repos/angular/cross_package_lib/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "rootDir": ".",
+    "paths": {
+      "../test_repo/src/app/*": ["../test_repo/src/app/*"]
+    }
+  },
+  "include": ["*.ts"]
+}

--- a/test/resources/repos/angular/test_repo/src/app/inline_template_sample.ts
+++ b/test/resources/repos/angular/test_repo/src/app/inline_template_sample.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+// Inline-template diagnostics fixture.
+//
+// ``{{ missingField }}`` is only an error to something that type-checks the template
+// *inside* the .ts file: plain tsserver sees a template literal and reports nothing.
+// The companion typescript-language-server flags it because @angular/language-service
+// is loaded into it as a tsserver plugin — which is what makes the companion a safe
+// sole source of published .ts diagnostics. If the plugin ever stops loading, this is
+// the fixture that fails.
+@Component({
+    selector: 'app-inline-template-sample',
+    standalone: true,
+    template: `<span>{{ missingField }}</span>`,
+})
+export class InlineTemplateSampleComponent {
+    readonly label: string = 'present';
+}

--- a/test/solidlsp/angular/test_angular_companion_startup.py
+++ b/test/solidlsp/angular/test_angular_companion_startup.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for companion-process cleanup when an Angular companion fails to start.
+
+Deliberately **not** marked ``angular``: no language server is started, so these belong in the
+default suite rather than behind the slow, node-dependent job.
+
+Both companions spawn their node process inside ``server.start()`` and only *then* initialize
+(``send.initialize`` plus capability asserts on the response). A failure after the spawn must
+still reach ``stop()``, or the process is orphaned: nothing else holds a handle to it once
+``_start_*_server`` drops its reference.
+"""
+
+import pytest
+
+from solidlsp.language_servers import angular_language_server as als
+from solidlsp.ls_config import LanguageServerConfig, LanguageServerId
+
+
+class _FailsAfterSpawn:
+    """Stand-in for a companion whose node process is up but whose initialize fails."""
+
+    def __init__(self, **_kwargs) -> None:
+        self.stopped = False
+
+    def start(self) -> None:
+        raise RuntimeError("initialize failed after the process was spawned")
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def _bare_angular_ls() -> als.AngularLanguageServer:
+    """Bypass ``__init__`` (which would install and launch the LS) and set only what the
+    ``_start_*_server`` methods read.
+    """
+    ls = object.__new__(als.AngularLanguageServer)
+    ls.config = LanguageServerConfig(ls_id=LanguageServerId.ANGULAR)
+    ls.repository_root_path = "/nonexistent"
+    ls._solidlsp_settings = None
+    ls._angular_plugin_path = "/nonexistent/plugin"
+    ls._tsdk_path = "/nonexistent/tsdk"
+    ls._ts_ls_executable = "/nonexistent/tsls"
+    ls._ts_server = None
+    ls._ts_server_started = False
+    ls._html_server = None
+    ls._html_server_started = False
+    return ls
+
+
+def test_failing_ts_companion_is_stopped_before_the_reference_is_dropped(monkeypatch) -> None:
+    spawned: list[_FailsAfterSpawn] = []
+    monkeypatch.setattr(als, "AngularTypeScriptServer", lambda **kw: spawned.append(_FailsAfterSpawn()) or spawned[-1])
+    ls = _bare_angular_ls()
+
+    with pytest.raises(RuntimeError):
+        ls._start_typescript_server()
+
+    assert spawned[0].stopped, "companion was dropped without stop(); its node process is orphaned"
+    assert ls._ts_server is None
+    assert ls._ts_server_started is False
+
+
+def test_failing_html_companion_is_stopped_and_startup_continues(monkeypatch) -> None:
+    """The HTML companion failure stays non-fatal — but must not leak on the way out."""
+    spawned: list[_FailsAfterSpawn] = []
+    monkeypatch.setattr(als, "VsCodeHtmlLanguageServer", lambda **kw: spawned.append(_FailsAfterSpawn()) or spawned[-1])
+    ls = _bare_angular_ls()
+
+    ls._start_html_server()  # must not raise
+
+    assert spawned[0].stopped, "companion was dropped without stop(); its node process is orphaned"
+    assert ls._html_server is None
+    assert ls._html_server_started is False

--- a/test/solidlsp/angular/test_angular_cross_package.py
+++ b/test/solidlsp/angular/test_angular_cross_package.py
@@ -6,6 +6,7 @@ into that package only appear once the extra workspace folder has been activated
 a file in it — which is what ``_activate_additional_workspaces`` does at startup.
 """
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -57,4 +58,23 @@ class TestAngularCrossPackageReferences:
             ref_paths = _greeter_interface_refs(ls)
         assert not any("external-greeter.ts" in p for p in ref_paths), (
             f"Did not expect references outside the app workspace, got: {ref_paths}"
+        )
+
+    def test_additional_workspace_project_load_is_awaited(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Regression: opening the extra folder's seed file only *triggers* ngserver's project load.
+
+        The base class returns from ``_activate_additional_workspaces`` as soon as the didOpen is
+        sent, so without the Angular override of ``_wait_for_additional_workspace_indexing`` the
+        first query races that load — exactly the bug the startup warm-up fixed for the main folder.
+        """
+        logger = "solidlsp.language_servers.angular_language_server"
+        with caplog.at_level(logging.INFO, logger=logger):
+            with start_ls_context(LanguageServerId.ANGULAR, repo_path=APP, additional_workspace_folders=[LIB]):
+                pass
+        messages = [r.getMessage() for r in caplog.records if r.name == logger]
+        assert any("Additional workspace project load finished" in m for m in messages), (
+            f"start() did not wait for the extra folder's project load; log was: {messages}"
+        )
+        assert not any("Timeout waiting for additional workspace project load" in m for m in messages), (
+            f"The wait fell through to its timeout, adding dead startup latency; log was: {messages}"
         )

--- a/test/solidlsp/angular/test_angular_cross_package.py
+++ b/test/solidlsp/angular/test_angular_cross_package.py
@@ -1,0 +1,60 @@
+"""Cross-package Angular references via ``additional_workspace_folders``.
+
+``cross_package_lib`` sits outside the Angular app and implements the app's ``Greeter``
+interface. ngserver loads projects lazily, per opened document, so references from the app
+into that package only appear once the extra workspace folder has been activated by opening
+a file in it — which is what ``_activate_additional_workspaces`` does at startup.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from serena.util.text_utils import find_text_coordinates
+from solidlsp import SolidLanguageServer
+from solidlsp.ls_config import LanguageServerId
+from test.conftest import start_ls_context
+from test.solidlsp.conftest import read_repo_file
+
+ANGULAR_REPOS_DIR = Path(__file__).parent.parent.parent / "resources" / "repos" / "angular"
+APP = str(ANGULAR_REPOS_DIR / "test_repo")
+LIB = str(ANGULAR_REPOS_DIR / "cross_package_lib")
+
+INTERFACE_FILE = "src/app/greeter.interface.ts"
+
+
+def _greeter_interface_refs(ls: SolidLanguageServer) -> list[str]:
+    coords = find_text_coordinates(read_repo_file(ls, INTERFACE_FILE), r"interface (Greeter)")
+    assert coords is not None, "Could not locate the Greeter interface declaration"
+    refs = ls.request_references(INTERFACE_FILE, coords.line, coords.col + 1)
+    return [r.get("relativePath", "") for r in refs]
+
+
+@pytest.mark.angular
+class TestAngularCrossPackageReferences:
+    def test_references_reach_additional_workspace_folder(self) -> None:
+        with start_ls_context(LanguageServerId.ANGULAR, repo_path=APP, additional_workspace_folders=[LIB]) as ls:
+            ref_paths = _greeter_interface_refs(ls)
+        assert any("external-greeter.ts" in p for p in ref_paths), (
+            f"Expected a reference from the additional workspace folder, got: {ref_paths}"
+        )
+
+    def test_referencing_symbols_reach_additional_workspace_folder(self) -> None:
+        """The `find_referencing_symbols` path: the symbol containing the reference has to be read
+        back out of the external file, which only works if the companion TS server was configured
+        with the same workspace folders as ngserver.
+        """
+        with start_ls_context(LanguageServerId.ANGULAR, repo_path=APP, additional_workspace_folders=[LIB]) as ls:
+            coords = find_text_coordinates(read_repo_file(ls, INTERFACE_FILE), r"interface (Greeter)")
+            assert coords is not None
+            referencing = ls.request_referencing_symbols(INTERFACE_FILE, coords.line, coords.col + 1, include_imports=True)
+            names = {r.symbol.get("name") for r in referencing}
+        assert "ExternalGreeter" in names, f"Expected the implementing class from the extra package, got: {names}"
+
+    def test_no_cross_package_references_without_additional_workspace_folder(self) -> None:
+        """Baseline: the extra folder is invisible unless it is configured."""
+        with start_ls_context(LanguageServerId.ANGULAR, repo_path=APP) as ls:
+            ref_paths = _greeter_interface_refs(ls)
+        assert not any("external-greeter.ts" in p for p in ref_paths), (
+            f"Did not expect references outside the app workspace, got: {ref_paths}"
+        )

--- a/test/solidlsp/angular/test_angular_diagnostics.py
+++ b/test/solidlsp/angular/test_angular_diagnostics.py
@@ -42,3 +42,27 @@ class TestAngularDiagnostics:
             (),
             min_count=1,
         )
+
+
+@pytest.mark.angular
+class TestAngularPublishedDiagnostics:
+    """``textDocument/publishDiagnostics`` — the stream Serena reads after an edit.
+
+    ngserver publishes for .html templates only; for .ts it publishes nothing, so before the
+    routing below every edited component waited out the full timeout and returned nothing.
+    """
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ANGULAR], indirect=True)
+    def test_published_diagnostics_for_component_class(self, language_server: SolidLanguageServer) -> None:
+        path = "src/app/diagnostics_sample.ts"
+        with language_server.open_file(path):
+            diagnostics = language_server.request_published_text_document_diagnostics(path, min_severity=2)
+        assert diagnostics, f"Expected published diagnostics for the type error in {path}, got: {diagnostics}"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ANGULAR], indirect=True)
+    def test_published_diagnostics_for_template(self, language_server: SolidLanguageServer) -> None:
+        """The .html half must keep coming from ngserver — the companion cannot type-check templates."""
+        path = "src/app/diagnostics_sample.html"
+        with language_server.open_file(path):
+            diagnostics = language_server.request_published_text_document_diagnostics(path, min_severity=2)
+        assert diagnostics, f"Expected published diagnostics for the template error in {path}, got: {diagnostics}"

--- a/test/solidlsp/angular/test_angular_diagnostics.py
+++ b/test/solidlsp/angular/test_angular_diagnostics.py
@@ -48,8 +48,12 @@ class TestAngularDiagnostics:
 class TestAngularPublishedDiagnostics:
     """``textDocument/publishDiagnostics`` — the stream Serena reads after an edit.
 
-    ngserver publishes for .html templates only; for .ts it publishes nothing, so before the
-    routing below every edited component waited out the full timeout and returned nothing.
+    ngserver publishes for .html templates, and for a .ts file whose *inline* template has an
+    error — but never for an ordinary TypeScript error, where every edited component waited out
+    the full timeout and returned nothing. .ts is therefore routed to the companion, which covers
+    both kinds; the two tests below pin exactly that, since a companion missing its
+    @angular/language-service plugin would silently drop inline-template errors with the plain-TS
+    test still passing.
     """
 
     @pytest.mark.parametrize("language_server", [LanguageServerId.ANGULAR], indirect=True)
@@ -58,6 +62,19 @@ class TestAngularPublishedDiagnostics:
         with language_server.open_file(path):
             diagnostics = language_server.request_published_text_document_diagnostics(path, min_severity=2)
         assert diagnostics, f"Expected published diagnostics for the type error in {path}, got: {diagnostics}"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ANGULAR], indirect=True)
+    def test_published_diagnostics_for_inline_template(self, language_server: SolidLanguageServer) -> None:
+        """The other half of the .ts route: an error inside an inline ``template:``.
+
+        Only the @angular/language-service plugin inside the companion sees this — plain tsserver
+        reads the template as an ordinary template literal. Since the companion is the sole source
+        of published .ts diagnostics, losing the plugin would lose these errors silently.
+        """
+        path = "src/app/inline_template_sample.ts"
+        with language_server.open_file(path):
+            diagnostics = language_server.request_published_text_document_diagnostics(path, min_severity=2)
+        assert diagnostics, f"Expected published diagnostics for the inline-template error in {path}, got: {diagnostics}"
 
     @pytest.mark.parametrize("language_server", [LanguageServerId.ANGULAR], indirect=True)
     def test_published_diagnostics_for_template(self, language_server: SolidLanguageServer) -> None:

--- a/test/solidlsp/angular/test_angular_error_cases.py
+++ b/test/solidlsp/angular/test_angular_error_cases.py
@@ -370,68 +370,6 @@ class TestAngularStartupCleanup:
                 pass
 
 
-class TestAngularWarmUpSeedFile:
-    """Unit tests for the warm-up seed search (``_find_representative_source_file``).
-
-    Pure filesystem walking — no language server is started.
-    """
-
-    @staticmethod
-    def _find(directory) -> str | None:
-        from solidlsp.language_servers.angular_language_server import AngularLanguageServer
-
-        # Bypass __init__ (which would install/launch the LS): the walk only needs the class' own
-        # is_ignored_dirname.
-        ls = object.__new__(AngularLanguageServer)
-        return AngularLanguageServer._find_representative_source_file(ls, str(directory))
-
-    @staticmethod
-    def _write(path, content: str = "export const x = 1;\n") -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content)
-
-    def test_prefers_component_over_plain_ts(self, tmp_path) -> None:
-        (tmp_path / "tsconfig.json").write_text("{}")
-        self._write(tmp_path / "src" / "main.ts")
-        self._write(tmp_path / "src" / "app" / "app.component.ts")
-        assert self._find(tmp_path) == str(tmp_path / "src" / "app" / "app.component.ts")
-
-    def test_falls_back_to_any_ts_file(self, tmp_path) -> None:
-        (tmp_path / "tsconfig.json").write_text("{}")
-        self._write(tmp_path / "src" / "main.ts")
-        assert self._find(tmp_path) == str(tmp_path / "src" / "main.ts")
-
-    def test_skips_declaration_and_spec_files(self, tmp_path) -> None:
-        """``.d.ts`` carries no project, and specs are excluded from the app tsconfig."""
-        (tmp_path / "tsconfig.json").write_text("{}")
-        self._write(tmp_path / "src" / "types.d.ts")
-        self._write(tmp_path / "src" / "app.component.spec.ts")
-        assert self._find(tmp_path) is None
-
-    def test_never_descends_into_node_modules(self, tmp_path) -> None:
-        """A seed inside node_modules would resolve the dependency's project, not the app's."""
-        (tmp_path / "tsconfig.json").write_text("{}")
-        self._write(tmp_path / "node_modules" / "some-lib" / "lib.component.ts")
-        assert self._find(tmp_path) is None
-
-    def test_returns_none_without_tsconfig(self, tmp_path) -> None:
-        """Regression: without a tsconfig.json ngserver never loads a project and never sends
-        ``projectLoadingFinish``, so warming up would burn the full NG_SERVER_READY_TIMEOUT on
-        every startup (measured 31s vs 1s) for nothing.
-        """
-        self._write(tmp_path / "src" / "app" / "app.component.ts")
-        assert self._find(tmp_path) is None
-
-    def test_finds_tsconfig_in_subproject(self, tmp_path) -> None:
-        """Monorepo layout: the tsconfig.json lives in the sub-project, not at the walk root."""
-        self._write(tmp_path / "projects" / "app" / "src" / "app.component.ts")
-        (tmp_path / "projects" / "app" / "tsconfig.json").write_text("{}")
-        assert self._find(tmp_path) == str(tmp_path / "projects" / "app" / "src" / "app.component.ts")
-
-    def test_returns_none_for_empty_directory(self, tmp_path) -> None:
-        assert self._find(tmp_path) is None
-
-
 class TestAngularProjectWarmUp:
     """Regression: ngserver must have resolved the Angular project by the time ``start()`` returns.
 
@@ -457,3 +395,50 @@ class TestAngularProjectWarmUp:
         assert not any("Timeout waiting for ngserver project load" in m for m in messages), (
             f"Startup fell back to the timeout path; log was: {messages}"
         )
+
+
+class TestAngularReferencesCompanionFailure:
+    """Regression: a broken companion must not discard ngserver's own reference answer.
+
+    ``.ts`` references are the union of the two servers, and ngserver's half is the primary one
+    (it is the only one that sees template usages). Before the guard, any companion failure —
+    a tsserver V8 heap OOM being the documented one — propagated out of a request that already
+    had a perfectly usable answer in hand.
+    """
+
+    # ``GreetingService`` on line 5 (0-based 4), column 13 — referenced from app.component.ts.
+    SERVICE_CLASS_LINE = 4
+    SERVICE_CLASS_COL = 13
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ANGULAR], indirect=True)
+    def test_companion_error_falls_back_to_ngserver_references(
+        self, language_server: SolidLanguageServer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        baseline = language_server.request_references(SERVICE_FILE, self.SERVICE_CLASS_LINE, self.SERVICE_CLASS_COL)
+        assert baseline, "Fixture problem: no references found even with a working companion"
+
+        calls: list[object] = []
+
+        def boom(*_args: object, **_kwargs: object) -> list:
+            calls.append(None)
+            raise SolidLSPException("simulated companion failure")
+
+        monkeypatch.setattr(language_server._ts_server, "request_references", boom)
+        refs = language_server.request_references(SERVICE_FILE, self.SERVICE_CLASS_LINE, self.SERVICE_CLASS_COL)
+        assert calls, "The companion was never consulted, so this test would pass even without the guard"
+        assert refs, "ngserver's references were discarded when the companion failed"
+
+    @pytest.mark.parametrize("language_server", [LanguageServerId.ANGULAR], indirect=True)
+    def test_terminated_companion_still_propagates(self, language_server: SolidLanguageServer, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A dead language server must keep propagating so tools_base can restart the LS and retry."""
+        from solidlsp.ls_process import LanguageServerTerminatedException
+
+        def terminated(*_args: object, **_kwargs: object) -> list:
+            raise SolidLSPException(
+                "simulated termination",
+                cause=LanguageServerTerminatedException("companion died", LanguageServerId.TYPESCRIPT),
+            )
+
+        monkeypatch.setattr(language_server._ts_server, "request_references", terminated)
+        with pytest.raises(SolidLSPException):
+            language_server.request_references(SERVICE_FILE, self.SERVICE_CLASS_LINE, self.SERVICE_CLASS_COL)

--- a/test/solidlsp/angular/test_angular_error_cases.py
+++ b/test/solidlsp/angular/test_angular_error_cases.py
@@ -14,6 +14,7 @@ upstream LSPs are known to differ (Windows TS server tends to swallow malformed
 positions instead of raising).
 """
 
+import logging
 import os
 import sys
 import time
@@ -367,3 +368,92 @@ class TestAngularStartupCleanup:
                 ls.stop(shutdown_timeout=2.0)
             except Exception:
                 pass
+
+
+class TestAngularWarmUpSeedFile:
+    """Unit tests for the warm-up seed search (``_find_representative_source_file``).
+
+    Pure filesystem walking — no language server is started.
+    """
+
+    @staticmethod
+    def _find(directory) -> str | None:
+        from solidlsp.language_servers.angular_language_server import AngularLanguageServer
+
+        # Bypass __init__ (which would install/launch the LS): the walk only needs the class' own
+        # is_ignored_dirname.
+        ls = object.__new__(AngularLanguageServer)
+        return AngularLanguageServer._find_representative_source_file(ls, str(directory))
+
+    @staticmethod
+    def _write(path, content: str = "export const x = 1;\n") -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def test_prefers_component_over_plain_ts(self, tmp_path) -> None:
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "src" / "main.ts")
+        self._write(tmp_path / "src" / "app" / "app.component.ts")
+        assert self._find(tmp_path) == str(tmp_path / "src" / "app" / "app.component.ts")
+
+    def test_falls_back_to_any_ts_file(self, tmp_path) -> None:
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "src" / "main.ts")
+        assert self._find(tmp_path) == str(tmp_path / "src" / "main.ts")
+
+    def test_skips_declaration_and_spec_files(self, tmp_path) -> None:
+        """``.d.ts`` carries no project, and specs are excluded from the app tsconfig."""
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "src" / "types.d.ts")
+        self._write(tmp_path / "src" / "app.component.spec.ts")
+        assert self._find(tmp_path) is None
+
+    def test_never_descends_into_node_modules(self, tmp_path) -> None:
+        """A seed inside node_modules would resolve the dependency's project, not the app's."""
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "node_modules" / "some-lib" / "lib.component.ts")
+        assert self._find(tmp_path) is None
+
+    def test_returns_none_without_tsconfig(self, tmp_path) -> None:
+        """Regression: without a tsconfig.json ngserver never loads a project and never sends
+        ``projectLoadingFinish``, so warming up would burn the full NG_SERVER_READY_TIMEOUT on
+        every startup (measured 31s vs 1s) for nothing.
+        """
+        self._write(tmp_path / "src" / "app" / "app.component.ts")
+        assert self._find(tmp_path) is None
+
+    def test_finds_tsconfig_in_subproject(self, tmp_path) -> None:
+        """Monorepo layout: the tsconfig.json lives in the sub-project, not at the walk root."""
+        self._write(tmp_path / "projects" / "app" / "src" / "app.component.ts")
+        (tmp_path / "projects" / "app" / "tsconfig.json").write_text("{}")
+        assert self._find(tmp_path) == str(tmp_path / "projects" / "app" / "src" / "app.component.ts")
+
+    def test_returns_none_for_empty_directory(self, tmp_path) -> None:
+        assert self._find(tmp_path) is None
+
+
+class TestAngularProjectWarmUp:
+    """Regression: ngserver must have resolved the Angular project by the time ``start()`` returns.
+
+    ngserver loads the project lazily on the first ``didOpen``, not on ``initialized``. Before the
+    warm-up landed, ``angular/projectLoadingFinish`` therefore never arrived during startup: the wait
+    always ran into its timeout (10s of dead latency) and the first symbol query of the session ran
+    against an unresolved project, silently returning incomplete cross-file references.
+    """
+
+    def test_project_load_completes_during_startup(self, caplog: pytest.LogCaptureFixture) -> None:
+        ls = _create_ls(LanguageServerId.ANGULAR)
+        logger = "solidlsp.language_servers.angular_language_server"
+        try:
+            with caplog.at_level(logging.INFO, logger=logger):
+                ls.start()
+            messages = [r.getMessage() for r in caplog.records if r.name == logger]
+        finally:
+            ls.stop(shutdown_timeout=2.0)
+
+        assert any("Angular project loading finished" in m for m in messages), (
+            f"ngserver never signalled projectLoadingFinish during startup; log was: {messages}"
+        )
+        assert not any("Timeout waiting for ngserver project load" in m for m in messages), (
+            f"Startup fell back to the timeout path; log was: {messages}"
+        )

--- a/test/solidlsp/angular/test_angular_seed_file.py
+++ b/test/solidlsp/angular/test_angular_seed_file.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for the Angular warm-up seed search.
+
+Deliberately **not** marked ``angular``: this is pure filesystem walking with no language
+server started (the whole class runs in <0.1s), and these are the regressions most worth
+catching in the default suite rather than behind the slow, node-dependent job.
+"""
+
+
+class TestAngularWarmUpSeedFile:
+    """Unit tests for the warm-up seed search (``_find_representative_source_file``).
+
+    Pure filesystem walking — no language server is started.
+    """
+
+    @staticmethod
+    def _find(directory) -> str | None:
+        from solidlsp.language_servers.angular_language_server import AngularLanguageServer
+
+        # Bypass __init__ (which would install/launch the LS). Safe only because the walk reads no
+        # instance state — just the class' own is_ignored_dirname and MAX_SEED_SEARCH_DIRS. Give it
+        # instance state and this construction starts raising AttributeError instead.
+        ls = object.__new__(AngularLanguageServer)
+        return AngularLanguageServer._find_representative_source_file(ls, str(directory))
+
+    @staticmethod
+    def _write(path, content: str = "export const x = 1;\n") -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def test_prefers_component_over_plain_ts(self, tmp_path) -> None:
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "src" / "main.ts")
+        self._write(tmp_path / "src" / "app" / "app.component.ts")
+        assert self._find(tmp_path) == str(tmp_path / "src" / "app" / "app.component.ts")
+
+    def test_falls_back_to_any_ts_file(self, tmp_path) -> None:
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "src" / "main.ts")
+        assert self._find(tmp_path) == str(tmp_path / "src" / "main.ts")
+
+    def test_skips_declaration_and_spec_files(self, tmp_path) -> None:
+        """``.d.ts`` carries no project, and specs are excluded from the app tsconfig."""
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "src" / "types.d.ts")
+        self._write(tmp_path / "src" / "app.component.spec.ts")
+        assert self._find(tmp_path) is None
+
+    def test_never_descends_into_node_modules(self, tmp_path) -> None:
+        """A seed inside node_modules would resolve the dependency's project, not the app's."""
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "node_modules" / "some-lib" / "lib.component.ts")
+        assert self._find(tmp_path) is None
+
+    def test_returns_none_without_tsconfig(self, tmp_path) -> None:
+        """Regression: without a tsconfig.json ngserver never loads a project and never sends
+        ``projectLoadingFinish``, so warming up would burn the full NG_SERVER_READY_TIMEOUT on
+        every startup (measured 31s vs 1s) for nothing.
+        """
+        self._write(tmp_path / "src" / "app" / "app.component.ts")
+        assert self._find(tmp_path) is None
+
+    def test_finds_tsconfig_in_subproject(self, tmp_path) -> None:
+        """Monorepo layout: the tsconfig.json lives in the sub-project, not at the walk root."""
+        self._write(tmp_path / "projects" / "app" / "src" / "app.component.ts")
+        (tmp_path / "projects" / "app" / "tsconfig.json").write_text("{}")
+        assert self._find(tmp_path) == str(tmp_path / "projects" / "app" / "src" / "app.component.ts")
+
+    def test_returns_none_for_empty_directory(self, tmp_path) -> None:
+        assert self._find(tmp_path) is None
+
+    def test_stops_scanning_once_a_fallback_is_in_hand(self, tmp_path, monkeypatch) -> None:
+        """A tree with no ``.component.ts`` must not be walked to the end just to prove it.
+
+        Without the budget the component preference can never be satisfied, so the walk runs over
+        the whole (pruned) source tree of a monorepo on every startup.
+        """
+        from solidlsp.language_servers.angular_language_server import AngularLanguageServer
+
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "a" / "main.ts")
+        for i in range(5):
+            self._write(tmp_path / "z" / f"pkg{i}" / "index.ts")
+
+        monkeypatch.setattr(AngularLanguageServer, "MAX_SEED_SEARCH_DIRS", 1)
+        assert self._find(tmp_path) == str(tmp_path / "a" / "main.ts")
+
+    def test_seed_choice_is_stable_across_directory_orderings(self, tmp_path) -> None:
+        """``os.walk`` lists subdirectories in filesystem order; sorting keeps the seed the same
+        file on every machine rather than whichever sibling happened to be listed first.
+        """
+        (tmp_path / "tsconfig.json").write_text("{}")
+        self._write(tmp_path / "zzz" / "late.ts")
+        self._write(tmp_path / "aaa" / "early.ts")
+        assert self._find(tmp_path) == str(tmp_path / "aaa" / "early.ts")


### PR DESCRIPTION
## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change.

## What this fixes

Related problems in the Angular language server, all about *which projects ngserver has actually loaded* when a query arrives, plus the failure handling around the companion servers that answer for it. Every number below is measured, and each behaviour has a test that fails without the corresponding change.

### 1. The startup wait was waiting for something that could not happen (commit 1)

ngserver does not load the Angular project on `initialized` — it loads it lazily, on the first document open. Serena waited for `angular/projectLoadingFinish` right after `initialized`, so:

* on one real app, across 226 recorded startups, **180 hit the 10s timeout**; of the 46 that eventually signalled, the notification arrived no sooner than 71s after startup (median ~8 minutes) — i.e. only once a real query happened to open a document;
* the **first symbol query of a session therefore ran against an unresolved project**, and cross-file references came back silently incomplete — one verified `find_referencing_symbols` returned 2 of 4 callers;
* raising the timeout does not help (measured: still times out at 45s, +35s of dead latency).

Opening one `.ts` file up front triggers the load, which makes the wait meaningful. On the test fixture, LS startup goes from **11.1s** (full 10s wait, timed out) to **4.6s** (project actually loads) — reproducible with `pytest test/solidlsp/angular --durations=5`.

The seed file is found via the base class' existing `_find_representative_source_file` hook (the TS language server already implements it) and opened via `open_file`, so the didOpen/didClose pair and the file encoding are handled by the shared buffer machinery.

A project with no `tsconfig.json` gets no warm-up and no wait: ngserver loads nothing there, so the wait would burn the whole budget on every startup (measured **31s vs 1s**).

### 2. `additional_workspace_folders` was declared but never activated (commit 2)

The extra folders were passed in `initialize` and then nothing opened a file in them, so their projects never existed. Fixing that exposed two more gaps, both measured on the new `cross_package_lib` fixture:

* **ngserver answers `references` from the project owning the queried file only** — 0 of the 2 cross-package callers, even with the folder loaded. The companion `typescript-language-server` finds both, and in turn misses the template usages ngserver finds. `.ts` references are now the **union** of the two, de-duplicated on the normalised absolute path (not the raw URI: the two servers spell it differently, which is exactly why `TypeScriptLanguageServer._get_published_diagnostics_uri` exists). This also covers a monorepo with several `tsconfig.json` under one root, not just extra folders.
* **the companions were built from a bare `LanguageServerConfig`**, so workspace folders, ignore patterns and encoding stopped at ngserver. Reading a referencing symbol back out of an external file goes through the companion, which rejected the path as outside its workspaces until it was given the parent's config.

Opening the seed file only *triggers* the extra folder's project load — the base class returns from `_activate_additional_workspaces` as soon as the didOpen is sent. The Angular server now also overrides `_signal_expect_indexing` / `_wait_for_additional_workspace_indexing` (as the TypeScript one already does) so `start()` waits for the load instead of racing it. Measured: the wait resolves rather than falling through to its timeout, so it costs no startup latency.

### 3. Post-edit diagnostics for `.ts` waited out a timeout every time (commit 2)

`request_published_text_document_diagnostics` — the stream Serena reads after each edit — was answered by ngserver for `.ts` files, and ngserver **never publishes for an ordinary TypeScript error**: measured 2.5s of timeout per edited file, then `None`, then a fallback to pull diagnostics. (It does publish for `.html` templates, and for a `.ts` file whose *inline* template has an error, in 0.39s — but not for a plain type error, where it stayed silent for the full 15s I waited.) `.ts` now goes to the companion, which covers both kinds in a measured 1.8s, along with the cached/generation accessors that have to agree with it. `.html` keeps going to ngserver, the only one of the two that type-checks templates.

### 4. A failing companion could turn a usable answer into an error (commit 3)

Once `.ts` references became the union of two servers, the companion call sat unguarded on a path that already had ngserver's answer in hand — so any companion failure discarded it and raised. Not hypothetical: a `tsserver` V8 heap OOM mid-indexing is a documented failure mode one `CHANGELOG` entry up. Every *other* routed method here goes exclusively to the companion and so had no fallback to lose; references is the one that did. A non-terminated failure now logs and returns ngserver's half; a terminated one still propagates, so `tools_base` can restart the server and retry. `_warm_up_project` had the mirror-image problem — its `except Exception` swallowed a terminated ngserver along with the unreadable seed file it means to tolerate, reporting a successful startup and surfacing the failure from wherever ran next.

Also in this commit: the seed walk sorts `dirnames`, so the chosen seed is the same file on every machine rather than whatever the filesystem listed first, and stops once a usable non-component seed is in hand instead of scanning a whole monorepo to confirm the component preference cannot be satisfied.

## Tests

`test/solidlsp/angular`: **64 tests, all passing** — 55 behind the `angular` marker (~63s against a real ngserver) and 9 that need no language server and run in the default suite in 0.08s. New coverage, each case verified to fail on the pre-change code:

* `test_angular_seed_file.py` — 9 pure-filesystem cases for the seed search (component preference, `node_modules` pruning, `.d.ts`/`.spec.ts` skipping, the no-`tsconfig.json` guard, monorepo sub-project layout, the scan bound, seed stability across directory orderings). Deliberately **not** marked `angular`: no server is started, so these are worth having in the default suite rather than behind the node-dependent job.
* `TestAngularProjectWarmUp` — asserts `projectLoadingFinish` arrives during startup and the timeout path is *not* taken.
* `test_angular_cross_package.py` — cross-package references and `find_referencing_symbols` with `additional_workspace_folders`, the baseline showing they stay out without it, and that the extra folder's project load is actually awaited rather than raced. New fixture `test/resources/repos/angular/cross_package_lib/` (tsconfig + one class implementing the app's `Greeter`); it needs no `npm install`.
* `TestAngularPublishedDiagnostics` — published diagnostics for a component class, for an **inline template** (new `inline_template_sample.ts` fixture), and for a template file. The inline-template case matters because routing `.ts` to the companion makes it the *sole* source of published diagnostics there: if its `@angular/language-service` plugin ever stopped loading, inline-template errors would vanish silently with the plain-TS test still green.
* `TestAngularReferencesCompanionFailure` — a broken companion falls back to ngserver's references (asserting the companion was actually consulted, so the test cannot pass with the branch dead), and a *terminated* companion still propagates.

`poe format` and `poe type-check` are clean. `test/solidlsp/typescript` and `test/solidlsp/python` pass unchanged.

## Notes for reviewers

* The three commits are independent enough to split — commit 2 builds on commit 1 only in that it reuses `_find_representative_source_file`, and commit 3 is review hardening on top of both.
* `request_completions`, `request_signature_help` and `request_workspace_symbol` are still unrouted for `.ts` (they go to ngserver). Nothing in Serena calls them today, so I left them alone.
* The Vue and Svelte language servers build their TypeScript companions from a bare `LanguageServerConfig` in the same way, so they likely have the same workspace-folder gap. Out of scope here.
* One thing I checked and did *not* change: the published-diagnostics cache and generation counter are keyed by the request URI while servers publish under their own spelling, which looks like a Windows drive-letter mismatch. It isn't — `_canonicalize_published_diagnostics_uri` runs on both the write and every read and collapses `C:`, `c:` and `%3A` to one key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
