### PR TITLE
docs: fix issue template user guide link

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue--bug--performance-problem--question-.md
+++ b/.github/ISSUE_TEMPLATE/issue--bug--performance-problem--question-.md
@@ -10,7 +10,7 @@ assignees: ''
 Preconditions:
 
 - [ ] I have made sure it's an actual issue, not a question (use [GitHub Discussions](https://github.com/oraios/serena/discussions) instead).
-- [ ] I have consulted the [user guide](https://oraios.github.io/serena/02-usage/) and verified that the issue cannot be resolved by adjusting configuration/following recommended workflows.
+- [ ] I have consulted the [user guide](https://oraios.github.io/serena/02-usage/000_intro.html) and verified that the issue cannot be resolved by adjusting configuration/following recommended workflows.
 - [ ] I have looked for similar issues and discussions, including closed ones.
 
 Issue details:


### PR DESCRIPTION
## Summary

- Point the bug template to the current user guide entry.
- Record the documentation fix in the changelog.

Fixes #1933

## Validation

- Old URL returns HTTP 404.
- Updated URL returns HTTP 200.
- `git diff --check`

## Checklist

- [x] This PR follows the contribution scope guidelines.
- [x] The fix is recorded in `CHANGELOG.md`.