### PR TITLE
fix(typescript): drain in-flight indexing on later cross-file queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Language Servers:
   - Add Fatou support as an alternative Julia language server (`julia_fatou`)
+  - Fix: TypeScript's `_has_waited_for_cross_file_references` latch was set after the first
+    cross-file query and never reset, so a later query that opened a file from a project tsserver
+    had not loaded yet (e.g. a monorepo package) skipped the indexing wait even while that
+    project's own `$/progress` indexing was still in flight (#1937)
   - Fix: Nextflow's `_flush_deferred_workspace_scan` marked the workspace scan flushed even when both
     of its `completion` probes failed, permanently skipping the flush (and silencing retries) for the
     rest of the session (#1871)

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -591,18 +591,29 @@ class TypeScriptLanguageServer(SolidLanguageServer):
 
     @override
     def _wait_for_cross_file_references_if_needed(self) -> None:
-        if self._has_waited_for_cross_file_references:
+        timeout = self._get_indexing_timeout()
+        if not self._has_waited_for_cross_file_references:
+            start_grace = self._get_indexing_start_grace()
+            self._log_cross_file_indexing_wait_outcome(
+                self._wait_for_indexing_start_or_completion(timeout=timeout, start_grace=start_grace), timeout
+            )
+            self._has_waited_for_cross_file_references = True
             return
 
-        timeout = self._get_indexing_timeout()
-        start_grace = self._get_indexing_start_grace()
-        if self._wait_for_indexing_start_or_completion(timeout=timeout, start_grace=start_grace):
+        # The latch above only covers the first query; a later one can still open a file from a
+        # project tsserver has not loaded before, starting a fresh $/progress cycle to drain.
+        with self._progress_lock:
+            indexing_in_progress = bool(self._active_progress_tokens)
+        if indexing_in_progress:
+            self._log_cross_file_indexing_wait_outcome(self.wait_for_indexing(timeout=timeout), timeout)
+
+    def _log_cross_file_indexing_wait_outcome(self, completed: bool, timeout: float) -> None:
+        if completed:
             log.info("TypeScript cross-file indexing complete")
         else:
             log.warning(
                 "TypeScript cross-file indexing did not complete within %.0fs; proceeding (%s)", timeout, self.describe_indexing_state()
             )
-        self._has_waited_for_cross_file_references = True
 
     @override
     def _get_preferred_definition(self, definitions: list[ls_types.Location]) -> ls_types.Location:

--- a/test/solidlsp/test_typescript_timeout_policy.py
+++ b/test/solidlsp/test_typescript_timeout_policy.py
@@ -284,6 +284,42 @@ class TestWaitForCrossFileReferencesUsesConfiguredGrace:
         server._wait_for_cross_file_references_if_needed()
         assert time.monotonic() - start < 0.1
 
+    def test_second_call_drains_a_progress_token_already_in_flight(self) -> None:
+        """oraios/serena#1937: a later cross-file query can open a file from a project tsserver
+        has not loaded yet (e.g. a monorepo package), starting a fresh $/progress cycle. The
+        once-only latch must not let that query return while the fresh token is still active.
+        """
+        server = _bare_ts_server(TypeScriptLanguageServer, {"indexing_start_grace": 0.05})
+        server._has_waited_for_cross_file_references = True
+        server._active_progress_tokens.add("tsserver/project-b-load")
+        server._indexing_complete.clear()
+
+        def _drain_shortly() -> None:
+            time.sleep(0.2)
+            with server._progress_lock:
+                server._active_progress_tokens.discard("tsserver/project-b-load")
+                server._indexing_complete.set()
+
+        threading.Thread(target=_drain_shortly, daemon=True).start()
+
+        start = time.monotonic()
+        server._wait_for_cross_file_references_if_needed()
+        elapsed = time.monotonic() - start
+
+        # proves the wait actually blocked for the still-active token, not a fast no-op return
+        assert elapsed >= 0.15
+        assert server._active_progress_tokens == set()
+
+    def test_second_call_proceeds_on_timeout_while_a_token_never_drains(self) -> None:
+        server = _bare_ts_server(TypeScriptLanguageServer, {"indexing_timeout": 0.05})
+        server._has_waited_for_cross_file_references = True
+        server._active_progress_tokens.add("tsserver/project-b-load")
+        server._indexing_complete.clear()
+
+        server._wait_for_cross_file_references_if_needed()  # must log and return, not raise or hang
+
+        assert server._active_progress_tokens == {"tsserver/project-b-load"}
+
 
 class _FakeSolidLSPSettings:
     """Minimal settings stand-in: returns a fixed TypeScript indexing_timeout so the guard tests can


### PR DESCRIPTION
`_wait_for_cross_file_references_if_needed` gates the pre-request indexing wait behind
`_has_waited_for_cross_file_references`, a latch set once after the first cross-file query and
never reset. The first query is exactly what makes tsserver start pulling in referenced and
referencing projects, and that indexing continues after it has answered.

A later `find_referencing_symbols`/`find_references` call that opens a file from a project
tsserver has not loaded yet restarts that indexing but skips the wait entirely, because the latch
is already set, so it can return while its own `$/progress` token is still open. The result is
silently partial: the reporter's own six-call sequence on one symbol returns 11 references, then
1, then 1, then 11 again, with nothing distinguishing the partial answers from complete ones.

The latch still covers the first query's start-grace wait unchanged (that grace exists to give
tsserver a window to *begin* reporting progress, and re-running it on every query would add a
multi-second delay to queries that trigger no new indexing at all). A later query now also checks
whether a progress token is already active and, if so, waits for it to drain via the same
`wait_for_indexing` the first query uses.

Scoped to the confirmed repro: it waits for progress that has already started by the time the
check runs. A narrower race, where a later query's own progress notification has not arrived yet
at that instant, is the same shape #1586 fixed for the first query but is not covered here, since
closing it would mean re-running the start-grace wait on every query.

## Verification

- New test, `test_second_call_drains_a_progress_token_already_in_flight`, fails on `main` (returns
  in under a millisecond while the token is still active) and passes on this branch (blocks until
  the token drains).
- Full `test/solidlsp/test_typescript_timeout_policy.py` (the file's own regression suite for this
  policy): 31 passed.
- `coverage run --source=solidlsp.language_servers.typescript_language_server -m pytest
  test/solidlsp/test_typescript_timeout_policy.py`: both new branches and the changed lines are
  covered, apart from the pre-existing `_pre_open_for_cross_file_references` latch check, which
  this PR does not touch and was already untested before it.
- `ruff format --check` and `ruff check` on the changed files, and `codespell`: clean.
- Not run: the full pytest matrix (native/jvm/other-langs across OS) and CodeQL, since those spin
  up real language servers this environment cannot provision; the change is confined to
  `typescript_language_server.py`'s own progress bookkeeping and does not touch any other server.

Fixes #1937
