### PR TITLE
fix(vue): don't mark indexing complete when every .vue file fails to open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Status of the `main` branch. Changes prior to the next official version change w
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate
     its analysis; symbol queries could then answer from a stale index, e.g. `find_symbol` returning a
     body from the position the symbol used to occupy (#1593)
+  - Fix: Vue's `_ensure_vue_files_indexed_on_ts_server` marked indexing complete even when every
+    `.vue` file failed to open on the companion TypeScript server, so a transient outage of that
+    server became a silent, permanent loss of Vue cross-file indexing for the rest of the session
+    (#1923)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,11 @@ Status of the `main` branch. Changes prior to the next official version change w
     body from the position the symbol used to occupy (#1593)
   - Fix: Vue's `_ensure_vue_files_indexed_on_ts_server` marked indexing complete even when every
     `.vue` file failed to open on the companion TypeScript server, so a transient outage of that
-    server became a silent, permanent loss of Vue cross-file indexing for the rest of the session
-    (#1923)
+    server became a silent, permanent loss of Vue cross-file indexing for the rest of the session.
+    The retry this was meant to enable was itself unreachable in practice, short-circuited by
+    `_ensure_ls_operational`'s own readiness gate before it could ever run; both are now fixed
+    together, with a backoff so a companion server that stays down doesn't turn every request
+    into a fresh full re-index attempt (#1923)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/src/solidlsp/language_servers/vue_language_server.py
+++ b/src/solidlsp/language_servers/vue_language_server.py
@@ -289,6 +289,16 @@ class VueLanguageServer(SolidLanguageServer):
             except Exception as e:
                 log.debug(f"Failed to open {vue_file} on TS server: {e}")
 
+        # a companion server that is down or unresponsive fails every open above; leave the
+        # flag unset so a later call retries instead of permanently treating a zero-file
+        # index as complete (files being found but none of them opening is the failure case
+        # to catch here, not the ordinary "no .vue files in this repo" case)
+        if vue_files and not self._indexed_vue_file_uris:
+            log.warning(
+                f"Failed to open any of the {len(vue_files)} .vue file(s) on the companion TypeScript server; will retry indexing on the next request"
+            )
+            return
+
         self._vue_files_indexed = True
         log.info("Vue file indexing on TypeScript server complete, waiting for TS server to finish processing")
 

--- a/src/solidlsp/language_servers/vue_language_server.py
+++ b/src/solidlsp/language_servers/vue_language_server.py
@@ -10,7 +10,7 @@ import shutil
 import threading
 from collections.abc import Callable
 from pathlib import Path, PurePath
-from time import sleep
+from time import monotonic, sleep
 from typing import Any
 
 from overrides import override
@@ -166,6 +166,10 @@ class VueLanguageServer(SolidLanguageServer):
 
     TS_SERVER_READY_TIMEOUT = 5.0
     VUE_SERVER_READY_TIMEOUT = 3.0
+    # a companion server that never recovers must not turn every future request into a fresh
+    # full re-index (opening every .vue file again); this puts a floor under how often a
+    # failed attempt is retried
+    VUE_INDEX_RETRY_BACKOFF_SECONDS = 30.0
 
     def __init__(self, config: LanguageServerConfig, repository_root_path: str, solidlsp_settings: SolidLSPSettings):
         vue_lsp_executable_path, self.tsdk_path, self._ts_ls_cmd = self._setup_runtime_dependencies(config, solidlsp_settings)
@@ -183,6 +187,7 @@ class VueLanguageServer(SolidLanguageServer):
         self._ts_server_started = False
         self._vue_files_indexed = False
         self._indexed_vue_file_uris: list[str] = []
+        self._vue_index_retry_after: float = 0.0
         self._ls_operational_ready_event = threading.Event()
         self._ls_operational_lock = threading.Lock()
         self._ls_operational_thread: threading.Thread | None = None
@@ -200,15 +205,36 @@ class VueLanguageServer(SolidLanguageServer):
         except Exception:
             log.exception("Error while warming up Vue language server operational state")
 
+    def _retry_vue_indexing_if_due(self) -> None:
+        """Retry Vue indexing if a previous attempt failed and the backoff window has elapsed.
+
+        Must be called while holding `_ls_operational_lock`.
+        """
+        if self._vue_files_indexed:
+            return
+        if monotonic() < self._vue_index_retry_after:
+            return
+        self._ensure_vue_files_indexed_on_ts_server()
+
     def _ensure_ls_operational(self) -> None:
-        # short-circuit completed warm-up
+        # short-circuit the one-time warm-up (server-availability check + the cross-file-
+        # reference wait) once it has completed. Vue indexing is retried below independently
+        # of this gate: a companion-server hiccup on the first attempt must not force every
+        # later request to repeat the warm-up wait just to get another indexing attempt.
         if self._ls_operational_ready_event.is_set():
+            # always take the lock rather than checking _vue_files_indexed first: an uncontended
+            # acquisition here is negligible next to the LSP request this guards, and it avoids
+            # relying on any implementation-specific guarantee about unlocked reads of shared
+            # state. _retry_vue_indexing_if_due() itself returns immediately once indexed.
+            with self._ls_operational_lock:
+                self._retry_vue_indexing_if_due()
             return
 
         # serialize the warm-up sequence
         with self._ls_operational_lock:
             # short-circuit repeated callers after waiting for the lock
             if self._ls_operational_ready_event.is_set():
+                self._retry_vue_indexing_if_due()
                 return
 
             # validate server availability
@@ -220,10 +246,16 @@ class VueLanguageServer(SolidLanguageServer):
                 sleep(self._get_wait_time_for_cross_file_referencing())
                 self._has_waited_for_cross_file_references = True
 
-            # index Vue files on the companion TypeScript server
+            # index Vue files on the companion TypeScript server; a total failure here does
+            # not block operational readiness (below) - it is retried (subject to backoff) on
+            # a later call instead
             self._ensure_vue_files_indexed_on_ts_server()
 
-            # publish operational readiness
+            # publish operational readiness. This does not wait on Vue indexing having
+            # succeeded: other request types (TS/JS definitions, renames, diagnostics) would
+            # otherwise re-run this whole method - including a full vue re-index attempt -
+            # on every single call for as long as the companion server stays down, instead of
+            # paying that cost once and proceeding.
             self._ls_operational_ready_event.set()
 
     @override
@@ -294,8 +326,10 @@ class VueLanguageServer(SolidLanguageServer):
         # index as complete (files being found but none of them opening is the failure case
         # to catch here, not the ordinary "no .vue files in this repo" case)
         if vue_files and not self._indexed_vue_file_uris:
+            self._vue_index_retry_after = monotonic() + self.VUE_INDEX_RETRY_BACKOFF_SECONDS
             log.warning(
-                f"Failed to open any of the {len(vue_files)} .vue file(s) on the companion TypeScript server; will retry indexing on the next request"
+                f"Failed to open any of the {len(vue_files)} .vue file(s) on the companion TypeScript server; "
+                f"will not retry indexing again for at least {self.VUE_INDEX_RETRY_BACKOFF_SECONDS:.0f}s"
             )
             return
 

--- a/test/solidlsp/vue/test_vue_indexing.py
+++ b/test/solidlsp/vue/test_vue_indexing.py
@@ -1,0 +1,104 @@
+"""Unit tests for VueLanguageServer._ensure_vue_files_indexed_on_ts_server that need no running
+language server, mirroring the reproduction harness from GH issue #1923.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, cast
+
+from solidlsp.language_servers.vue_language_server import VueLanguageServer
+
+
+@dataclass
+class _FakeFileBuffer:
+    uri: str
+    ref_count: int = 0
+
+
+class _FakeTSServer:
+    """Minimal stand-in for VueTypeScriptServer: only open_file()/expect_indexing() are exercised."""
+
+    def __init__(self, failing_files: frozenset[str] = frozenset()) -> None:
+        self._failing_files = failing_files
+        self.indexing_expected_count = 0
+
+    def expect_indexing(self) -> None:
+        self.indexing_expected_count += 1
+
+    @contextmanager
+    def open_file(self, relative_path: str) -> Iterator[_FakeFileBuffer]:
+        if relative_path in self._failing_files:
+            raise RuntimeError(f"companion TS server unavailable for {relative_path}")
+        yield _FakeFileBuffer(uri=f"file:///{relative_path}")
+
+
+def _make_server(vue_files: list[str], failing_files: frozenset[str] = frozenset()) -> tuple[VueLanguageServer, list[int]]:
+    """Build a bare VueLanguageServer with just enough state to exercise the indexing method.
+
+    :return: the server and a single-element list tracking how many times
+        _wait_for_ts_indexing_complete was called (a plain counter, since the method itself is
+        stubbed to a no-op).
+    """
+    srv = object.__new__(VueLanguageServer)
+    srv._vue_files_indexed = False
+    srv._indexed_vue_file_uris = []
+    srv._ts_server = cast(Any, _FakeTSServer(failing_files))
+    srv._find_all_vue_files = lambda: list(vue_files)
+    wait_calls = [0]
+    srv._wait_for_ts_indexing_complete = lambda: wait_calls.__setitem__(0, wait_calls[0] + 1)
+    return srv, wait_calls
+
+
+def test_all_files_fail_leaves_indexed_flag_unset() -> None:
+    """A companion server that is down/unresponsive fails every open; the completion flag must
+    stay False so a later call retries, instead of silently and permanently losing cross-file
+    indexing (GH #1923).
+    """
+    srv, wait_calls = _make_server(["a.vue", "b.vue"], failing_files=frozenset({"a.vue", "b.vue"}))
+    srv._ensure_vue_files_indexed_on_ts_server()
+    assert srv._vue_files_indexed is False
+    assert srv._indexed_vue_file_uris == []
+    assert wait_calls[0] == 0
+
+
+def test_all_files_succeed_sets_indexed_flag() -> None:
+    srv, wait_calls = _make_server(["a.vue", "b.vue"])
+    srv._ensure_vue_files_indexed_on_ts_server()
+    assert srv._vue_files_indexed is True
+    assert srv._indexed_vue_file_uris == ["file:///a.vue", "file:///b.vue"]
+    assert wait_calls[0] == 1
+
+
+def test_partial_failure_still_sets_indexed_flag() -> None:
+    """Some coverage is better than none; only a *total* failure defers completion."""
+    srv, wait_calls = _make_server(["a.vue", "b.vue"], failing_files=frozenset({"a.vue"}))
+    srv._ensure_vue_files_indexed_on_ts_server()
+    assert srv._vue_files_indexed is True
+    assert srv._indexed_vue_file_uris == ["file:///b.vue"]
+    assert wait_calls[0] == 1
+
+
+def test_no_vue_files_sets_indexed_flag() -> None:
+    """Nothing to index is not the failure case; it is trivially complete."""
+    srv, wait_calls = _make_server([])
+    srv._ensure_vue_files_indexed_on_ts_server()
+    assert srv._vue_files_indexed is True
+    assert srv._indexed_vue_file_uris == []
+    assert wait_calls[0] == 1
+
+
+def test_retry_after_total_failure_can_succeed() -> None:
+    """A transient companion-server outage must not be permanent: once it recovers, the next
+    call finishes indexing instead of short-circuiting on a flag that was never set.
+    """
+    srv, wait_calls = _make_server(["a.vue"], failing_files=frozenset({"a.vue"}))
+    srv._ensure_vue_files_indexed_on_ts_server()
+    assert srv._vue_files_indexed is False
+
+    # the companion server recovers; the next call should actually retry, not short-circuit
+    srv._ts_server = cast(Any, _FakeTSServer())
+    srv._ensure_vue_files_indexed_on_ts_server()
+    assert srv._vue_files_indexed is True
+    assert srv._indexed_vue_file_uris == ["file:///a.vue"]
+    assert wait_calls[0] == 1

--- a/test/solidlsp/vue/test_vue_indexing.py
+++ b/test/solidlsp/vue/test_vue_indexing.py
@@ -2,6 +2,7 @@
 language server, mirroring the reproduction harness from GH issue #1923.
 """
 
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -102,3 +103,100 @@ def test_retry_after_total_failure_can_succeed() -> None:
     assert srv._vue_files_indexed is True
     assert srv._indexed_vue_file_uris == ["file:///a.vue"]
     assert wait_calls[0] == 1
+
+
+def _make_operational_server(vue_files: list[str], failing_files: frozenset[str] = frozenset()) -> tuple[VueLanguageServer, list[int]]:
+    """Build a bare VueLanguageServer with the `_ensure_ls_operational` state machine wired up,
+    on top of the same indexing stand-ins as `_make_server`.
+
+    :return: the server and a single-element list tracking how many times the (stubbed)
+        cross-file-reference wait actually ran.
+    """
+    srv, _ = _make_server(vue_files, failing_files)
+    srv.server_started = True
+    srv._ls_operational_ready_event = threading.Event()
+    srv._ls_operational_lock = threading.Lock()
+    srv._has_waited_for_cross_file_references = False
+    wait_calls = [0]
+    srv._get_wait_time_for_cross_file_referencing = lambda: 0
+    real_ensure_ls_operational = VueLanguageServer._ensure_ls_operational.__get__(srv)
+
+    def _ensure_ls_operational_counting_sleeps() -> None:
+        had_waited = srv._has_waited_for_cross_file_references
+        real_ensure_ls_operational()
+        if not had_waited and srv._has_waited_for_cross_file_references:
+            wait_calls[0] += 1
+
+    srv._ensure_ls_operational = _ensure_ls_operational_counting_sleeps  # type: ignore[method-assign]
+    return srv, wait_calls
+
+
+def test_ensure_ls_operational_retries_vue_indexing_on_a_later_call() -> None:
+    """GH review on #1970: a total failure on the first `_ensure_ls_operational()` call must
+    actually be retried by a *later* call, not just by calling
+    `_ensure_vue_files_indexed_on_ts_server` directly in isolation (the gap that let the
+    original fix through: `_ensure_ls_operational` unconditionally sets the ready event, which
+    every real caller short-circuits on before ever reaching the retry).
+    """
+    srv, wait_calls = _make_operational_server(["a.vue"], failing_files=frozenset({"a.vue"}))
+
+    srv._ensure_ls_operational()
+    assert srv._vue_files_indexed is False
+    assert srv._ls_operational_ready_event.is_set(), "other request types must not be blocked by a failed vue index"
+
+    # companion server recovers; a later call (as any real request handler makes) must retry.
+    # Simulates the backoff window having elapsed (see the dedicated backoff test below for the
+    # window itself) rather than actually sleeping VUE_INDEX_RETRY_BACKOFF_SECONDS in a test.
+    srv._ts_server = cast(Any, _FakeTSServer())
+    srv._vue_index_retry_after = 0
+    srv._ensure_ls_operational()
+    assert srv._vue_files_indexed is True
+    assert srv._indexed_vue_file_uris == ["file:///a.vue"]
+
+    # the one-time cross-file-reference wait must not repeat just to retry vue indexing
+    assert wait_calls[0] == 1
+
+
+def test_ensure_ls_operational_does_not_rewait_or_block_readiness_on_permanent_vue_failure() -> None:
+    """A companion server that never recovers must not turn every future request into a
+    repeated cross-file-reference wait, and must not prevent operational readiness from ever
+    being reached - every other request type (TS/JS definitions, renames, diagnostics) would
+    otherwise re-run this whole method, including a full vue re-index attempt, on every single
+    call for as long as the companion server stays down.
+    """
+    srv, wait_calls = _make_operational_server(["a.vue"], failing_files=frozenset({"a.vue"}))
+
+    for _ in range(3):
+        srv._ensure_ls_operational()
+        assert srv._vue_files_indexed is False
+        assert srv._ls_operational_ready_event.is_set()
+
+    # still only one cross-file-reference wait across all 3 calls
+    assert wait_calls[0] == 1
+    # and only one indexing attempt: the backoff (tested directly below) suppresses the 2nd
+    # and 3rd calls' retries, since they happen well within VUE_INDEX_RETRY_BACKOFF_SECONDS of
+    # the first - without it, a permanently-broken companion server would make every single
+    # future request (of any kind, not just vue-related) re-open every .vue file in the repo
+    assert cast(Any, srv._ts_server).indexing_expected_count == 1
+
+
+def test_ensure_ls_operational_backs_off_between_retries() -> None:
+    """A failed attempt must not be retried again until VUE_INDEX_RETRY_BACKOFF_SECONDS have
+    passed, even if the companion server has since recovered - otherwise every request in that
+    window would still pay the cost of reopening every .vue file, just to fail.
+    """
+    srv, _ = _make_operational_server(["a.vue"], failing_files=frozenset({"a.vue"}))
+    srv._ensure_ls_operational()
+    assert srv._vue_files_indexed is False
+
+    # companion server recovers immediately, but the backoff window has not elapsed yet
+    srv._ts_server = cast(Any, _FakeTSServer())
+    srv._ensure_ls_operational()
+    assert srv._vue_files_indexed is False, "must not retry before the backoff window elapses"
+    assert cast(Any, srv._ts_server).indexing_expected_count == 0
+
+    # simulate the backoff window having elapsed
+    srv._vue_index_retry_after = 0
+    srv._ensure_ls_operational()
+    assert srv._vue_files_indexed is True
+    assert cast(Any, srv._ts_server).indexing_expected_count == 1

--- a/test/solidlsp/vue/test_vue_indexing.py
+++ b/test/solidlsp/vue/test_vue_indexing.py
@@ -118,7 +118,7 @@ def _make_operational_server(vue_files: list[str], failing_files: frozenset[str]
     srv._ls_operational_lock = threading.Lock()
     srv._has_waited_for_cross_file_references = False
     wait_calls = [0]
-    srv._get_wait_time_for_cross_file_referencing = lambda: 0
+    srv._get_wait_time_for_cross_file_referencing = lambda: 0  # type: ignore[method-assign]
     real_ensure_ls_operational = VueLanguageServer._ensure_ls_operational.__get__(srv)
 
     def _ensure_ls_operational_counting_sleeps() -> None:
@@ -193,7 +193,7 @@ def test_ensure_ls_operational_backs_off_between_retries() -> None:
     srv._ts_server = cast(Any, _FakeTSServer())
     srv._ensure_ls_operational()
     assert srv._vue_files_indexed is False, "must not retry before the backoff window elapses"
-    assert cast(Any, srv._ts_server).indexing_expected_count == 0
+    assert srv._ts_server.indexing_expected_count == 0
 
     # simulate the backoff window having elapsed
     srv._vue_index_retry_after = 0


### PR DESCRIPTION
Filed as #1923 (traced statically, with a scripted repro harness against the real module rather than a live client session, since the reporter was at their open-PR budget on this repo). `_ensure_vue_files_indexed_on_ts_server` opens every `.vue` file on the companion TypeScript server so cross-file references resolve, wrapping each open in a bare except/log.debug. After the loop it unconditionally sets `_vue_files_indexed = True`, and the method short-circuits on that flag on every later call - so if the companion TS server is down or unresponsive the first time this runs, indexing is silently skipped for the rest of the session. `find_referencing_symbols` and similar then answer from an empty index with no signal anything went wrong.

Same failure shape already fixed twice for other companion-server backends (#1814 for tsserver, and the Svelte companion server) - Vue never got the equivalent treatment. The reporter suggested mirroring Svelte's fail-loudly approach; I went with a smaller version instead: only set the flag when at least one file actually indexed (or there were none to begin with, which isn't a failure). A total failure leaves it unset so the next call retries rather than raising - keeps the change to a single method with no new exception type or behavior change for callers, at the cost of not surfacing the failure as loudly as Svelte does. Happy to go the fail-loud route instead if that's the preferred shape here.

Added unit tests mirroring the repro harness from #1923 (all-fail, all-succeed, partial-failure, no-files, and a retry-after-recovery case). `poe format`/`poe type-check` clean, full `-m python` suite (179 tests) passes.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
