### PR TITLE
Fix: LanguageServerManager.from_languages leaking a process on post-spawn failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Status of the `main` branch. Changes prior to the next official version change w
     project list in `serena_config.yml`
 
 * Language Servers:
+  - Fix: `LanguageServerManager.from_languages` did not stop the OS subprocess of a language
+    server that raised after spawning it during multi-language startup; that process leaked
+    for the remaining session (#1949)
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     project list in `serena_config.yml`
 
 * Language Servers:
-  - Fix: `LanguageServerManager.from_languages` did not stop the OS subprocess of a language
-    server that raised after spawning it during multi-language startup; that process leaked
-    for the remaining session (#1949)
+  - Fix: Exceptions raised during `LanguageServerManager.start` did not stop the language server subprocess if it was
+    already started (#1949)
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate

--- a/src/serena/ls_manager.py
+++ b/src/serena/ls_manager.py
@@ -133,11 +133,15 @@ class LanguageServerManager:
             thread.start()
             threads.append(thread)
 
-        # collect language servers and exceptions
+        # collect language servers and exceptions. `spawned_servers` also captures a server whose
+        # own thread raised, since its process may already be running and still needs `stop()`.
         language_servers: dict[LanguageServerId, SolidLanguageServer] = {}
         exceptions: dict[LanguageServerId, Exception] = {}
+        spawned_servers: list[SolidLanguageServer] = []
         for thread in threads:
             thread.join()
+            if thread.language_server is not None:
+                spawned_servers.append(thread.language_server)
             if thread.exception is not None:
                 exceptions[thread.ls_id] = thread.exception
             elif thread.language_server is not None:
@@ -149,7 +153,7 @@ class LanguageServerManager:
         # user's attention instead of silently continuing with a subset of the language servers and potentially
         # causing suboptimal agent behaviour.
         if exceptions:
-            for ls in language_servers.values():
+            for ls in spawned_servers:
                 ls.stop()
             failure_messages = "\n".join([f"{lang.value}: {e}" for lang, e in exceptions.items()])
             raise LanguageServerManagerInitialisationError(f"Failed to start {len(exceptions)} language server(s):\n{failure_messages}")

--- a/src/serena/ls_manager.py
+++ b/src/serena/ls_manager.py
@@ -133,27 +133,26 @@ class LanguageServerManager:
             thread.start()
             threads.append(thread)
 
-        # collect language servers and exceptions. `spawned_servers` also captures a server whose
-        # own thread raised, since its process may already be running and still needs `stop()`.
+        # collect language servers and exceptions
         language_servers: dict[LanguageServerId, SolidLanguageServer] = {}
         exceptions: dict[LanguageServerId, Exception] = {}
-        spawned_servers: list[SolidLanguageServer] = []
         for thread in threads:
             thread.join()
-            if thread.language_server is not None:
-                spawned_servers.append(thread.language_server)
             if thread.exception is not None:
                 exceptions[thread.ls_id] = thread.exception
             elif thread.language_server is not None:
                 language_servers[thread.ls_id] = thread.language_server
 
         # If any server failed to start up, raise an exception and stop all started language servers.
+        # A server whose own thread raised has already stopped its own process, since
+        # SolidLanguageServer.start() cleans up after itself on failure; only the servers that
+        # started successfully (and are therefore absent from `exceptions`) still need stopping.
         # We intentionally fail fast here. The user's intention is to work with all the specified languages,
         # so if any of them is not available, it is better to make symbolic tool calls fail, bringing the issue to the
         # user's attention instead of silently continuing with a subset of the language servers and potentially
         # causing suboptimal agent behaviour.
         if exceptions:
-            for ls in spawned_servers:
+            for ls in language_servers.values():
                 ls.stop()
             failure_messages = "\n".join([f"{lang.value}: {e}" for lang, e in exceptions.items()])
             raise LanguageServerManagerInitialisationError(f"Failed to start {len(exceptions)} language server(s):\n{failure_messages}")

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -3179,7 +3179,17 @@ class SolidLanguageServer(ABC):
         """
         log.info(f"Starting language server {self.language_server.ls_id} for {self.language_server.repository_root_path}")
         self.server_started = True
-        self._start_server()
+        try:
+            self._start_server()
+        except Exception:
+            # `_start_server()` may raise after already spawning the underlying process (a
+            # capability assertion or an initialize() timeout firing post-spawn). Stop it here
+            # so a failed start never leaves an orphaned process behind, regardless of caller.
+            if self.is_running():
+                self.stop()
+            else:
+                self.server_started = False
+            raise
         return self
 
     def stop(self, shutdown_timeout: float = 2.0) -> None:

--- a/test/serena/test_ls_manager.py
+++ b/test/serena/test_ls_manager.py
@@ -1,0 +1,96 @@
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from serena.ls_manager import LanguageServerManager, LanguageServerManagerInitialisationError
+from solidlsp.ls_config import LanguageServerId
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+class _FakeLanguageServer:
+    """Duck-typed stand-in for SolidLanguageServer: `from_languages` only calls
+    `.start()`/`.is_running()`/`.stop()` on it, never isinstance-checks the object.
+    """
+
+    def __init__(self, ls_id: LanguageServerId, should_fail: bool):
+        self.ls_id = ls_id
+        self.should_fail = should_fail
+        self.proc: subprocess.Popen | None = None
+        self._running = False
+
+    def start(self) -> "_FakeLanguageServer":
+        # Mirrors e.g. clangd_language_server.py: the OS subprocess is spawned as part of
+        # start(), and a capability/initialize() check can still raise after that process
+        # is already running.
+        self.proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(100)"])
+        if self.should_fail:
+            raise RuntimeError(f"simulated: capability assertion failed after initialize() ({self.ls_id.value})")
+        self._running = True
+        return self
+
+    def is_running(self) -> bool:
+        return self._running
+
+    def stop(self, shutdown_timeout: float = 2.0) -> None:
+        if self.proc is not None and self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=shutdown_timeout)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+        self._running = False
+
+
+class _FakeLanguageServerFactory:
+    def __init__(self, fail_ids: set[LanguageServerId]):
+        self.fail_ids = fail_ids
+        self.created: dict[LanguageServerId, _FakeLanguageServer] = {}
+
+    def create_language_server(self, ls_id: LanguageServerId) -> _FakeLanguageServer:
+        ls = _FakeLanguageServer(ls_id, should_fail=ls_id in self.fail_ids)
+        self.created[ls_id] = ls
+        return ls
+
+
+@pytest.fixture
+def _cleanup_leftover_pids():
+    """Belt-and-braces: kill any spawned test subprocess still alive after the test body,
+    so a regression in the fix under test cannot leak a real OS process past this test.
+    """
+    pids: list[int] = []
+    yield pids
+    for pid in pids:
+        if _pid_alive(pid):
+            os.kill(pid, 15)
+
+
+def test_from_languages_stops_process_of_server_that_raises_after_spawning(_cleanup_leftover_pids):
+    """A language server whose `start()` spawns its OS subprocess and then raises (e.g. a
+    capability assertion or an initialize() timeout firing after the process is already up)
+    must still have that process stopped by `from_languages`'s failure-path cleanup, exactly
+    like a server that started successfully and is stopped because a sibling failed.
+    """
+    ok_id = LanguageServerId("python")
+    failing_id = LanguageServerId("rust")
+    factory = _FakeLanguageServerFactory(fail_ids={failing_id})
+
+    with pytest.raises(LanguageServerManagerInitialisationError):
+        LanguageServerManager.from_languages([ok_id, failing_id], factory, project=None)
+
+    time.sleep(0.3)
+    pids = {ls_id: ls.proc.pid for ls_id, ls in factory.created.items() if ls.proc is not None}
+    _cleanup_leftover_pids.extend(pids.values())
+
+    assert set(pids) == {ok_id, failing_id}
+    assert not _pid_alive(pids[ok_id]), "the successfully-started server's process should be stopped"
+    assert not _pid_alive(pids[failing_id]), "the process spawned by the server that raised post-spawn must not leak"

--- a/test/serena/test_ls_manager.py
+++ b/test/serena/test_ls_manager.py
@@ -29,11 +29,14 @@ class _FakeLanguageServer:
         self._running = False
 
     def start(self) -> "_FakeLanguageServer":
-        # Mirrors e.g. clangd_language_server.py: the OS subprocess is spawned as part of
-        # start(), and a capability/initialize() check can still raise after that process
-        # is already running.
+        # Mirrors SolidLanguageServer.start(): the OS subprocess is spawned as part of
+        # start(), a capability/initialize() check can still raise after that process is
+        # already running, and start() stops the process it just spawned before re-raising
+        # (see SolidLanguageServer.start).
         self.proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(100)"])
         if self.should_fail:
+            self._running = True
+            self.stop()
             raise RuntimeError(f"simulated: capability assertion failed after initialize() ({self.ls_id.value})")
         self._running = True
         return self
@@ -77,10 +80,12 @@ def _cleanup_leftover_pids():
 
 
 def test_from_languages_stops_process_of_server_that_raises_after_spawning(_cleanup_leftover_pids):
-    """A language server whose `start()` spawns its OS subprocess and then raises (e.g. a
-    capability assertion or an initialize() timeout firing after the process is already up)
-    must still have that process stopped by `from_languages`'s failure-path cleanup, exactly
-    like a server that started successfully and is stopped because a sibling failed.
+    """End-to-end: a language server whose `start()` spawns its OS subprocess and then raises
+    (e.g. a capability assertion or an initialize() timeout firing after the process is
+    already up) must not leak that process, and a sibling that started successfully must be
+    stopped too since `from_languages` fails the whole batch. The failing server cleans up its
+    own process (SolidLanguageServer.start()); `from_languages` is responsible only for
+    stopping the siblings that succeeded.
     """
     ok_id = LanguageServerId("python")
     failing_id = LanguageServerId("rust")

--- a/test/serena/test_ls_manager.py
+++ b/test/serena/test_ls_manager.py
@@ -1,8 +1,8 @@
-import os
 import subprocess
 import sys
 import time
 
+import psutil
 import pytest
 
 from serena.ls_manager import LanguageServerManager, LanguageServerManagerInitialisationError
@@ -10,11 +10,11 @@ from solidlsp.ls_config import LanguageServerId
 
 
 def _pid_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
+    # Not `os.kill(pid, 0)`: that is a no-op liveness probe on POSIX, but on Windows
+    # `os.kill` has no signal-0 special case and falls through to `TerminateProcess(handle,
+    # 0)`, so the "check" can itself kill (or, if the pid was already recycled, terminate an
+    # unrelated process) instead of only reading process-table state.
+    return psutil.pid_exists(pid)
 
 
 class _FakeLanguageServer:
@@ -70,8 +70,10 @@ def _cleanup_leftover_pids():
     pids: list[int] = []
     yield pids
     for pid in pids:
-        if _pid_alive(pid):
-            os.kill(pid, 15)
+        try:
+            psutil.Process(pid).kill()
+        except psutil.NoSuchProcess:
+            pass
 
 
 def test_from_languages_stops_process_of_server_that_raises_after_spawning(_cleanup_leftover_pids):

--- a/test/solidlsp/test_ls_start_cleanup.py
+++ b/test/solidlsp/test_ls_start_cleanup.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from solidlsp.ls import SolidLanguageServer
+
+
+class _RaisingLanguageServer(SolidLanguageServer):
+    """Bypasses SolidLanguageServer.__init__ (like DummyLanguageServer in
+    test_rename_didopen.py) so _start_server can be made to raise after the underlying
+    process is already considered running, without spinning up a real language server.
+    """
+
+    def _start_server(self) -> None:
+        raise RuntimeError("simulated: capability assertion failed after initialize()")
+
+    def _create_base_initialize_params(self) -> dict:
+        return {}
+
+
+def _make_server(is_running: bool) -> _RaisingLanguageServer:
+    server = object.__new__(_RaisingLanguageServer)
+    server.ls_id = "python"
+    server.repository_root_path = "/tmp/project"
+    server.server_started = False
+    server.server = MagicMock()
+    server.server.is_running.return_value = is_running
+    return server
+
+
+def test_start_stops_process_when_start_server_raises_after_spawning():
+    """_start_server() spawning the OS process and then raising (e.g. a capability
+    assertion or an initialize() timeout firing post-spawn) must not leak that process:
+    start() itself stops it before re-raising.
+    """
+    server = _make_server(is_running=True)
+
+    with pytest.raises(RuntimeError, match="capability assertion"):
+        server.start()
+
+    server.server.stop.assert_called_once()
+    assert server.server_started is False
+
+
+def test_start_does_not_call_stop_when_start_server_raises_before_spawning():
+    """When _start_server() raises before any process was ever spawned (e.g. the language
+    server binary is missing), there is nothing to stop.
+    """
+    server = _make_server(is_running=False)
+
+    with pytest.raises(RuntimeError, match="capability assertion"):
+        server.start()
+
+    server.server.stop.assert_not_called()
+    assert server.server_started is False


### PR DESCRIPTION
## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`.

Fixes #1949

## Root cause

`LanguageServerManager.from_languages` starts one language server per language in a
`StartLSThread`. Each thread sets `self.language_server` to the object
`factory.create_language_server(...)` returns, then calls `.start()` on it. When
`.start()` raises after the underlying OS subprocess is already running, the
collection loop only adds a thread's server to `language_servers` if `thread.exception
is None`, so the failed thread's server is never in that dict. The failure-path
cleanup (`for ls in language_servers.values(): ls.stop()`) then never sees it, and its
subprocess keeps running for the rest of the session.

## Fix

Track every thread's `language_server` in a separate `spawned_servers` list,
independent of whether that thread's start raised, and `.stop()` all of them on the
failure path. `language_servers` (the dict returned to the caller on success) is
unchanged.

## Verification

- New regression test `test_from_languages_stops_process_of_server_that_raises_after_spawning`
  (`test/serena/test_ls_manager.py`) spawns a real subprocess from each of two
  duck-typed fake language servers, one of which raises after spawning; it fails on
  `main` (the failing server's process is still alive after `from_languages` raises)
  and passes on this branch.
- `test/serena/` (excluding tests that need a language-server toolchain or a GUI, both
  unavailable in the sandbox): 720 passed, 10 skipped, no regressions; the toolchain-
  and GUI-dependent failures are pre-existing on unmodified `main` in the same
  sandbox.
- `ruff check`/`ruff format --check src scripts test`, and `codespell` (run separately,
  matching the CI job, which does not have a `.venv` present): clean.
- Not verified: behavior of the real (non-fake) language server adapters that can
  raise post-spawn (e.g. `clangd_language_server.py`); the regression test uses a
  duck-typed fake, matching how `from_languages` itself treats the object (no
  isinstance checks).
