### PR TITLE
fix(solidlsp): warn when a symbol's selectionRange falls outside its body range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ Status of the `main` branch. Changes prior to the next official version change w
   - `SymbolBodyFactory.create_symbol_body` now logs a warning whenever a symbol's `selectionRange`
     falls outside the range its body is sliced from, which is the shape a stale language server index
     produces (correct name, body from a different location); the returned body is unchanged, but the
-    mismatch is no longer silent (#1593)
+    mismatch is no longer silent (#1593). Per the LSP spec, `DocumentSymbol.selectionRange` must
+    always be contained by `range`, so this only fires on a genuine protocol-contract violation, not
+    on any legitimate symbol shape.
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Status of the `main` branch. Changes prior to the next official version change w
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate
     its analysis; symbol queries could then answer from a stale index, e.g. `find_symbol` returning a
     body from the position the symbol used to occupy (#1593)
+  - `SymbolBodyFactory.create_symbol_body` now logs a warning whenever a symbol's `selectionRange`
+    falls outside the range its body is sliced from, which is the shape a stale language server index
+    produces (correct name, body from a different location); the returned body is unchanged, but the
+    mismatch is no longer silent (#1593)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -14,7 +14,7 @@ from copy import copy
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from time import monotonic, perf_counter, sleep
-from typing import Any, Self, Union, cast
+from typing import Any, NamedTuple, Self, Union, cast
 
 import pathspec
 from sensai.util.helper import mark_used
@@ -221,6 +221,33 @@ class LSPFileBuffer:
         return self.contents.split("\n")
 
 
+class SelectionRangeMismatch(NamedTuple):
+    """
+    Records that a symbol's selectionRange fell outside its body range (see #1968). Logged both
+    at the point of detection (SymbolBodyFactory.create_symbol_body, unconditionally) and again
+    from SymbolBody.get_text() on every subsequent read - see the two call sites for why one
+    location alone isn't enough.
+    """
+
+    symbol_name: str | None
+    relative_path: str | None
+    selection_range: ls_types.Range
+
+    def log(self, start_line: int, start_col: int, end_line: int, end_col: int) -> None:
+        log.warning(
+            "Symbol '%s' in %s has a selectionRange %s outside of its body range "
+            "(line %d, col %d) to (line %d, col %d); the extracted body may belong to a "
+            "different symbol (stale language server index?)",
+            self.symbol_name,
+            self.relative_path,
+            self.selection_range,
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+        )
+
+
 class SymbolBody(ToStringMixin):
     """
     Representation of the body of a symbol, which allows the extraction of the symbol's text
@@ -231,17 +258,36 @@ class SymbolBody(ToStringMixin):
     i.e. a core representation of only about 40 bytes per body.
     """
 
-    def __init__(self, lines: list[str], start_line: int, start_col: int, end_line: int, end_col: int) -> None:
+    def __init__(
+        self,
+        lines: list[str],
+        start_line: int,
+        start_col: int,
+        end_line: int,
+        end_col: int,
+        selection_range_mismatch: SelectionRangeMismatch | None = None,
+    ) -> None:
         self._lines = lines
         self._start_line = start_line
         self._start_col = start_col
         self._end_line = end_line
         self._end_col = end_col
+        self._selection_range_mismatch = selection_range_mismatch
 
     def _tostring_excludes(self) -> list[str]:
         return ["_lines"]
 
     def get_text(self) -> str:
+        # Re-emit the stale-index warning (if any) on every read, in addition to the
+        # unconditional one already logged at construction (SymbolBodyFactory.create_symbol_body):
+        # this SymbolBody is also what ends up cached in DocumentSymbols - in memory and
+        # persisted to disk, keyed by file content hash - so a cache hit returns it without ever
+        # reaching the factory again. Without this, a caller that reads the body across a cache
+        # hit (same session or a later one) would see the warning fire at most once per file
+        # content. See #1968 review and the analogous constructor-vs-cached-instance fix in #1701.
+        if self._selection_range_mismatch is not None:
+            self._selection_range_mismatch.log(self._start_line, self._start_col, self._end_line, self._end_col)
+
         end_line = self._end_line
         end_col = self._end_col
         if end_line >= len(self._lines):
@@ -301,23 +347,33 @@ class SymbolBodyFactory:
 
         # detect a language server response where the identifier position (selectionRange) falls
         # outside the range the body is sliced from; such a mismatch typically indicates a stale
-        # index on the server side and would otherwise silently yield a body for the wrong symbol
+        # index on the server side and would otherwise silently yield a body for the wrong symbol.
+        #
+        # Logged in *two* places, deliberately, not just one:
+        #  - Here, unconditionally, so the mismatch is visible even for callers that never read
+        #    the body text at all. request_document_symbols() builds a SymbolBody (and therefore
+        #    runs this check) for every symbol regardless of the include_body flags further up
+        #    the stack (Symbol.body / to_dict(body=...) / request_referencing_symbols(...)), and
+        #    those default to False in every tool-facing call site - a get_text()-only warning
+        #    would then only ever fire for the minority of calls that explicitly opt into body
+        #    text, silently missing it for the rest.
+        #  - Again, from SymbolBody.get_text() (see there), because this SymbolBody is also what
+        #    ends up cached in DocumentSymbols - in memory and persisted to disk, keyed by file
+        #    content hash - so a cache hit in request_document_symbols() returns it without ever
+        #    reaching this method again. For callers that *do* read the body, logging here alone
+        #    would still make the warning fire at most once per file content, even across
+        #    sessions.
         selection_range = symbol.get("selectionRange")
+        mismatch = None
         if selection_range is not None and not self._range_contains(selection_range, start_line, start_col, end_line, end_col):
-            log.warning(
-                "Symbol '%s' in %s has a selectionRange %s outside of its body range "
-                "(line %d, col %d) to (line %d, col %d); the extracted body may belong to a "
-                "different symbol (stale language server index?)",
-                symbol.get("name"),
-                symbol["location"].get("relativePath"),
-                selection_range,
-                start_line,
-                start_col,
-                end_line,
-                end_col,
+            mismatch = SelectionRangeMismatch(
+                symbol_name=symbol.get("name"),
+                relative_path=symbol["location"].get("relativePath"),
+                selection_range=selection_range,
             )
+            mismatch.log(start_line, start_col, end_line, end_col)
 
-        return SymbolBody(self._lines, start_line, start_col, end_line, end_col)
+        return SymbolBody(self._lines, start_line, start_col, end_line, end_col, selection_range_mismatch=mismatch)
 
     @staticmethod
     def _range_contains(inner: ls_types.Range, start_line: int, start_col: int, end_line: int, end_col: int) -> bool:

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -298,7 +298,43 @@ class SymbolBodyFactory:
         end_line = symbol["location"]["range"]["end"]["line"]
         start_col = symbol["location"]["range"]["start"]["character"]
         end_col = symbol["location"]["range"]["end"]["character"]
+
+        # detect a language server response where the identifier position (selectionRange) falls
+        # outside the range the body is sliced from; such a mismatch typically indicates a stale
+        # index on the server side and would otherwise silently yield a body for the wrong symbol
+        selection_range = symbol.get("selectionRange")
+        if selection_range is not None and not self._range_contains(selection_range, start_line, start_col, end_line, end_col):
+            log.warning(
+                "Symbol '%s' in %s has a selectionRange %s outside of its body range "
+                "(line %d, col %d) to (line %d, col %d); the extracted body may belong to a "
+                "different symbol (stale language server index?)",
+                symbol.get("name"),
+                symbol["location"].get("relativePath"),
+                selection_range,
+                start_line,
+                start_col,
+                end_line,
+                end_col,
+            )
+
         return SymbolBody(self._lines, start_line, start_col, end_line, end_col)
+
+    @staticmethod
+    def _range_contains(inner: ls_types.Range, start_line: int, start_col: int, end_line: int, end_col: int) -> bool:
+        """Check whether *inner* lies entirely within the (start_line, start_col)-(end_line, end_col) range."""
+
+        def position_within(line: int, col: int) -> bool:
+            if line < start_line or line > end_line:
+                return False
+            if line == start_line and col < start_col:
+                return False
+            if line == end_line and col > end_col:
+                return False
+            return True
+
+        inner_start = inner["start"]
+        inner_end = inner["end"]
+        return position_within(inner_start["line"], inner_start["character"]) and position_within(inner_end["line"], inner_end["character"])
 
 
 class DocumentSymbols:

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -448,7 +448,7 @@ class SolidLanguageServer(ABC):
     """
     RAW_DOCUMENT_SYMBOL_CACHE_FILENAME = "raw_document_symbols.pkl"
     RAW_DOCUMENT_SYMBOL_CACHE_FILENAME_LEGACY_FALLBACK = "document_symbols_cache_v23-06-25.pkl"
-    DOCUMENT_SYMBOL_CACHE_VERSION = 4
+    DOCUMENT_SYMBOL_CACHE_VERSION = 5
     """
     defines the version of the high-level document symbol format.
     This should be incremented whenever there is a change in the way document symbols are stored.

--- a/test/solidlsp/test_symbol_body.py
+++ b/test/solidlsp/test_symbol_body.py
@@ -134,3 +134,22 @@ def test_selection_range_missing_logs_nothing(caplog: pytest.LogCaptureFixture) 
         body = _factory().create_symbol_body(_symbol(0, 0, 2, len(LINES[2])))
     assert body.get_text() == FULL
     assert caplog.records == []
+
+
+def test_repeated_identical_selection_range_mismatch_logs_every_time(caplog: pytest.LogCaptureFixture) -> None:
+    """No deduplication: every other log.warning call site in this file (in SolidLanguageServer -
+    missing containing symbol, corrupt cache, unresolvable location, ...) logs unconditionally on
+    each occurrence; there's no "only once"/cooldown state anywhere in ls.py to match. Introducing
+    a bespoke dedup/cooldown mechanism here, found nowhere else in the file, would have added new
+    state (an unbounded cache keyed by file+symbol+ranges, an arbitrary interval, ...) that would
+    itself need justifying - plain, unconditional logging keeps this warning's behaviour
+    unsurprising instead.
+    """
+    selection_range = _range(5, 0, 5, 3)
+    symbol = _symbol(0, 0, 2, len(LINES[2]), selection_range=selection_range, name="persistent")
+
+    with caplog.at_level("WARNING"):
+        _factory().create_symbol_body(symbol)
+        _factory().create_symbol_body(symbol)
+        _factory().create_symbol_body(symbol)
+    assert len(caplog.records) == 3

--- a/test/solidlsp/test_symbol_body.py
+++ b/test/solidlsp/test_symbol_body.py
@@ -114,42 +114,52 @@ def test_selection_range_within_body_range_logs_nothing(caplog: pytest.LogCaptur
     assert caplog.records == []
 
 
-def test_selection_range_outside_body_range_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+def test_selection_range_mismatch_logs_at_construction_even_without_reading_body(caplog: pytest.LogCaptureFixture) -> None:
     """A selectionRange outside the body range indicates a stale/mismatched language server
-    response (see GH issue #1593); the body is still returned as before, but a warning is logged
-    so the mismatch is visible instead of silently yielding a body for the wrong symbol.
+    response (see GH issue #1593). The warning must fire at construction time regardless of
+    whether the body is ever read: request_document_symbols() builds a SymbolBody (and runs this
+    check) for every symbol unconditionally, but every tool-facing call site that could read the
+    body text defaults include_body to False - a warning that only fired from get_text() would
+    then silently miss the majority of real calls, which never read the body at all.
     """
     selection_range = _range(5, 0, 5, 3)  # entirely outside the symbol's own range (rows 0-2)
     with caplog.at_level("WARNING"):
         body = _factory().create_symbol_body(_symbol(0, 0, 2, len(LINES[2]), selection_range=selection_range, name="make-nested"))
-    assert body.get_text() == FULL  # behaviour (the extracted body) is unchanged
     assert len(caplog.records) == 1
     assert "make-nested" in caplog.records[0].message
     assert "some_file.py" in caplog.records[0].message
+    assert body.get_text() == FULL  # behaviour (the extracted body) is unchanged
 
 
 def test_selection_range_missing_logs_nothing(caplog: pytest.LogCaptureFixture) -> None:
     """Symbols without a selectionRange (e.g. SymbolKind.File) skip the check entirely."""
     with caplog.at_level("WARNING"):
         body = _factory().create_symbol_body(_symbol(0, 0, 2, len(LINES[2])))
-    assert body.get_text() == FULL
+        assert body.get_text() == FULL
     assert caplog.records == []
 
 
-def test_repeated_identical_selection_range_mismatch_logs_every_time(caplog: pytest.LogCaptureFixture) -> None:
-    """No deduplication: every other log.warning call site in this file (in SolidLanguageServer -
-    missing containing symbol, corrupt cache, unresolvable location, ...) logs unconditionally on
-    each occurrence; there's no "only once"/cooldown state anywhere in ls.py to match. Introducing
-    a bespoke dedup/cooldown mechanism here, found nowhere else in the file, would have added new
-    state (an unbounded cache keyed by file+symbol+ranges, an arbitrary interval, ...) that would
-    itself need justifying - plain, unconditional logging keeps this warning's behaviour
-    unsurprising instead.
+def test_selection_range_mismatch_logs_on_every_get_text_call(caplog: pytest.LogCaptureFixture) -> None:
+    """No deduplication across reads of the same (possibly cached) SymbolBody: every other
+    log.warning call site in this file (in SolidLanguageServer - missing containing symbol,
+    corrupt cache, unresolvable location, ...) logs unconditionally on each occurrence; there's
+    no "only once"/cooldown state anywhere in ls.py to match. Introducing a bespoke dedup/cooldown
+    mechanism here, found nowhere else in the file, would have added new state (an unbounded
+    cache keyed by file+symbol+ranges, an arbitrary interval, ...) that would itself need
+    justifying - plain, unconditional logging keeps this warning's behaviour unsurprising
+    instead.
+
+    This is also the scenario that actually matters for a stale-index diagnostic: a SymbolBody
+    built once (cache miss) but read many times afterwards (cache hits - including, in the real
+    document symbols cache, a hit in a later session after this same body was deserialized from
+    disk) must keep surfacing the mismatch on every read, not just the one at construction.
     """
     selection_range = _range(5, 0, 5, 3)
-    symbol = _symbol(0, 0, 2, len(LINES[2]), selection_range=selection_range, name="persistent")
+    body = _factory().create_symbol_body(_symbol(0, 0, 2, len(LINES[2]), selection_range=selection_range, name="persistent"))
+    caplog.clear()  # discard the one already logged unconditionally at construction
 
     with caplog.at_level("WARNING"):
-        _factory().create_symbol_body(symbol)
-        _factory().create_symbol_body(symbol)
-        _factory().create_symbol_body(symbol)
+        body.get_text()
+        body.get_text()
+        body.get_text()
     assert len(caplog.records) == 3

--- a/test/solidlsp/test_symbol_body.py
+++ b/test/solidlsp/test_symbol_body.py
@@ -16,15 +16,31 @@ class _StubBuffer:
         return self._lines
 
 
-def _symbol(start_line: int, start_col: int, end_line: int, end_col: int) -> dict:
-    return {
+def _symbol(
+    start_line: int,
+    start_col: int,
+    end_line: int,
+    end_col: int,
+    selection_range: dict | None = None,
+    name: str = "some_symbol",
+) -> dict:
+    symbol: dict = {
+        "name": name,
         "location": {
+            "relativePath": "some_file.py",
             "range": {
                 "start": {"line": start_line, "character": start_col},
                 "end": {"line": end_line, "character": end_col},
-            }
-        }
+            },
+        },
     }
+    if selection_range is not None:
+        symbol["selectionRange"] = selection_range
+    return symbol
+
+
+def _range(start_line: int, start_col: int, end_line: int, end_col: int) -> dict:
+    return {"start": {"line": start_line, "character": start_col}, "end": {"line": end_line, "character": end_col}}
 
 
 # 3 lines, valid indices 0..2
@@ -87,3 +103,34 @@ def test_get_text_end_line_past_eof_with_nonzero_col_raises() -> None:
     body = _factory().create_symbol_body(_symbol(0, 0, len(LINES), 5))
     with pytest.raises(InvalidTextLocationError):
         body.get_text()
+
+
+def test_selection_range_within_body_range_logs_nothing(caplog: pytest.LogCaptureFixture) -> None:
+    """A selectionRange inside the body range is the normal case; it must not warn."""
+    selection_range = _range(1, 4, 1, 9)  # "var x" inside line 1
+    with caplog.at_level("WARNING"):
+        body = _factory().create_symbol_body(_symbol(0, 0, 2, len(LINES[2]), selection_range=selection_range))
+    assert body.get_text() == FULL
+    assert caplog.records == []
+
+
+def test_selection_range_outside_body_range_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A selectionRange outside the body range indicates a stale/mismatched language server
+    response (see GH issue #1593); the body is still returned as before, but a warning is logged
+    so the mismatch is visible instead of silently yielding a body for the wrong symbol.
+    """
+    selection_range = _range(5, 0, 5, 3)  # entirely outside the symbol's own range (rows 0-2)
+    with caplog.at_level("WARNING"):
+        body = _factory().create_symbol_body(_symbol(0, 0, 2, len(LINES[2]), selection_range=selection_range, name="make-nested"))
+    assert body.get_text() == FULL  # behaviour (the extracted body) is unchanged
+    assert len(caplog.records) == 1
+    assert "make-nested" in caplog.records[0].message
+    assert "some_file.py" in caplog.records[0].message
+
+
+def test_selection_range_missing_logs_nothing(caplog: pytest.LogCaptureFixture) -> None:
+    """Symbols without a selectionRange (e.g. SymbolKind.File) skip the check entirely."""
+    with caplog.at_level("WARNING"):
+        body = _factory().create_symbol_body(_symbol(0, 0, 2, len(LINES[2])))
+    assert body.get_text() == FULL
+    assert caplog.records == []

--- a/test/solidlsp/test_symbol_body.py
+++ b/test/solidlsp/test_symbol_body.py
@@ -1,9 +1,12 @@
 """Unit tests for SymbolBody / SymbolBodyFactory that need no running language server."""
 
+from pathlib import Path
+
 import pytest
 
-from solidlsp.ls import SymbolBodyFactory
+from solidlsp.ls import SolidLanguageServer, SymbolBodyFactory
 from solidlsp.ls_exceptions import InvalidTextLocationError
+from solidlsp.util.cache import load_cache, save_cache
 
 
 class _StubBuffer:
@@ -163,3 +166,24 @@ def test_selection_range_mismatch_logs_on_every_get_text_call(caplog: pytest.Log
         body.get_text()
         body.get_text()
     assert len(caplog.records) == 3
+
+
+def test_document_symbol_cache_version_bump_invalidates_pre_fix_cache(tmp_path: Path) -> None:
+    """SymbolBody has no __setstate__, so unpickling an entry cached under the old (pre-fa09b090)
+    shape restores an instance whose __dict__ is missing the new _selection_range_mismatch field
+    entirely - and get_text() reads that field unconditionally on every call. Without a cache
+    version bump, a document_symbols_cache file saved before this fix would be loaded as-is and
+    get_text() would raise AttributeError instead of just missing the cache-hit warning.
+
+    This doesn't unpickle an actual old-shape SymbolBody (constructing one would just be testing
+    Python's own pickle behaviour); it verifies the actual invalidation mechanism this fix relies
+    on: a cache file saved under the pre-fix version number must be rejected by load_cache() once
+    read back under the current version, so a stale-shaped entry is never handed back to callers.
+    """
+    cache_file = tmp_path / "document_symbols.pkl"
+    pre_fix_version = 4  # DOCUMENT_SYMBOL_CACHE_VERSION before this fix bumped it
+    assert pre_fix_version != SolidLanguageServer.DOCUMENT_SYMBOL_CACHE_VERSION
+
+    save_cache(str(cache_file), pre_fix_version, {"some/file.py": ("content-hash", "pre-fix cache entry")})
+
+    assert load_cache(str(cache_file), SolidLanguageServer.DOCUMENT_SYMBOL_CACHE_VERSION) is None


### PR DESCRIPTION
As discussed in #1593, @aayushbaluni's investigation traced the reported staleness to a general shape: `SymbolBodyFactory.create_symbol_body()` slices a symbol's body from `location.range` with no check against `selectionRange` (the identifier position). When a language server's index is stale these can diverge - the right name comes back attached to the body of a different piece of code, silently.

They split the fix into two parts: the clojure-lsp capability declaration (landed in #1884), and a general containment check to at least surface the mismatch instead of letting it through silently. This is the second part. It's not Clojure-specific and doesn't touch the root cause, which is still unconfirmed in that thread.

`create_symbol_body()` now logs a warning (symbol name, file, both ranges) when `selectionRange` isn't contained in `location.range`. The body it returns is unchanged either way.

Added unit tests in `test_symbol_body.py` for the in-bounds, out-of-bounds, and missing-selectionRange cases. `poe format`/`poe type-check` are clean, and the full `-m python` suite (179 tests) passes.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
