### PR TITLE
fix(typescript): don't drop export/const/let/var from replace_symbol_body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,15 @@ Status of the `main` branch. Changes prior to the next official version change w
     its analysis; symbol queries could then answer from a stale index, e.g. `find_symbol` returning a
     body from the position the symbol used to occupy (#1593)
   - Fix: tsserver reports the range of a single top-level `const`/`let`/`var` declaration starting
-    at the identifier, excluding a leading `export` and the keyword (unlike `function`/`class`
-    declarations, whose range includes their keyword). `replace_symbol_body` then dropped the
-    prefix from the body and replacement range, so re-supplying it in a keyword-inclusive edit
-    duplicated it and produced invalid syntax (e.g. `export const twice = ...` became
-    `export const export const twice = ...`, returned as `OK`). Mirrors the same fix already
-    applied to Go's `type`/`var`/`const` declarations (#1956)
+    at the identifier and ending before the statement's semicolon, excluding a leading `export`,
+    the keyword, and the trailing `;` (unlike `function`/`class` declarations, whose range already
+    includes their keyword). `replace_symbol_body` then dropped the prefix and the semicolon from
+    the body and replacement range, so re-supplying them in a full-statement edit either duplicated
+    the prefix and produced invalid syntax (`export const twice = ...` became `export const export
+    const twice = ...`, returned as `OK`) or, once only the prefix was fixed, left a harmless but
+    incorrect double semicolon behind (`... n * 3;;`). Mirrors the range-start fix already applied
+    to Go's `type`/`var`/`const` declarations, and the range-end fix already applied to Nix's
+    attribute declarations (#1956)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Status of the `main` branch. Changes prior to the next official version change w
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate
     its analysis; symbol queries could then answer from a stale index, e.g. `find_symbol` returning a
     body from the position the symbol used to occupy (#1593)
+  - Fix: tsserver reports the range of a single top-level `const`/`let`/`var` declaration starting
+    at the identifier, excluding a leading `export` and the keyword (unlike `function`/`class`
+    declarations, whose range includes their keyword). `replace_symbol_body` then dropped the
+    prefix from the body and replacement range, so re-supplying it in a keyword-inclusive edit
+    duplicated it and produced invalid syntax (e.g. `export const twice = ...` became
+    `export const export const twice = ...`, returned as `OK`). Mirrors the same fix already
+    applied to Go's `type`/`var`/`const` declarations (#1956)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -627,16 +627,20 @@ class TypeScriptLanguageServer(SolidLanguageServer):
     def _document_symbols_cache_fingerprint(self) -> Hashable:
         # bump whenever request_document_symbols's post-processing below changes what it returns,
         # so a pre-existing on-disk cache from before this override existed gets invalidated
-        return 1
+        return 2
 
     @override
     def request_document_symbols(self, relative_file_path: str, file_buffer: LSPFileBuffer | None = None) -> DocumentSymbols:
-        # Override to extend single `const`/`let`/`var` declaration ranges to include a leading
-        # `export` and the declaration keyword. tsserver excludes both from such ranges (unlike
-        # `function`/`class` declarations), which causes replace_symbol_body to drop them from the
-        # symbol body and replacement range; re-supplying them in a keyword-inclusive edit then
-        # duplicates the prefix and corrupts the file (e.g. `export const` becomes
-        # `export const export const`). See _extend_ts_symbol_range_to_include_leading_keyword.
+        # Override to extend single `const`/`let`/`var` declaration ranges on both ends: a leading
+        # `export` and the declaration keyword, and a trailing statement-terminating semicolon.
+        # tsserver excludes both from such ranges (unlike `function`/`class` declarations, whose
+        # range already includes the keyword), which causes replace_symbol_body to drop them from
+        # the symbol body and replacement range. Re-supplying a dropped leading keyword duplicates
+        # the prefix and corrupts the file (`export const` becomes `export const export const`);
+        # re-supplying a dropped trailing semicolon (as naturally happens when the replacement is
+        # itself a full statement) produces a harmless but incorrect double semicolon. See
+        # _extend_ts_symbol_range_to_include_leading_keyword and
+        # _extend_ts_symbol_range_to_include_trailing_semicolon.
         document_symbols = super().request_document_symbols(relative_file_path, file_buffer=file_buffer)
         if not document_symbols.root_symbols:
             return document_symbols
@@ -651,6 +655,7 @@ class TypeScriptLanguageServer(SolidLanguageServer):
             # at the original (un-extended) nodes
             def extend_symbol_and_children(symbol: ls_types.UnifiedSymbolInformation) -> ls_types.UnifiedSymbolInformation:
                 extended = self._extend_ts_symbol_range_to_include_leading_keyword(symbol, file_lines, body_factory)
+                extended = self._extend_ts_symbol_range_to_include_trailing_semicolon(extended, file_lines, body_factory)
                 children = symbol.get("children")
                 if children:
                     if extended is symbol:
@@ -713,6 +718,62 @@ class TypeScriptLanguageServer(SolidLanguageServer):
         # recompute the body from the now-extended location range so the displayed body stays
         # consistent with the replacement range; the stale body must be removed first, since the
         # factory returns an existing SymbolBody as-is and otherwise reads the updated location range
+        extended.pop("body", None)
+        extended["body"] = body_factory.create_symbol_body(extended)
+        return extended
+
+    def _extend_ts_symbol_range_to_include_trailing_semicolon(
+        self,
+        symbol: ls_types.UnifiedSymbolInformation,
+        file_lines: list[str],
+        body_factory: SymbolBodyFactory,
+    ) -> ls_types.UnifiedSymbolInformation:
+        """
+        Extend a TypeScript/JavaScript symbol's body range to include a trailing statement-
+        terminating semicolon, if one immediately follows the range's current end.
+
+        tsserver reports the range of statement declarations (e.g. `const`/`let`/`var`) as the
+        underlying expression, excluding the semicolon that terminates the statement. Replacing
+        the body with a full statement (as naturally happens when the replacement is copied from
+        the body :meth:`request_document_symbols`/`find_symbol` itself returned, semicolon
+        included, per the leading-keyword extension above) then leaves the file's own original
+        semicolon in place *after* the replaced range, producing a harmless but incorrect double
+        semicolon rather than the single one the replacement supplied.
+
+        Mirrors ``NixdLanguageServer._extend_nix_symbol_range_to_include_semicolon``, adapted to
+        recompute the body from the shared ``body_factory``/``file_lines`` already available here
+        rather than re-reading the file.
+
+        :param symbol: the symbol whose range may be extended.
+        :param file_lines: the lines of the file in which the symbol is defined.
+        :param body_factory: the factory used to recompute the symbol body from the extended range.
+        :return: a copy of the symbol with an extended range, or the original symbol if no
+            semicolon immediately follows the range's end (e.g. for `function`/`class`
+            declarations, which are not semicolon-terminated).
+        """
+        range_info = symbol["range"]
+        end_line = range_info["end"]["line"]
+        end_char = range_info["end"]["character"]
+        if end_line >= len(file_lines):
+            return symbol
+        line = file_lines[end_line]
+        if end_char >= len(line) or line[end_char] != ";":
+            return symbol
+
+        # extend the range end past the semicolon, updating both the symbol range and its
+        # location range so the replacement range covers it
+        new_end = ls_types.Position(line=end_line, character=end_char + 1)
+        extended = symbol.copy()
+        extended["range"] = ls_types.Range(start=range_info["start"], end=new_end)
+        location = extended.get("location")
+        if location:
+            location = location.copy()
+            if "range" in location:
+                location["range"] = ls_types.Range(start=location["range"]["start"], end=new_end)
+            extended["location"] = location
+
+        # recompute the body from the now-extended location range, for the same reason as in
+        # _extend_ts_symbol_range_to_include_leading_keyword
         extended.pop("body", None)
         extended["body"] = body_factory.create_symbol_body(extended)
         return extended

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -8,13 +8,21 @@ import re
 import shutil
 import threading
 import time
+from collections.abc import Hashable
 from typing import Any
 
 from overrides import override
 from sensai.util.logging import LogTime
 
 from solidlsp import ls_types
-from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
+from solidlsp.ls import (
+    DocumentSymbols,
+    LanguageServerDependencyProvider,
+    LanguageServerDependencyProviderSinglePath,
+    LSPFileBuffer,
+    SolidLanguageServer,
+    SymbolBodyFactory,
+)
 from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_exceptions import SolidLSPException
 from solidlsp.ls_utils import PlatformId, PlatformUtils
@@ -99,6 +107,13 @@ class TypeScriptLanguageServer(SolidLanguageServer):
     @classmethod
     def supports_implementation_request(cls) -> bool:
         return True
+
+    # matches a line prefix that consists solely of a leading `const`/`let`/`var` declaration
+    # keyword (with an optional `export` modifier, optional indentation, and the whitespace
+    # before the declared identifier). tsserver reports the symbol range of such declarations
+    # starting at the identifier, i.e. after the keyword(s), unlike `function`/`class` declarations
+    # whose range includes the leading keyword(s). Mirrors Gopls._LEADING_DECL_KEYWORD_RE.
+    _LEADING_DECL_KEYWORD_RE = re.compile(r"(?P<indent>\s*)(?:export\s+)?(?:const|let|var)\s+")
 
     # Safety timeout for $/progress-based indexing wait. Normally the event fires
     # well within this window; the timeout is only hit if the server never sends progress.
@@ -607,3 +622,97 @@ class TypeScriptLanguageServer(SolidLanguageServer):
     @override
     def _get_preferred_definition(self, definitions: list[ls_types.Location]) -> ls_types.Location:
         return prefer_non_node_modules_definition(definitions)
+
+    @override
+    def _document_symbols_cache_fingerprint(self) -> Hashable:
+        # bump whenever request_document_symbols's post-processing below changes what it returns,
+        # so a pre-existing on-disk cache from before this override existed gets invalidated
+        return 1
+
+    @override
+    def request_document_symbols(self, relative_file_path: str, file_buffer: LSPFileBuffer | None = None) -> DocumentSymbols:
+        # Override to extend single `const`/`let`/`var` declaration ranges to include a leading
+        # `export` and the declaration keyword. tsserver excludes both from such ranges (unlike
+        # `function`/`class` declarations), which causes replace_symbol_body to drop them from the
+        # symbol body and replacement range; re-supplying them in a keyword-inclusive edit then
+        # duplicates the prefix and corrupts the file (e.g. `export const` becomes
+        # `export const export const`). See _extend_ts_symbol_range_to_include_leading_keyword.
+        document_symbols = super().request_document_symbols(relative_file_path, file_buffer=file_buffer)
+        if not document_symbols.root_symbols:
+            return document_symbols
+
+        # obtain the file lines and a body factory to recompute the bodies of extended symbols
+        with self._open_file_context(relative_file_path, file_buffer, open_in_ls=False) as file_data:
+            file_lines = file_data.split_lines()
+            body_factory = SymbolBodyFactory(file_data)
+
+            # extend ranges recursively, operating on copies so the cached symbols are not mutated;
+            # see Gopls.request_document_symbols for why child `parent` back-pointers are left aimed
+            # at the original (un-extended) nodes
+            def extend_symbol_and_children(symbol: ls_types.UnifiedSymbolInformation) -> ls_types.UnifiedSymbolInformation:
+                extended = self._extend_ts_symbol_range_to_include_leading_keyword(symbol, file_lines, body_factory)
+                children = symbol.get("children")
+                if children:
+                    if extended is symbol:
+                        extended = symbol.copy()
+                    extended["children"] = [extend_symbol_and_children(child) for child in children]
+                return extended
+
+            extended_root_symbols = [extend_symbol_and_children(sym) for sym in document_symbols.root_symbols]
+
+        return DocumentSymbols(extended_root_symbols)
+
+    def _extend_ts_symbol_range_to_include_leading_keyword(
+        self,
+        symbol: ls_types.UnifiedSymbolInformation,
+        file_lines: list[str],
+        body_factory: SymbolBodyFactory,
+    ) -> ls_types.UnifiedSymbolInformation:
+        """
+        Extend a TypeScript/JavaScript symbol's body range to include a leading `export`/
+        `const`/`let`/`var`.
+
+        tsserver reports the range of a single `const`/`let`/`var` declaration starting at the
+        declared identifier (after the keyword(s)), whereas the range of a `function`/`class`
+        declaration includes its leading keyword. This asymmetry makes :meth:`replace_symbol_body`
+        omit the keyword(s) from both the displayed body and the replacement range, so re-supplying
+        them in an edit duplicates the prefix (e.g. ``export const twice = ...`` becomes
+        ``export const export const twice = ...``).
+
+        :param symbol: the symbol whose range may be extended.
+        :param file_lines: the lines of the file in which the symbol is defined.
+        :param body_factory: the factory used to recompute the symbol body from the extended range.
+        :return: a copy of the symbol with an extended range, or the original symbol if no leading
+            `export`/`const`/`let`/`var` precedes the identifier on the start line (e.g. for
+            functions/classes, or for destructuring declarations whose keyword sits before the
+            opening bracket rather than directly before this identifier).
+        """
+        # determine whether only `export`/`const`/`let`/`var` precedes the identifier on the start line
+        range_info = symbol["range"]
+        start_line = range_info["start"]["line"]
+        start_char = range_info["start"]["character"]
+        if start_line >= len(file_lines):
+            return symbol
+        prefix = file_lines[start_line][:start_char]
+        match = self._LEADING_DECL_KEYWORD_RE.fullmatch(prefix)
+        if match is None:
+            return symbol
+
+        # extend the range start back to the keyword (excluding indentation), updating both the
+        # symbol range and its location range so the replacement range covers the keyword(s)
+        new_start = ls_types.Position(line=start_line, character=len(match.group("indent")))
+        extended = symbol.copy()
+        extended["range"] = ls_types.Range(start=new_start, end=range_info["end"])
+        location = extended.get("location")
+        if location:
+            location = location.copy()
+            if "range" in location:
+                location["range"] = ls_types.Range(start=new_start, end=location["range"]["end"])
+            extended["location"] = location
+
+        # recompute the body from the now-extended location range so the displayed body stays
+        # consistent with the replacement range; the stale body must be removed first, since the
+        # factory returns an existing SymbolBody as-is and otherwise reads the updated location range
+        extended.pop("body", None)
+        extended["body"] = body_factory.create_symbol_body(extended)
+        return extended

--- a/test/resources/repos/typescript/test_repo/symbol_body.ts
+++ b/test/resources/repos/typescript/test_repo/symbol_body.ts
@@ -1,0 +1,14 @@
+// Fixture for verifying that replace_symbol_body includes the leading `export`/`const`/`let`/`var`
+// keyword(s) in the symbol body and replacement range, just like `function`/`class` declarations do.
+
+export const twice = (n: number): number => n * 2;
+
+const localCounter: number = 0;
+
+export let mutableFlag: boolean = false;
+
+var legacyVar: string = "legacy";
+
+export function helperFunction(): void {}
+
+export class HelperClass {}

--- a/test/serena/__snapshots__/test_symbol_editing.ambr
+++ b/test/serena/__snapshots__/test_symbol_editing.ambr
@@ -2388,7 +2388,7 @@
   // Fixture for verifying that replace_symbol_body includes the leading `export`/`const`/`let`/`var`
   // keyword(s) in the symbol body and replacement range, just like `function`/`class` declarations do.
   
-  export const twice = (n: number): number => n * 3;;
+  export const twice = (n: number): number => n * 3;
   
   const localCounter: number = 0;
   

--- a/test/serena/__snapshots__/test_symbol_editing.ambr
+++ b/test/serena/__snapshots__/test_symbol_editing.ambr
@@ -2383,3 +2383,22 @@
   
   '''
 # ---
+# name: test_typescript_symbol_replacement_no_double_keyword
+  '''
+  // Fixture for verifying that replace_symbol_body includes the leading `export`/`const`/`let`/`var`
+  // keyword(s) in the symbol body and replacement range, just like `function`/`class` declarations do.
+  
+  export const twice = (n: number): number => n * 3;;
+  
+  const localCounter: number = 0;
+  
+  export let mutableFlag: boolean = false;
+  
+  var legacyVar: string = "legacy";
+  
+  export function helperFunction(): void {}
+  
+  export class HelperClass {}
+  
+  '''
+# ---

--- a/test/serena/test_symbol_editing.py
+++ b/test/serena/test_symbol_editing.py
@@ -531,6 +531,65 @@ def test_go_symbol_replacement_no_double_keyword(snapshot: SnapshotAssertion):
     test_case.run_test(content_after_ground_truth=snapshot)
 
 
+# A single `export const` declaration body that re-supplies the leading `export const` prefix, as a
+# user would after copying the body returned by find_symbol. Replacing the body with this must not
+# duplicate the prefix.
+TS_DECL_REPLACEMENT = """export const twice = (n: number): number => n * 3;"""
+
+
+class TsDeclReplacementTest(EditingTest):
+    """Test for replacing a single TypeScript `const`/`let`/`var` declaration that should NOT result
+    in a duplicated leading `export`/keyword (e.g. `export const export const twice = ...`).
+    """
+
+    def __init__(self, ls_id: LanguageServerId, rel_path: str, symbol_name: str, new_body: str):
+        super().__init__(ls_id, rel_path)
+        self.symbol_name = symbol_name
+        self.new_body = new_body
+
+    def _apply_edit(self, code_editor: CodeEditor) -> None:
+        code_editor.replace_body(self.symbol_name, self.rel_path, self.new_body)
+
+    @overrides
+    def _test_diff(self, code_diff: CodeDiff, snapshot: SnapshotAssertion | None) -> None:
+        # the leading `export`/declaration keyword must appear exactly once (no `export const
+        # export const` corruption); this doubles as a syntax check, since a duplicated prefix is
+        # `export`/`const`/`let`/`var` immediately followed by whitespace and the same word again
+        for keyword in ("export const", "const", "let", "var"):
+            assert f"{keyword} {keyword} " not in code_diff.modified_content, (
+                f"Replacement duplicated the '{keyword}' prefix: {code_diff.modified_content!r}"
+            )
+        return super()._test_diff(code_diff, snapshot)
+
+
+@pytest.mark.typescript
+def test_typescript_symbol_replacement_no_double_keyword(snapshot: SnapshotAssertion):
+    """
+    Test that replacing a TypeScript `const`/`let`/`var` declaration does not duplicate the leading
+    `export`/keyword.
+
+    This exercises the bug where:
+    - Original: export const twice = (n: number): number => n * 2;
+    - Replacement body (as displayed by find_symbol): export const twice = (n: number): number => n * 3;
+    - Bug result would be: export const export const twice = (n: number): number => n * 3;; (the
+      original `export const ` prefix is kept because the tsserver symbol range starts at the
+      identifier, and the supplied body adds another `export const`)
+    - Correct result should be: export const twice = (n: number): number => n * 3;
+
+    tsserver reports the symbol range of such declarations starting at the identifier (after the
+    keyword(s)), unlike `function`/`class` declarations whose range includes the leading keyword.
+    The range extension in TypeScriptLanguageServer.request_document_symbols prevents the
+    duplicated prefix (GH #1956).
+    """
+    test_case = TsDeclReplacementTest(
+        LanguageServerId.TYPESCRIPT,
+        "symbol_body.ts",
+        "twice",
+        TS_DECL_REPLACEMENT,
+    )
+    test_case.run_test(content_after_ground_truth=snapshot)
+
+
 class RenameSymbolTest(EditingTest):
     def __init__(self, ls_id: LanguageServerId, rel_path: str, symbol_name: str, new_name: str):
         super().__init__(ls_id, rel_path)

--- a/test/serena/test_symbol_editing.py
+++ b/test/serena/test_symbol_editing.py
@@ -538,8 +538,9 @@ TS_DECL_REPLACEMENT = """export const twice = (n: number): number => n * 3;"""
 
 
 class TsDeclReplacementTest(EditingTest):
-    """Test for replacing a single TypeScript `const`/`let`/`var` declaration that should NOT result
-    in a duplicated leading `export`/keyword (e.g. `export const export const twice = ...`).
+    """Test for replacing a single TypeScript `const`/`let`/`var` declaration that should NOT
+    result in a duplicated leading `export`/keyword (e.g. `export const export const twice = ...`)
+    or a duplicated trailing semicolon (e.g. `... n * 3;;`).
     """
 
     def __init__(self, ls_id: LanguageServerId, rel_path: str, symbol_name: str, new_body: str):
@@ -559,6 +560,8 @@ class TsDeclReplacementTest(EditingTest):
             assert f"{keyword} {keyword} " not in code_diff.modified_content, (
                 f"Replacement duplicated the '{keyword}' prefix: {code_diff.modified_content!r}"
             )
+        # the trailing semicolon must appear exactly once, not doubled up
+        assert ";;" not in code_diff.modified_content, f"Replacement duplicated the trailing semicolon: {code_diff.modified_content!r}"
         return super()._test_diff(code_diff, snapshot)
 
 
@@ -566,20 +569,21 @@ class TsDeclReplacementTest(EditingTest):
 def test_typescript_symbol_replacement_no_double_keyword(snapshot: SnapshotAssertion):
     """
     Test that replacing a TypeScript `const`/`let`/`var` declaration does not duplicate the leading
-    `export`/keyword.
+    `export`/keyword or the trailing semicolon.
 
     This exercises the bug where:
     - Original: export const twice = (n: number): number => n * 2;
     - Replacement body (as displayed by find_symbol): export const twice = (n: number): number => n * 3;
     - Bug result would be: export const export const twice = (n: number): number => n * 3;; (the
-      original `export const ` prefix is kept because the tsserver symbol range starts at the
-      identifier, and the supplied body adds another `export const`)
+      original `export const ` prefix and trailing `;` are kept because the tsserver symbol range
+      starts at the identifier and ends before the semicolon, and the supplied body adds both back)
     - Correct result should be: export const twice = (n: number): number => n * 3;
 
     tsserver reports the symbol range of such declarations starting at the identifier (after the
-    keyword(s)), unlike `function`/`class` declarations whose range includes the leading keyword.
-    The range extension in TypeScriptLanguageServer.request_document_symbols prevents the
-    duplicated prefix (GH #1956).
+    keyword(s)) and ending before the semicolon, unlike `function`/`class` declarations whose range
+    includes the leading keyword (and are not semicolon-terminated). The range extension in
+    TypeScriptLanguageServer.request_document_symbols prevents both the duplicated prefix and the
+    duplicated semicolon (GH #1956).
     """
     test_case = TsDeclReplacementTest(
         LanguageServerId.TYPESCRIPT,

--- a/test/solidlsp/typescript/test_typescript_basic.py
+++ b/test/solidlsp/typescript/test_typescript_basic.py
@@ -34,6 +34,46 @@ class TestTypescriptLanguageServer:
             "index.ts should reference helperFunction (tried all positions in selectionRange)"
         )
 
+    @pytest.mark.parametrize("language_server", [LanguageServerId.TYPESCRIPT], indirect=True)
+    def test_const_let_var_body_includes_leading_keyword(self, language_server: SolidLanguageServer) -> None:
+        """
+        Single top-level ``const``/``let``/``var`` declarations must expose a body and replacement
+        range that include a leading ``export`` (if present) and the declaration keyword, just like
+        ``function``/``class`` declarations do.
+
+        Regression test for tsserver reporting the symbol range of such declarations starting at the
+        declared identifier (after the keyword(s)) rather than at the keyword(s). That asymmetry made
+        replace_symbol_body drop them from the body and replacement range, so a natural
+        keyword-inclusive round-trip edit duplicated the prefix and corrupted the file (e.g.
+        ``export const twice = ...`` -> ``export const export const twice = ...``, GH #1956).
+        """
+        all_symbols, _ = language_server.request_document_symbols("symbol_body.ts").get_all_symbols_and_roots()
+        symbols_by_name = {sym.get("name"): sym for sym in all_symbols}
+
+        # single declarations: body starts with the full keyword prefix, the range start moves to
+        # the keyword (column 0 here), and the selection range still points at the identifier
+        expected_prefix_by_name = {
+            "twice": "export const ",
+            "localCounter": "const ",
+            "mutableFlag": "export let ",
+            "legacyVar": "var ",
+        }
+        for name, prefix in expected_prefix_by_name.items():
+            sym = symbols_by_name.get(name)
+            assert sym is not None, f"{name} not found in symbol_body.ts"
+            body = sym["body"].get_text()
+            assert body.startswith(prefix), f"Expected body of {name} to start with {prefix!r}, got {body[:24]!r}"
+            assert sym["location"]["range"]["start"]["character"] == 0, f"Expected {name} body range to start at the keyword (col 0)"
+            assert sym["selectionRange"]["start"]["character"] > 0, f"Expected {name} selectionRange to point at the identifier"
+
+        # function/class declarations already include their keyword in tsserver's own range;
+        # this override must be a no-op for them
+        for name in ("helperFunction", "HelperClass"):
+            sym = symbols_by_name.get(name)
+            assert sym is not None, f"{name} not found in symbol_body.ts"
+            body = sym["body"].get_text()
+            assert body.startswith("export "), f"Expected {name} body to already start with 'export ', got {body[:24]!r}"
+
     if ls_has_verified_implementation_support(LanguageServerId.TYPESCRIPT):
 
         @pytest.mark.parametrize("language_server", [LanguageServerId.TYPESCRIPT], indirect=True)

--- a/test/solidlsp/typescript/test_typescript_basic.py
+++ b/test/solidlsp/typescript/test_typescript_basic.py
@@ -35,23 +35,27 @@ class TestTypescriptLanguageServer:
         )
 
     @pytest.mark.parametrize("language_server", [LanguageServerId.TYPESCRIPT], indirect=True)
-    def test_const_let_var_body_includes_leading_keyword(self, language_server: SolidLanguageServer) -> None:
+    def test_const_let_var_body_includes_leading_keyword_and_trailing_semicolon(self, language_server: SolidLanguageServer) -> None:
         """
         Single top-level ``const``/``let``/``var`` declarations must expose a body and replacement
-        range that include a leading ``export`` (if present) and the declaration keyword, just like
-        ``function``/``class`` declarations do.
+        range that include a leading ``export`` (if present), the declaration keyword, and the
+        trailing statement-terminating semicolon, just like ``function``/``class`` declarations
+        already do (for the keyword; they are not semicolon-terminated).
 
-        Regression test for tsserver reporting the symbol range of such declarations starting at the
-        declared identifier (after the keyword(s)) rather than at the keyword(s). That asymmetry made
-        replace_symbol_body drop them from the body and replacement range, so a natural
-        keyword-inclusive round-trip edit duplicated the prefix and corrupted the file (e.g.
-        ``export const twice = ...`` -> ``export const export const twice = ...``, GH #1956).
+        Regression test for tsserver reporting the symbol range of such declarations starting at
+        the declared identifier (after the keyword(s)) and ending before the semicolon, rather
+        than spanning the full statement. That asymmetry made replace_symbol_body drop the prefix
+        and the semicolon from the body and replacement range, so a natural round-trip edit either
+        duplicated the prefix and corrupted the file (``export const twice = ...`` ->
+        ``export const export const twice = ...``) or, once only the prefix was fixed, left a
+        harmless but incorrect double semicolon behind (``... n * 3;;``). GH #1956.
         """
         all_symbols, _ = language_server.request_document_symbols("symbol_body.ts").get_all_symbols_and_roots()
         symbols_by_name = {sym.get("name"): sym for sym in all_symbols}
 
-        # single declarations: body starts with the full keyword prefix, the range start moves to
-        # the keyword (column 0 here), and the selection range still points at the identifier
+        # single declarations: body starts with the full keyword prefix and ends with the
+        # semicolon, the range start moves to the keyword (column 0 here), the range end moves
+        # past the semicolon, and the selection range still points at the identifier
         expected_prefix_by_name = {
             "twice": "export const ",
             "localCounter": "const ",
@@ -63,16 +67,18 @@ class TestTypescriptLanguageServer:
             assert sym is not None, f"{name} not found in symbol_body.ts"
             body = sym["body"].get_text()
             assert body.startswith(prefix), f"Expected body of {name} to start with {prefix!r}, got {body[:24]!r}"
+            assert body.endswith(";"), f"Expected body of {name} to end with a semicolon, got {body[-8:]!r}"
             assert sym["location"]["range"]["start"]["character"] == 0, f"Expected {name} body range to start at the keyword (col 0)"
             assert sym["selectionRange"]["start"]["character"] > 0, f"Expected {name} selectionRange to point at the identifier"
 
-        # function/class declarations already include their keyword in tsserver's own range;
-        # this override must be a no-op for them
+        # function/class declarations already include their keyword in tsserver's own range and
+        # are not semicolon-terminated; this override must be a no-op for them
         for name in ("helperFunction", "HelperClass"):
             sym = symbols_by_name.get(name)
             assert sym is not None, f"{name} not found in symbol_body.ts"
             body = sym["body"].get_text()
             assert body.startswith("export "), f"Expected {name} body to already start with 'export ', got {body[:24]!r}"
+            assert not body.endswith(";"), f"Expected {name} body to not have gained a trailing semicolon, got {body[-8:]!r}"
 
     if ls_has_verified_implementation_support(LanguageServerId.TYPESCRIPT):
 


### PR DESCRIPTION
Fixes #1956. tsserver reports the range of a single top-level `const`/`let`/`var` declaration starting at the identifier and ending before the statement's semicolon - excluding a leading `export`, the keyword, and the trailing `;` - unlike `function`/`class` declarations, whose range already includes their keyword (and which aren't semicolon-terminated). `replace_symbol_body` then dropped both from the body and replacement range, so re-supplying them in a full-statement edit (as a user naturally would after copying the body `find_symbol` returned) either duplicated the prefix and produced invalid syntax (`export const twice = ...` became `export const export const twice = ...`, returned as `OK`) or, with only the prefix fixed, left a harmless but incorrect double semicolon behind (`... n * 3;;`).

`TypeScriptLanguageServer.request_document_symbols` now extends the range on both ends: the start back to the keyword (mirroring the fix already applied to Go's analogous `type`/`var`/`const` asymmetry), and the end past the semicolon if one immediately follows (mirroring `NixdLanguageServer`'s existing `_extend_nix_symbol_range_to_include_semicolon`, reusing the `file_lines`/`body_factory` already available here instead of re-reading the file). `function`/`class` declarations are untouched on both ends, since tsserver already gets those right. The document-symbols cache fingerprint is bumped again so a pre-existing cache doesn't keep serving the old ranges.

Round-trip snapshot now shows the exact single-semicolon output the issue's "Expected behavior" section describes - `export const twice = (n: number): number => n * 3;`, not the double-semicolon I flagged as a follow-up in an earlier version of this PR.

`symbol_body.ts` fixture (mirrors Go's `symbol_body.go`), a document-symbols regression test, and a live round-trip replacement test against the actual TS server, all updated to cover both ends. `poe format`/`poe type-check` clean; full `-m python` (179), `-m typescript` (30), `-m vue` (46), and `-m svelte` (16) suites all pass.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
