### PR TITLE
fix: disable automatic type acquisition in TypeScript backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Status of the `main` branch. Changes prior to the next official version change w
     Serena's own tools to close the gap (#1852)
 
 * Language Servers:
+  - Fix: TypeScript and VTS now disable automatic type acquisition as intended, while VTS
+    preserves explicit user settings across initialization and configuration requests (#1989)
   - Add FreeBSD mapping to platform detection
   - Remove unnecessary platform checks from the following language servers, expanding the set of
     supported platforms accordingly: Elixir Tools, Intelephense, Perl, TypeScript, VTS

--- a/src/solidlsp/language_servers/typescript_language_server.py
+++ b/src/solidlsp/language_servers/typescript_language_server.py
@@ -339,9 +339,7 @@ class TypeScriptLanguageServer(SolidLanguageServer):
             # slow, network-dependent, and nondeterministic (and can hang on offline/locked-down
             # machines). Serena relies on the types already installed in the project instead.
             "initializationOptions": {
-                "preferences": {
-                    "disableAutomaticTypingAcquisition": True,
-                },
+                "disableAutomaticTypingAcquisition": True,
             },
             "capabilities": {
                 "textDocument": {

--- a/src/solidlsp/language_servers/vts_language_server.py
+++ b/src/solidlsp/language_servers/vts_language_server.py
@@ -8,11 +8,14 @@ import logging
 import os
 import shutil
 import threading
+from copy import deepcopy
+from typing import cast
 
 from overrides import override
 
 from solidlsp.ls import SolidLanguageServer
 from solidlsp.ls_config import LanguageServerConfig, LanguageServerId
+from solidlsp.lsp_protocol_handler.lsp_types import InitializeParams
 from solidlsp.lsp_protocol_handler.server import ProcessLaunchInfo
 from solidlsp.settings import SolidLSPSettings
 
@@ -34,8 +37,8 @@ class VtsLanguageServer(SolidLanguageServer):
     Supported entries in ``ls_specific_settings["typescript_vts"]``:
         - ``vtsls_version``: version of ``@vtsls/language-server`` to install (default: ``"0.2.9"``).
         - ``npm_registry``: custom npm registry for the managed install.
-        - ``initialization_options``: optional dict forwarded verbatim as LSP
-          ``initializationOptions``. Useful for Yarn PnP projects, e.g.::
+        - ``initialization_options``: optional LSP configuration. Automatic type acquisition
+          is disabled by default; explicit settings take precedence. Useful for Yarn PnP projects, e.g.::
 
               initialization_options:
                 typescript:
@@ -128,16 +131,11 @@ class VtsLanguageServer(SolidLanguageServer):
         """
         Returns the initialize params for the VTS Language Server.
 
-        If ``initialization_options`` is set in ``ls_specific_settings["typescript_vts"]``,
-        it is forwarded verbatim as LSP ``initializationOptions``.
+        User-provided options are copied so initialization overrides do not mutate the caller's settings.
         """
         initialize_params: dict = {
             "locale": "en",
-            "initializationOptions": {
-                "preferences": {
-                    "disableAutomaticTypingAcquisition": True,
-                },
-            },
+            "initializationOptions": deepcopy(self._initialization_options),
             "capabilities": {
                 "textDocument": {
                     "synchronization": {"didSave": True, "dynamicRegistration": True},
@@ -161,11 +159,18 @@ class VtsLanguageServer(SolidLanguageServer):
             },
         }
 
-        if self._initialization_options:
-            log.info("Forwarding user-provided initializationOptions to vtsls: %s", self._initialization_options)
-            initialize_params["initializationOptions"] = self._initialization_options
-
         return initialize_params
+
+    @override
+    def _create_initialize_params(self) -> InitializeParams:
+        """Apply the ATA default after both adapter-specific and generic initialization overrides."""
+        params = super()._create_initialize_params()
+        options = cast(dict, deepcopy(params["initializationOptions"]))
+        typescript_options = options.setdefault("typescript", {})
+        if isinstance(typescript_options, dict):
+            typescript_options.setdefault("disableAutomaticTypeAcquisition", True)
+        params["initializationOptions"] = options
+        return params
 
     def _start_server(self) -> None:
         """
@@ -192,12 +197,13 @@ class VtsLanguageServer(SolidLanguageServer):
         def execute_client_command_handler(params: dict) -> list:
             return []
 
-        init_options = self._initialization_options
+        # share the final configuration across initialization, requests and notifications
+        initialize_params = self._create_initialize_params()
+        init_options = cast(dict, initialize_params["initializationOptions"])
 
         def workspace_configuration_handler(params: dict) -> list[object]:
-            # vtsls pulls settings for sections like "typescript", "vtsls", "javascript".
-            # Return the matching sub-dicts from the user-provided initialization_options.
-            return [init_options.get(item.get("section", ""), {}) for item in params["items"]]
+            # vtsls requests the whole configuration (empty section) during startup
+            return [init_options.get(item["section"], {}) if item.get("section") else init_options for item in params["items"]]
 
         def do_nothing(params: dict) -> None:
             return
@@ -222,7 +228,6 @@ class VtsLanguageServer(SolidLanguageServer):
 
         log.info("Starting VTS server process")
         self.server.start()
-        initialize_params = self._create_initialize_params()
 
         log.info("Sending initialize request from LSP client to LSP server and awaiting response")
         init_response = self.server.send.initialize(initialize_params)
@@ -243,7 +248,7 @@ class VtsLanguageServer(SolidLanguageServer):
 
         # vtsls also reads settings via workspace/didChangeConfiguration (in addition
         # to initializationOptions and workspace/configuration pulls). Push the same
-        # user-provided settings on all three channels for maximum compatibility,
+        # effective settings on all three channels for maximum compatibility,
         # e.g. so that `typescript.tsdk` is honoured for Yarn PnP projects.
         if init_options:
             self.server.notify.workspace_did_change_configuration({"settings": init_options})

--- a/test/solidlsp/typescript/test_typescript_automatic_type_acquisition.py
+++ b/test/solidlsp/typescript/test_typescript_automatic_type_acquisition.py
@@ -1,0 +1,99 @@
+"""Automatic type acquisition must be disabled on the semantic TypeScript worker."""
+
+import copy
+import os
+import threading
+from pathlib import Path
+from unittest.mock import Mock
+
+import psutil
+import pytest
+
+from solidlsp.language_servers.vts_language_server import VtsLanguageServer
+from solidlsp.ls_config import LanguageServerConfig, LanguageServerId
+from solidlsp.settings import SolidLSPSettings
+from test.conftest import get_repo_path, start_ls_context
+
+
+@pytest.mark.typescript
+@pytest.mark.parametrize("backend", [LanguageServerId.TYPESCRIPT, LanguageServerId.TYPESCRIPT_VTS])
+def test_default_disables_type_acquisition_in_running_server(backend: LanguageServerId) -> None:
+    parent = psutil.Process(os.getpid())
+    existing_pids = {child.pid for child in parent.children(recursive=True)}
+
+    # VTS uses the same fixture project, but has no default repository alias.
+    with start_ls_context(backend, repo_path=str(get_repo_path(LanguageServerId.TYPESCRIPT))) as ls:
+        symbols = ls.request_document_symbols("index.ts").get_all_symbols_and_roots()[0]
+        assert any(symbol["name"] == "DemoClass" for symbol in symbols)
+
+        semantic_workers = []
+        typings_installers = []
+        for child in parent.children(recursive=True):
+            if child.pid in existing_pids:
+                continue
+            try:
+                command = child.cmdline()
+            except psutil.NoSuchProcess:
+                continue
+            filenames = {Path(arg).name for arg in command}
+            if "typingsInstaller.js" in filenames:
+                typings_installers.append(command)
+            if "tsserver.js" in filenames and "partialSemantic" not in command and "--syntaxOnly" not in command:
+                semantic_workers.append(command)
+
+        # The syntax worker disables ATA independently, even on the broken baseline.
+        assert semantic_workers, "No semantic tsserver was observed after a successful symbol request"
+        assert all("--disableAutomaticTypingAcquisition" in command for command in semantic_workers), semantic_workers
+        assert not typings_installers, typings_installers
+
+
+@pytest.mark.parametrize(
+    ("custom_settings", "expected"),
+    [
+        ({}, {"typescript": {"disableAutomaticTypeAcquisition": True}}),
+        (
+            {"initialization_options": {"typescript": {"tsdk": "workspace/typescript/lib"}, "vtsls": {"autoUseWorkspaceTsdk": True}}},
+            {
+                "typescript": {"tsdk": "workspace/typescript/lib", "disableAutomaticTypeAcquisition": True},
+                "vtsls": {"autoUseWorkspaceTsdk": True},
+            },
+        ),
+        (
+            {"initialization_options": {"typescript": {"disableAutomaticTypeAcquisition": False}}},
+            {"typescript": {"disableAutomaticTypeAcquisition": False}},
+        ),
+        (
+            {"initializationOptions": {"typescript": {"tsdk": "workspace/typescript/lib"}}},
+            {"typescript": {"tsdk": "workspace/typescript/lib", "disableAutomaticTypeAcquisition": True}},
+        ),
+    ],
+)
+def test_vts_sends_consistent_effective_configuration(tmp_path: Path, custom_settings: dict, expected: dict) -> None:
+    original_settings = copy.deepcopy(custom_settings)
+
+    # Use the real startup/configuration path with only the remote LSP transport replaced.
+    server = object.__new__(VtsLanguageServer)
+    server._custom_settings = SolidLSPSettings.CustomLSSettings(custom_settings)
+    server.repository_root_path = str(tmp_path)
+    server.config = LanguageServerConfig(ls_id=LanguageServerId.TYPESCRIPT_VTS)
+    server.server_ready = threading.Event()
+    server.server_ready.set()
+    server.initialize_searcher_command_available = threading.Event()
+    transport = Mock()
+    transport.send.initialize.return_value = {"capabilities": {"textDocumentSync": 1, "completionProvider": {}}}
+    handlers = {}
+    transport.on_request.side_effect = handlers.__setitem__
+    server.server = transport
+
+    server._start_server()
+
+    assert transport.send.initialize.call_args.args[0]["initializationOptions"] == expected
+    configuration = handlers["workspace/configuration"]
+    assert configuration({"items": [{"section": ""}, {}, {"section": "typescript"}, {"section": "missing"}]}) == [
+        expected,
+        expected,
+        expected["typescript"],
+        {},
+    ]
+    assert transport.notify.workspace_did_change_configuration.call_args.args[0] == {"settings": expected}
+    assert custom_settings == original_settings


### PR DESCRIPTION
## Summary

The automatic type acquisition defaults were sent under settings neither TypeScript backend consumes. VTS also returned an empty response to the root configuration request it makes during startup, so its semantic tsserver could still launch the typings installer.

Fixes #1989.

- Put the TypeScript Language Server option at the correct initialization level.
- Use the shared initialization builder for VTS and share its effective settings across initialization, configuration requests, and change notifications.
- Preserve the legacy `initialization_options` alias when `initializationOptions` is absent, without mutating caller-owned settings during assembly.
- Follow the shared builder's per-top-level-key overrides: supplying a `typescript` block replaces the entire default block, including the ATA default. This behavior is documented in the changelog and VTS configuration docstring.

## Testing

The original six regressions failed against the original main baseline. Following review, three configuration cases failed against the previous PR implementation before simplifying VTS. The revised focused file now has eight passing cases, including actual startup of both backends: symbol lookup succeeds, the semantic tsserver receives the disabling flag, and no typings-installer process is observed. The syntax worker is excluded from the semantic-worker assertion.

- Affected TypeScript and timeout-policy suites: **49 passed** on the final run. An earlier run had 48 passed and one failure in the unchanged cross-package reference test; its isolated module passed (3 tests), then the full affected suite passed without changing that code or test.
- `poe format`, `poe type-check`, `poe lint`, and `git diff --check`: passed.
- Tested on Windows with Python 3.13.12 and Node 24.16.0, using the existing default backend versions. The all-language suite was not run locally.

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] Added a concise entry under Language Servers in `CHANGELOG.md`.
