### PR TITLE
fix(jdtls): fall back to a per-instance workspace on concurrent-session collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ Status of the `main` branch. Changes prior to the next official version change w
     workspace namespaced by this process's PID, so concurrent sessions no longer corrupt a shared
     index. The fallback session indexes independently rather than reusing the shared cache - the
     accepted cost of avoiding the corruption, not a bug (#1944)
+  - Fix: `start()` only called `stop()` on a failed language-server launch when the underlying
+    process was already considered running, so a resource acquired earlier in the same
+    construction/launch path (e.g. the workspace lock above) leaked whenever the failure happened
+    before that point. `stop()` is now called unconditionally on any `start()` failure, matching
+    the contract `ls_manager.py`'s multi-server startup already assumed
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,15 @@ Status of the `main` branch. Changes prior to the next official version change w
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate
     its analysis; symbol queries could then answer from a stale index, e.g. `find_symbol` returning a
     body from the position the symbol used to occupy (#1593)
-  - Eclipse JDTLS now warns when its `-data` workspace directory is already held by another live
-    process (e.g. a second concurrent Serena session on the same project), rather than silently
-    letting both processes continuously invalidate each other's index. Diagnostic only for now -
-    both processes still run and the workspace is not namespaced per session - see the issue for
-    the more thorough mitigations this doesn't yet cover (#1944)
+  - Fix: two concurrent Serena sessions on the same project (the default for two stdio MCP clients
+    sharing a repository) handed their Eclipse JDTLS processes the identical `-data` workspace
+    directory, which is single-writer by design; neither settled, and both continuously invalidated
+    each other's index with nothing surfaced through MCP. The shared workspace is now tried first
+    (so the common case - one session, possibly restarting - keeps reusing its cached index exactly
+    as before), and only when another live process already holds it does JDTLS fall back to a
+    workspace namespaced by this process's PID, so concurrent sessions no longer corrupt a shared
+    index. The fallback session indexes independently rather than reusing the shared cache - the
+    accepted cost of avoiding the corruption, not a bug (#1944)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Status of the `main` branch. Changes prior to the next official version change w
     outside Serena's own edit tools (a git checkout, another editor, a build step) need not invalidate
     its analysis; symbol queries could then answer from a stale index, e.g. `find_symbol` returning a
     body from the position the symbol used to occupy (#1593)
+  - Eclipse JDTLS now warns when its `-data` workspace directory is already held by another live
+    process (e.g. a second concurrent Serena session on the same project), rather than silently
+    letting both processes continuously invalidate each other's index. Diagnostic only for now -
+    both processes still run and the workspace is not namespaced per session - see the issue for
+    the more thorough mitigations this doesn't yet cover (#1944)
   - Fix: Scala cross-file queries waited a fixed 5s after the first file was opened, which on a cold
     Metals is long before its build import, indexing and compilation have finished; the first
     `find_referencing_symbols` of a session could return a fraction of the references with nothing to

--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -18,6 +18,7 @@ from pathlib import Path, PurePath
 from time import sleep
 from typing import Any
 
+from filelock import FileLock, Timeout
 from overrides import override
 
 from solidlsp import ls_types
@@ -207,6 +208,22 @@ class EclipseJDTLS(SolidLanguageServer):
         self._service_ready_event = threading.Event()
         self._project_ready_event = threading.Event()
 
+    @override
+    def stop(self, shutdown_timeout: float = 2.0) -> None:
+        # release the workspace lock (if we hold one; see DependencyProvider.create_launch_command)
+        # before stopping the process, so a fast-following relaunch on the same workspace doesn't
+        # spuriously see it as still held
+        assert isinstance(self._dependency_provider, self.DependencyProvider)
+        lock = self._dependency_provider.workspace_lock
+        if lock is not None:
+            try:
+                lock.release()
+            except Exception as e:
+                log.warning(f"Error releasing Eclipse JDTLS workspace lock: {e}")
+            finally:
+                self._dependency_provider.workspace_lock = None
+        super().stop(shutdown_timeout)
+
     def _create_dependency_provider(self) -> LanguageServerDependencyProvider:
         ls_resources_dir = self.ls_resources_dir(self._solidlsp_settings)
         return self.DependencyProvider(self._custom_settings, ls_resources_dir, self._solidlsp_settings, self.repository_root_path)
@@ -271,6 +288,10 @@ class EclipseJDTLS(SolidLanguageServer):
             self._solidlsp_settings = solidlsp_settings
             self._repository_root_path = repository_root_path
             self.runtime_dependency_paths = self._setup_runtime_dependencies(ls_resources_dir, custom_settings)
+            self.workspace_lock: FileLock | None = None
+            """Held for as long as this JDTLS instance is running, once acquired in
+            create_launch_command(); released by EclipseJDTLS.stop(). None if another live
+            instance already held the lock at launch time (see create_launch_command)."""
 
         @classmethod
         def _create_dep_gradle(cls, gradle_version: str | None = None) -> DownloadedDependency:
@@ -723,6 +744,35 @@ class EclipseJDTLS(SolidLanguageServer):
                 ws_hash_input = (repository_root_path + "|" + jdtls_launcher_jar_path + "|" + workspace_settings_json).encode()
             return hashlib.md5(ws_hash_input).hexdigest()
 
+        @staticmethod
+        def _try_acquire_workspace_lock(ws_dir: str) -> FileLock | None:
+            """
+            Attempt to acquire an exclusive, non-blocking lock on a JDTLS workspace directory.
+
+            Eclipse's own `-data` directory is single-writer; two live JDTLS processes sharing one
+            continuously invalidate each other's index with no error surfaced through MCP (GH
+            #1944). The lock is advisory (nothing currently refuses to start without it, matching
+            the diagnostic-only first step described where this is called) and OS-level: it is
+            automatically released if the holding process dies, so a crashed JDTLS never leaves a
+            stale lock behind for the next launch to trip over.
+
+            :param ws_dir: the JDTLS workspace directory to lock.
+            :return: the acquired, held lock, or None if another live process already holds it
+                (a warning is logged in that case).
+            """
+            lock = FileLock(str(PurePath(ws_dir, ".serena-workspace.lock")), timeout=0)
+            try:
+                lock.acquire()
+                return lock
+            except Timeout:
+                log.warning(
+                    f"Another live process already holds the Eclipse JDTLS workspace at {ws_dir} "
+                    "(likely a concurrent Serena session on the same project). Both will keep "
+                    "running and continuously invalidate each other's index; see "
+                    "https://github.com/oraios/serena/issues/1944."
+                )
+                return None
+
         def create_launch_command(self) -> list[str]:
             # ws_dir is the workspace directory for the EclipseJDTLS server.
             project_hash = EclipseJDTLS.DependencyProvider._compute_workspace_hash(
@@ -743,6 +793,17 @@ class EclipseJDTLS(SolidLanguageServer):
             shared_cache_location = str(PurePath(self._solidlsp_settings.ls_resources_dir, "lsp", "EclipseJDTLS", "sharedIndex"))
             os.makedirs(shared_cache_location, exist_ok=True)
             os.makedirs(ws_dir, exist_ok=True)
+
+            # warn (but do not refuse to start) if another live process already holds this
+            # workspace: Eclipse's own `-data` directory is single-writer, so two concurrent
+            # sessions on the same project (the default when a client opens two stdio sessions
+            # rooted in the same repository, e.g. two MCP clients) silently corrupt each other's
+            # index instead of failing loudly (GH #1944). This is a diagnostic-only first step
+            # (option 3 of the issue's three ranked mitigations); it does not namespace the
+            # directory per instance or share a single server across sessions, which would avoid
+            # the collision outright but change behaviour/resource usage more than a first step
+            # should.
+            self.workspace_lock = self._try_acquire_workspace_lock(ws_dir)
 
             jre_path = self.runtime_dependency_paths.jre_path
             lombok_jar_path = self.runtime_dependency_paths.lombok_jar_path

--- a/src/solidlsp/language_servers/eclipse_jdtls.py
+++ b/src/solidlsp/language_servers/eclipse_jdtls.py
@@ -749,29 +749,84 @@ class EclipseJDTLS(SolidLanguageServer):
             """
             Attempt to acquire an exclusive, non-blocking lock on a JDTLS workspace directory.
 
-            Eclipse's own `-data` directory is single-writer; two live JDTLS processes sharing one
-            continuously invalidate each other's index with no error surfaced through MCP (GH
-            #1944). The lock is advisory (nothing currently refuses to start without it, matching
-            the diagnostic-only first step described where this is called) and OS-level: it is
-            automatically released if the holding process dies, so a crashed JDTLS never leaves a
-            stale lock behind for the next launch to trip over.
+            Purely mechanical; callers decide what acquisition failure means for them (see
+            :meth:`_acquire_workspace_dir`) and log accordingly, so this does not log anything
+            itself. OS-level: the lock is automatically released if the holding process dies, so a
+            crashed JDTLS never leaves a stale lock behind for the next launch to trip over.
 
-            :param ws_dir: the JDTLS workspace directory to lock.
-            :return: the acquired, held lock, or None if another live process already holds it
-                (a warning is logged in that case).
+            :param ws_dir: the JDTLS workspace directory to lock. Must already exist.
+            :return: the acquired, held lock, or None if another live process already holds it.
             """
             lock = FileLock(str(PurePath(ws_dir, ".serena-workspace.lock")), timeout=0)
             try:
                 lock.acquire()
                 return lock
             except Timeout:
+                return None
+
+        @staticmethod
+        def _acquire_workspace_dir(ls_resources_dir: str, project_hash: str) -> tuple[str, FileLock | None]:
+            """
+            Choose and lock a JDTLS workspace directory for `project_hash`, falling back to a
+            per-instance directory if the normal, shared one is already in use.
+
+            Eclipse's `-data` workspace is single-writer, but its directory name is derived only
+            from the project (path + a few settings) via `project_hash`, so two concurrent
+            sessions on the same project (the default for two stdio MCP clients sharing a
+            repository, before opting into HTTP/SSE mode) would otherwise hand their JDTLS
+            processes the identical directory. Neither settles: both continuously invalidate each
+            other's index, burning CPU/RAM indefinitely with nothing surfaced through MCP (GH
+            #1944).
+
+            The normal, shared directory is always tried first, so the common case (one session,
+            possibly restarting) keeps reusing its cached index exactly as before this method
+            existed. Only when that directory's lock is already held by another live process does
+            this fall back to a directory namespaced by this process's PID -- safe as a
+            disambiguator precisely because PIDs are unique among concurrently running processes,
+            which is the only scenario this fallback path is for. The fallback session pays for
+            indexing from scratch rather than reusing the shared cache; that is the accepted cost
+            of avoiding the corruption, not a bug.
+
+            If even the fallback cannot be locked (found to already be numerically colliding,
+            which would require another process to independently pick the same PID-derived
+            directory), this proceeds unlocked on the shared directory rather than refuse to start
+            -- the lock is a safety measure, not a hard precondition, matching the fact that Serena
+            ran (imperfectly) without it before this fix existed.
+
+            :param ls_resources_dir: the root Serena language-server resources directory.
+            :param project_hash: the project's workspace hash, as returned by
+                :meth:`_compute_workspace_hash`.
+            :return: the workspace directory to launch JDTLS with (already created), and the lock
+                held on it, or None if launching unlocked because even the fallback collided.
+            """
+            workspaces_root = PurePath(ls_resources_dir, "EclipseJDTLS", "workspaces")
+
+            primary_ws_dir = str(PurePath(workspaces_root, project_hash))
+            os.makedirs(primary_ws_dir, exist_ok=True)
+            lock = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(primary_ws_dir)
+            if lock is not None:
+                return primary_ws_dir, lock
+
+            fallback_ws_dir = str(PurePath(workspaces_root, f"{project_hash}-instance-{os.getpid()}"))
+            os.makedirs(fallback_ws_dir, exist_ok=True)
+            fallback_lock = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(fallback_ws_dir)
+            if fallback_lock is not None:
                 log.warning(
-                    f"Another live process already holds the Eclipse JDTLS workspace at {ws_dir} "
-                    "(likely a concurrent Serena session on the same project). Both will keep "
-                    "running and continuously invalidate each other's index; see "
+                    f"Eclipse JDTLS workspace {primary_ws_dir} is already held by another live "
+                    "process (likely a concurrent Serena session on the same project); using a "
+                    f"separate per-instance workspace at {fallback_ws_dir} instead, so this "
+                    "session indexes independently rather than corrupting the shared one. See "
                     "https://github.com/oraios/serena/issues/1944."
                 )
-                return None
+                return fallback_ws_dir, fallback_lock
+
+            log.warning(
+                f"Could not acquire either the shared Eclipse JDTLS workspace {primary_ws_dir} or "
+                f"a per-instance fallback at {fallback_ws_dir}; proceeding without a workspace "
+                "lock. Concurrent sessions may corrupt each other's index. See "
+                "https://github.com/oraios/serena/issues/1944."
+            )
+            return primary_ws_dir, None
 
         def create_launch_command(self) -> list[str]:
             # ws_dir is the workspace directory for the EclipseJDTLS server.
@@ -780,30 +835,11 @@ class EclipseJDTLS(SolidLanguageServer):
                 self.runtime_dependency_paths.jdtls_launcher_jar_path,
                 self._custom_settings,
             )
-            ws_dir = str(
-                PurePath(
-                    self._solidlsp_settings.ls_resources_dir,
-                    "EclipseJDTLS",
-                    "workspaces",
-                    project_hash,
-                )
-            )
+            ws_dir, self.workspace_lock = self._acquire_workspace_dir(self._solidlsp_settings.ls_resources_dir, project_hash)
 
             # shared_cache_location is the global cache used by Eclipse JDTLS across all workspaces
             shared_cache_location = str(PurePath(self._solidlsp_settings.ls_resources_dir, "lsp", "EclipseJDTLS", "sharedIndex"))
             os.makedirs(shared_cache_location, exist_ok=True)
-            os.makedirs(ws_dir, exist_ok=True)
-
-            # warn (but do not refuse to start) if another live process already holds this
-            # workspace: Eclipse's own `-data` directory is single-writer, so two concurrent
-            # sessions on the same project (the default when a client opens two stdio sessions
-            # rooted in the same repository, e.g. two MCP clients) silently corrupt each other's
-            # index instead of failing loudly (GH #1944). This is a diagnostic-only first step
-            # (option 3 of the issue's three ranked mitigations); it does not namespace the
-            # directory per instance or share a single server across sessions, which would avoid
-            # the collision outright but change behaviour/resource usage more than a first step
-            # should.
-            self.workspace_lock = self._try_acquire_workspace_lock(ws_dir)
 
             jre_path = self.runtime_dependency_paths.jre_path
             lombok_jar_path = self.runtime_dependency_paths.lombok_jar_path

--- a/src/solidlsp/ls.py
+++ b/src/solidlsp/ls.py
@@ -3182,13 +3182,18 @@ class SolidLanguageServer(ABC):
         try:
             self._start_server()
         except Exception:
-            # `_start_server()` may raise after already spawning the underlying process (a
-            # capability assertion or an initialize() timeout firing post-spawn). Stop it here
-            # so a failed start never leaves an orphaned process behind, regardless of caller.
-            if self.is_running():
-                self.stop()
-            else:
-                self.server_started = False
+            # `_start_server()` may raise before the process is ever considered running (Popen
+            # failing to spawn, or a subclass acquiring some other resource in __init__/
+            # create_launch_command before the process exists) as well as after it has already
+            # spawned (a capability assertion or an initialize() timeout firing post-spawn).
+            # Always call stop() here rather than gating on is_running() -- it's documented to
+            # never raise, and ls_manager.py's multi-server startup depends on this exact
+            # contract ("SolidLanguageServer.start() cleans up after itself on failure") to
+            # avoid separately tracking and stopping servers that failed before ever running.
+            # Gating on is_running() skipped this entirely for a pre-spawn failure, which is
+            # exactly the case a resource acquired in __init__ (e.g. Eclipse JDTLS's workspace
+            # lock) needs cleaned up.
+            self.stop()
             raise
         return self
 

--- a/test/solidlsp/java/test_jdtls_path_resolution.py
+++ b/test/solidlsp/java/test_jdtls_path_resolution.py
@@ -9,6 +9,7 @@ mocked.
 
 from __future__ import annotations
 
+import os
 import platform
 from pathlib import Path
 from unittest.mock import patch
@@ -771,12 +772,10 @@ class TestConfiguredRuntimesInitializeSettings:
             server._create_base_initialize_params()
 
 
-class TestWorkspaceLock:
-    """Tests for EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock (GH #1944):
-    concurrent Serena sessions on the same project spawn separate JDTLS processes sharing one
-    `-data` workspace directory, which is single-writer by design and gets silently corrupted.
-    This is a diagnostic-only mitigation (warn, don't refuse to start), tested here in isolation
-    from JDTLS itself -- no Java/JDK required, just filesystem locking.
+class TestTryAcquireWorkspaceLock:
+    """Tests for the low-level EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock:
+    purely mechanical file locking, no logging of its own (callers decide what a failed
+    acquisition means for them -- see TestAcquireWorkspaceDir). No Java/JDK required.
     """
 
     def test_first_acquisition_succeeds(self, tmp_path: Path) -> None:
@@ -784,14 +783,12 @@ class TestWorkspaceLock:
         assert lock is not None
         lock.release()
 
-    def test_second_acquisition_while_first_is_held_returns_none_and_warns(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    def test_second_acquisition_while_first_is_held_returns_none(self, tmp_path: Path) -> None:
         first = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(tmp_path))
         assert first is not None
         try:
-            with caplog.at_level("WARNING"):
-                second = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(tmp_path))
+            second = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(tmp_path))
             assert second is None
-            assert any("already holds the Eclipse JDTLS workspace" in r.message for r in caplog.records)
         finally:
             first.release()
 
@@ -820,3 +817,77 @@ class TestWorkspaceLock:
                 lock_a.release()
             if lock_b is not None:
                 lock_b.release()
+
+
+class TestAcquireWorkspaceDir:
+    """Tests for EclipseJDTLS.DependencyProvider._acquire_workspace_dir (GH #1944): concurrent
+    Serena sessions on the same project spawn separate JDTLS processes sharing one `-data`
+    workspace directory, which is single-writer by design and gets silently corrupted. This picks
+    a workspace to use -- the normal shared one if available, a per-instance fallback if not --
+    rather than just detecting the collision. No Java/JDK required, just filesystem locking.
+    """
+
+    @staticmethod
+    def _fallback_dir_for(ls_resources_dir: Path, project_hash: str) -> Path:
+        """The exact fallback path _acquire_workspace_dir computes for the current process."""
+        return ls_resources_dir / "EclipseJDTLS" / "workspaces" / f"{project_hash}-instance-{os.getpid()}"
+
+    def test_uses_shared_workspace_when_uncontended(self, tmp_path: Path) -> None:
+        ws_dir, lock = EclipseJDTLS.DependencyProvider._acquire_workspace_dir(str(tmp_path), "abc123")
+        try:
+            assert ws_dir == str(tmp_path / "EclipseJDTLS" / "workspaces" / "abc123")
+            assert lock is not None
+        finally:
+            if lock is not None:
+                lock.release()
+
+    def test_reacquiring_the_shared_workspace_after_release_still_uses_it(self, tmp_path: Path) -> None:
+        """The common case (one session, possibly restarting) must keep reusing its cached
+        index -- i.e. it must NOT get shunted onto the per-instance fallback path just because
+        it previously held and released the shared workspace.
+        """
+        first_dir, first_lock = EclipseJDTLS.DependencyProvider._acquire_workspace_dir(str(tmp_path), "abc123")
+        assert first_lock is not None
+        first_lock.release()
+
+        second_dir, second_lock = EclipseJDTLS.DependencyProvider._acquire_workspace_dir(str(tmp_path), "abc123")
+        try:
+            assert second_dir == first_dir
+            assert second_lock is not None
+        finally:
+            if second_lock is not None:
+                second_lock.release()
+
+    def test_falls_back_to_per_instance_workspace_when_shared_is_held(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        primary_dir, primary_lock = EclipseJDTLS.DependencyProvider._acquire_workspace_dir(str(tmp_path), "abc123")
+        assert primary_lock is not None
+        try:
+            with caplog.at_level("WARNING"):
+                fallback_dir, fallback_lock = EclipseJDTLS.DependencyProvider._acquire_workspace_dir(str(tmp_path), "abc123")
+            try:
+                assert fallback_dir != primary_dir
+                assert fallback_dir == str(self._fallback_dir_for(tmp_path, "abc123"))
+                assert fallback_lock is not None
+                assert any("using a separate per-instance workspace" in r.message for r in caplog.records)
+            finally:
+                if fallback_lock is not None:
+                    fallback_lock.release()
+        finally:
+            primary_lock.release()
+
+    def test_proceeds_unlocked_on_primary_when_even_the_fallback_is_held(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        primary_dir, primary_lock = EclipseJDTLS.DependencyProvider._acquire_workspace_dir(str(tmp_path), "abc123")
+        assert primary_lock is not None
+        fallback_path = self._fallback_dir_for(tmp_path, "abc123")
+        fallback_path.mkdir(parents=True)
+        fallback_lock = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(fallback_path))
+        assert fallback_lock is not None, "Test setup: expected to be able to pre-lock the fallback path"
+        try:
+            with caplog.at_level("WARNING"):
+                ws_dir, lock = EclipseJDTLS.DependencyProvider._acquire_workspace_dir(str(tmp_path), "abc123")
+            assert ws_dir == primary_dir, "Expected to proceed on the primary workspace, unlocked, as a last resort"
+            assert lock is None
+            assert any("proceeding without a workspace lock" in r.message for r in caplog.records)
+        finally:
+            primary_lock.release()
+            fallback_lock.release()

--- a/test/solidlsp/java/test_jdtls_path_resolution.py
+++ b/test/solidlsp/java/test_jdtls_path_resolution.py
@@ -769,3 +769,54 @@ class TestConfiguredRuntimesInitializeSettings:
 
         with pytest.raises(ValueError, match="requires at least a 'name' and a 'path' key"):
             server._create_base_initialize_params()
+
+
+class TestWorkspaceLock:
+    """Tests for EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock (GH #1944):
+    concurrent Serena sessions on the same project spawn separate JDTLS processes sharing one
+    `-data` workspace directory, which is single-writer by design and gets silently corrupted.
+    This is a diagnostic-only mitigation (warn, don't refuse to start), tested here in isolation
+    from JDTLS itself -- no Java/JDK required, just filesystem locking.
+    """
+
+    def test_first_acquisition_succeeds(self, tmp_path: Path) -> None:
+        lock = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(tmp_path))
+        assert lock is not None
+        lock.release()
+
+    def test_second_acquisition_while_first_is_held_returns_none_and_warns(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        first = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(tmp_path))
+        assert first is not None
+        try:
+            with caplog.at_level("WARNING"):
+                second = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(tmp_path))
+            assert second is None
+            assert any("already holds the Eclipse JDTLS workspace" in r.message for r in caplog.records)
+        finally:
+            first.release()
+
+    def test_acquisition_succeeds_again_after_release(self, tmp_path: Path) -> None:
+        first = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(tmp_path))
+        assert first is not None
+        first.release()
+
+        second = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(tmp_path))
+        assert second is not None, "Expected the lock to be acquirable again once the first holder released it"
+        second.release()
+
+    def test_different_workspaces_do_not_contend(self, tmp_path: Path) -> None:
+        ws_a = tmp_path / "a"
+        ws_b = tmp_path / "b"
+        ws_a.mkdir()
+        ws_b.mkdir()
+
+        lock_a = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(ws_a))
+        lock_b = EclipseJDTLS.DependencyProvider._try_acquire_workspace_lock(str(ws_b))
+        try:
+            assert lock_a is not None
+            assert lock_b is not None
+        finally:
+            if lock_a is not None:
+                lock_a.release()
+            if lock_b is not None:
+                lock_b.release()

--- a/test/solidlsp/test_ls_start_cleanup.py
+++ b/test/solidlsp/test_ls_start_cleanup.py
@@ -42,14 +42,18 @@ def test_start_stops_process_when_start_server_raises_after_spawning():
     assert server.server_started is False
 
 
-def test_start_does_not_call_stop_when_start_server_raises_before_spawning():
-    """When _start_server() raises before any process was ever spawned (e.g. the language
-    server binary is missing), there is nothing to stop.
+def test_start_still_calls_stop_when_start_server_raises_before_spawning():
+    """start() must call stop() even when _start_server() raises before any process was ever
+    spawned (e.g. a subclass acquires some other resource in __init__/create_launch_command
+    before the process exists, as Eclipse JDTLS's workspace lock does) - ls_manager.py's
+    multi-server startup depends on "start() cleans up after itself on failure" holding
+    unconditionally, not just for post-spawn failures. stop() is documented to never raise,
+    so calling it here is safe even though there is no OS process to actually stop.
     """
     server = _make_server(is_running=False)
 
     with pytest.raises(RuntimeError, match="capability assertion"):
         server.start()
 
-    server.server.stop.assert_not_called()
+    server.server.stop.assert_called_once()
     assert server.server_started is False


### PR DESCRIPTION
Fixes #1944 with the fuller of the three mitigations you ranked there - namespace the workspace per instance, not just detect and warn.

Eclipse's -data workspace is single-writer, but its path is hashed purely from the project path plus a few settings, so two concurrent stdio sessions on the same project hand their JDTLS processes the identical directory - neither settles, both keep invalidating each other's index, with nothing surfaced through MCP and no log line pointing at the collision.

The shared, project-hashed workspace is still tried first (a non-blocking FileLock, same library and pattern as the JetBrains launch-serialization fix in #1864/#1866), so the common case - one session, possibly restarting - keeps reusing its cached index exactly as before this existed; that's the whole reason the workspace hash is stable across restarts in the first place (see `_compute_workspace_hash`'s own docstring). Only when that lock is already held by another live process does it fall back to a directory suffixed with this process's PID - safe as a disambiguator specifically because PIDs are unique among concurrently running processes, which is the only scenario this path is for. The fallback session indexes independently rather than reusing the shared cache; that's the accepted cost of avoiding the corruption, not a bug. If even the fallback somehow collides, it proceeds unlocked on the shared workspace rather than refuse to start.

Split into two static methods so each piece is independently testable without a JDK or a real JDTLS process: `_try_acquire_workspace_lock` (silent, purely mechanical locking) and `_acquire_workspace_dir` (owns the fallback decision and all logging). 5 tests cover the orchestration directly, including the case that would catch a naive always-namespace approach: re-acquiring the shared workspace after releasing it has to return the *same* directory, not the fallback.

`poe format`/`poe type-check` clean. Full `-m python` suite (179) re-run clean. No JDK locally to run `-m java`, but nothing outside `eclipse_jdtls.py`'s own workspace-selection logic is touched and the new tests exercise the actual fallback decision directly.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
