### PR TITLE
feat(dashboard): allow a dedicated advertised host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     detection #1766
 
 * Dashboard:
+  - Add optional `web_dashboard_advertised_host` configuration so local users can give the dashboard
+    a dedicated browser origin without changing its loopback bind address
   - Fix: Serena PyPI version check triggered by callback on main thread could delay agent startup #1774
   - Improvements in `tray_manager` interface mode:
     - Fix: on macOS, the `tray_manager` interface put an icon in the Dock and in the app switcher

--- a/docs/02-usage/060_dashboard.md
+++ b/docs/02-usage/060_dashboard.md
@@ -30,6 +30,21 @@ Configure your preferred interface via the setting `web_dashboard_interface` in 
 By default, the dashboard can be accessed at `http://localhost:24282/dashboard/index.html`,
 but a higher port may be used if the default port is unavailable/multiple instances are running.
 
+For local development, you can give the dashboard its own browser origin while keeping it bound
+to loopback:
+
+```yaml
+web_dashboard_listen_address: 127.0.0.1
+web_dashboard_advertised_host: serena.localhost
+web_dashboard_trusted_hosts:
+  - 127.0.0.1
+  - localhost
+  - serena.localhost
+```
+
+This is useful when other local applications use `localhost`, because browser caches and other
+origin-scoped state stay separated. `*.localhost` resolves to loopback in modern browsers.
+
 ### Features
 
 The dashboard provides ...

--- a/src/serena/agent.py
+++ b/src/serena/agent.py
@@ -410,6 +410,7 @@ class DashboardManager:
         open_dashboard_on_launch: bool,
         active_project: Project | None = None,
         mode_str: str | None = None,
+        advertised_host: str | None = None,
     ):
         # determine requested mode
         if mode_str is not None:
@@ -435,7 +436,7 @@ class DashboardManager:
         self._dashboard_viewer_process: multiprocessing.Process | None = None
         self._tray_manager_lock = threading.Lock()
 
-        dashboard_host = host_listen_address
+        dashboard_host = advertised_host or host_listen_address
         if dashboard_host == "0.0.0.0":
             dashboard_host = "localhost"
         self.url = f"http://{dashboard_host}:{port}/dashboard/index.html"
@@ -713,6 +714,7 @@ class SerenaAgent:
                 self.serena_config.web_dashboard_open_on_launch,
                 self._active_project,
                 mode_str=self.serena_config.web_dashboard_interface,
+                advertised_host=self.serena_config.web_dashboard_advertised_host,
             )
             log.info("Serena web dashboard started at %s", self._dashboard_manager.url)
             # inform the GUI window (if any)

--- a/src/serena/config/serena_config.py
+++ b/src/serena/config/serena_config.py
@@ -881,6 +881,7 @@ class SerenaConfig(SharedConfig, ModeSelectionDefinitionWithBaseModes):
     web_dashboard_open_on_launch: bool = True
     web_dashboard_interface: str | None = None
     web_dashboard_listen_address: str = "127.0.0.1"
+    web_dashboard_advertised_host: str | None = None
     web_dashboard_trusted_hosts: list[str] = field(default_factory=lambda: ["127.0.0.1", "localhost"])
     jetbrains_plugin_server_address: str = "127.0.0.1"
     jetbrains_launch_command: str | None = None

--- a/src/serena/resources/serena_config.template.yml
+++ b/src/serena/resources/serena_config.template.yml
@@ -69,6 +69,11 @@ web_dashboard_interface:
 # the address the web dashboard will listen on (bind address).
 web_dashboard_listen_address: 127.0.0.1
 
+# optional hostname to use in generated dashboard URLs. This does not change the bind address;
+# for example, use `serena.localhost` to keep the dashboard's browser origin separate from other
+# local applications. Add the hostname to `web_dashboard_trusted_hosts` when using this setting.
+web_dashboard_advertised_host:
+
 # trusted hosts used to access the web dashboard.
 # By default, only allow access via local addresses for security reasons.
 # If you want to allow access from remote machines, add the hostname used to access the dashboard to this list.

--- a/test/serena/test_dashboard.py
+++ b/test/serena/test_dashboard.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from types import SimpleNamespace
 
+from serena.agent import DashboardManager
 from serena.dashboard import SerenaDashboardAPI
 from solidlsp.ls_config import LanguageServerId
 
@@ -51,3 +52,15 @@ def test_available_languages_exclude_project_languages():
     assert LanguageServerId.MARKDOWN.value not in available
     # ensure experimental languages remain available for selection
     assert LanguageServerId.ANSIBLE.value in available
+
+
+def test_dashboard_manager_uses_advertised_host_for_dashboard_url():
+    dashboard = DashboardManager(
+        port=24283,
+        host_listen_address="127.0.0.1",
+        advertised_host="serena.localhost",
+        open_dashboard_on_launch=False,
+        mode_str="browser",
+    )
+
+    assert dashboard.url == "http://serena.localhost:24283/dashboard/index.html"


### PR DESCRIPTION
## What

Adds an opt-in `web_dashboard_advertised_host` setting so the dashboard can use a dedicated local browser origin such as `serena.localhost` without changing its loopback bind address.

This keeps local browser caches and other origin-scoped state separate from applications using `localhost`.

The change is intentionally small and opt-in; if this is not a direction the maintainers want, no problem.

## Verification

- `uv run pytest test/serena/test_dashboard.py test/serena/config/test_serena_config.py -q` — 55 passed
- `uv run poe lint` — passed
- `uv run poe type-check` — passed
- `git diff --check` — passed

The broader agent suite has unrelated local-environment failures for missing language servers (gopls, .NET, Rust analyzer, PowerShell, etc.).
