### PR TITLE
fix: send languageId typescriptreact for .tsx files in vtsls

### DIFF
--- a/src/solidlsp/language_servers/vts_language_server.py
+++ b/src/solidlsp/language_servers/vts_language_server.py
@@ -70,6 +70,15 @@ class VtsLanguageServer(SolidLanguageServer):
             "build",
         ]
 
+    def _get_language_id_for_file(self, relative_file_path: str) -> str:
+        # JSX is parsed as TS without this, which silently truncates symbol
+        # ranges at the first multi-line JSX expression.
+        if relative_file_path.endswith(".tsx"):
+            return "typescriptreact"
+        if relative_file_path.endswith(".jsx"):
+            return "javascriptreact"
+        return self.language_id
+
     @classmethod
     def _setup_runtime_dependencies(cls, config: LanguageServerConfig, solidlsp_settings: SolidLSPSettings) -> str:
         """


### PR DESCRIPTION
Same fix as #1436, for the vtsls backend.

`vts_language_server.py` doesn't override `_get_language_id_for_file`, so `.tsx`
and `.jsx` are opened with the base `typescript` id. JSX then parses as TS and
symbol ranges silently truncate at the first multi-line JSX expression.

Implementation is identical to the one #1436 added to
`typescript_language_server.py`.
