### PR TITLE
fix(nix): use schema-valid default nixd options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Status of the `main` branch. Changes prior to the next official version change w
   - Fix: `read_only` restriction in project definition was not applied to base tool set when in single-project context (#1938)
 
 * Language Servers:
+  - Fix: nixd's built-in `options` configuration now uses a schema-valid provider map (#1948)
   - Fix: Dart's `$/analyzerStatus` notifications were logged as unhandled-method warnings during analysis (#1855)
   - Fix: clojure-lsp was not told that Serena sends `workspace/didChangeWatchedFiles`, so changes made
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate

--- a/src/solidlsp/language_servers/nixd_ls.py
+++ b/src/solidlsp/language_servers/nixd_ls.py
@@ -225,12 +225,7 @@ class NixLanguageServer(SolidLanguageServer):
         return {
             "nixpkgs": {"expr": "import <nixpkgs> { }"},
             "formatting": {"command": ["nixpkgs-fmt"]},
-            "options": {
-                "enable": True,
-                "target": {
-                    "installable": "",
-                },
-            },
+            "options": {},
         }
 
     @classmethod

--- a/test/solidlsp/nix/test_nix_server.py
+++ b/test/solidlsp/nix/test_nix_server.py
@@ -63,15 +63,15 @@ def test_default_launch_command_uses_managed_dependency_resolution(tmp_path: Pat
     managed_resolution.assert_called_once_with()
 
 
-def test_default_nixd_settings_preserve_existing_behavior() -> None:
-    assert NixLanguageServer._load_nixd_settings(SolidLSPSettings.CustomLSSettings({})) == {
+def test_default_nixd_settings_use_schema_valid_options_map() -> None:
+    settings = NixLanguageServer._load_nixd_settings(SolidLSPSettings.CustomLSSettings({}))
+
+    assert settings == {
         "nixpkgs": {"expr": "import <nixpkgs> { }"},
         "formatting": {"command": ["nixpkgs-fmt"]},
-        "options": {
-            "enable": True,
-            "target": {"installable": ""},
-        },
+        "options": {},
     }
+    assert NixLanguageServer._get_workspace_configuration({"items": [{"section": "nixd.options"}]}, settings) == [{}]
 
 
 def test_config_path_loads_bare_nixd_settings_object(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #1948

When no Nix-specific configuration is supplied, Serena now sends nixd an empty provider map for `options`. This matches nixd's schema while preserving all custom `config_path` settings unchanged.

## Changes

- Replace the invalid default `options.enable`/`options.target` structure with `options: {}`.
- Extend the focused nixd test to assert the default workspace configuration response.
- Document the fix in `CHANGELOG.md`.

## Tests

- `uv run pytest test/solidlsp/nix/test_nix_server.py -q` (17 passed)
- `uv run poe lint` (ruff format and check passed)
- `uv run poe type-check` (core and test checks passed)
