### PR TITLE
Remove unnecessary platform restrictions in language servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Status of the `main` branch. Changes prior to the next official version change w
 
 * Language Servers:
   - Add FreeBSD mapping to platform detection
+  - Remove unnecessary platform checks from the following language servers, expanding the set of
+    supported platforms accordingly: Elixir Tools, Intelephense, Perl, TypeScript, VTS
   - Fix: the managed Solidity language server could report no diagnostics on macOS when Hardhat could not write
     its global state under ``~/Library``; Serena now gives the child process an isolated home-directory view
     via ``solidity_state_dir`` without changing the parent process's ``HOME`` (#1817)

--- a/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
+++ b/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
@@ -97,16 +97,6 @@ class ElixirTools(SolidLanguageServer):
             return expert_in_path
 
         platform_id = PlatformUtils.get_platform_id()
-
-        valid_platforms = [
-            PlatformId.LINUX_x64,
-            PlatformId.LINUX_arm64,
-            PlatformId.OSX_x64,
-            PlatformId.OSX_arm64,
-            PlatformId.WIN_x64,
-        ]
-        assert platform_id in valid_platforms, f"Platform {platform_id} is not supported for Expert at the moment"
-
         expert_dir = os.path.join(cls.ls_resources_dir(solidlsp_settings), "expert")
 
         # Define runtime dependencies inline
@@ -163,6 +153,8 @@ class ElixirTools(SolidLanguageServer):
             ),
         }
 
+        if platform_id not in runtime_deps:
+            raise RuntimeError(f"Platform {platform_id} is not supported for Expert")
         dependency = runtime_deps[platform_id]
         # On Windows, use .exe extension
         executable_name = "expert.exe" if platform_id.value.startswith("win") else "expert"

--- a/src/solidlsp/language_servers/intelephense.py
+++ b/src/solidlsp/language_servers/intelephense.py
@@ -11,7 +11,6 @@ from overrides import override
 
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig
-from solidlsp.ls_utils import PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import Definition, DefinitionParams, DidChangeConfigurationParams, LocationLink
 from solidlsp.settings import SolidLSPSettings
 
@@ -51,19 +50,6 @@ class Intelephense(SolidLanguageServer):
             """
             Setup runtime dependencies for Intelephense and return the path to the executable.
             """
-            platform_id = PlatformUtils.get_platform_id()
-
-            valid_platforms = [
-                PlatformId.LINUX_x64,
-                PlatformId.LINUX_arm64,
-                PlatformId.OSX,
-                PlatformId.OSX_x64,
-                PlatformId.OSX_arm64,
-                PlatformId.WIN_x64,
-                PlatformId.WIN_arm64,
-            ]
-            assert platform_id in valid_platforms, f"Platform {platform_id} is not supported by Intelephense at the moment"
-
             # Verify both node and npm are installed
             is_node_installed = shutil.which("node") is not None
             assert is_node_installed, "node is not installed or isn't in PATH. Please install NodeJS and try again."

--- a/src/solidlsp/language_servers/perl_language_server.py
+++ b/src/solidlsp/language_servers/perl_language_server.py
@@ -12,7 +12,6 @@ from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig, LanguageServerId
-from solidlsp.ls_utils import PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import DidChangeConfigurationParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
@@ -84,18 +83,6 @@ class PerlLanguageServer(SolidLanguageServer):
         Check if required Perl runtime dependencies are available.
         Raises RuntimeError with helpful message if dependencies are missing.
         """
-        platform_id = PlatformUtils.get_platform_id()
-
-        valid_platforms = [
-            PlatformId.LINUX_x64,
-            PlatformId.LINUX_arm64,
-            PlatformId.OSX,
-            PlatformId.OSX_x64,
-            PlatformId.OSX_arm64,
-        ]
-        if platform_id not in valid_platforms:
-            raise RuntimeError(f"Platform {platform_id} is not supported for Perl at the moment")
-
         perl_version = cls._get_perl_version()
         if not perl_version:
             raise RuntimeError(

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -17,7 +17,7 @@ from solidlsp import ls_types
 from solidlsp.ls import LanguageServerDependencyProvider, LanguageServerDependencyProviderSinglePath, SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig
 from solidlsp.ls_exceptions import SolidLSPException
-from solidlsp.ls_utils import PlatformId, PlatformUtils
+from solidlsp.ls_utils import PlatformUtils
 from solidlsp.lsp_protocol_handler.lsp_types import MessageType
 from solidlsp.settings import SolidLSPSettings
 
@@ -267,21 +267,6 @@ class TypeScriptLanguageServer(SolidLanguageServer):
             """
             Setup runtime dependencies for TypeScript Language Server and return the path to the executable.
             """
-            platform_id = PlatformUtils.get_platform_id()
-
-            valid_platforms = [
-                PlatformId.LINUX_x64,
-                PlatformId.LINUX_arm64,
-                PlatformId.OSX,
-                PlatformId.OSX_x64,
-                PlatformId.OSX_arm64,
-                PlatformId.WIN_x64,
-                PlatformId.WIN_arm64,
-            ]
-            assert platform_id in valid_platforms, (
-                f"Platform {platform_id} is not supported for multilspy javascript/typescript at the moment"
-            )
-
             # Get version settings from ls_specific_settings or use defaults
             language_specific_config = self._custom_settings
             typescript_version = language_specific_config.get("typescript_version", DEFAULT_TYPESCRIPT_VERSION)

--- a/src/solidlsp/language_servers/vts_language_server.py
+++ b/src/solidlsp/language_servers/vts_language_server.py
@@ -13,7 +13,6 @@ from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig, LanguageServerId
-from solidlsp.ls_utils import PlatformId, PlatformUtils
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
 
@@ -75,18 +74,6 @@ class VtsLanguageServer(SolidLanguageServer):
         """
         Setup runtime dependencies for VTS Language Server and return the command to start the server.
         """
-        platform_id = PlatformUtils.get_platform_id()
-
-        valid_platforms = [
-            PlatformId.LINUX_x64,
-            PlatformId.LINUX_arm64,
-            PlatformId.OSX,
-            PlatformId.OSX_x64,
-            PlatformId.OSX_arm64,
-            PlatformId.WIN_x64,
-            PlatformId.WIN_arm64,
-        ]
-        assert platform_id in valid_platforms, f"Platform {platform_id} is not supported for vtsls at the moment"
         vts_config = solidlsp_settings.get_ls_specific_settings(LanguageServerId.TYPESCRIPT_VTS)
         vtsls_version = vts_config.get("vtsls_version", DEFAULT_VTSLS_VERSION)
         npm_registry = vts_config.get("npm_registry")


### PR DESCRIPTION
Platform checks in the following language servers are affected, expanding the set of supported platforms for these LS:
* Elixir Tools
* Intelephense
* Perl
* TypeScript
* VTS
