### PR TITLE
CI: isolate the JetBrains launch-polling test clock

### DIFF
--- a/test/serena/test_jetbrains_launch_coordinator.py
+++ b/test/serena/test_jetbrains_launch_coordinator.py
@@ -65,15 +65,17 @@ class TestLaunchAndWaitForPluginServer:
             mock.patch.object(jetbrains_plugin_client.JetBrainsPluginClient, "from_project", side_effect=from_project),
             mock.patch.object(launch_coordinator, "_lock_path_for_launch_command", return_value=tmp_path / "lock"),
             mock.patch("serena.jetbrains.launch_coordinator.subprocess.Popen", return_value=_fake_process()) as popen,
-            mock.patch("serena.jetbrains.launch_coordinator.time.sleep") as sleep,
+            # leave the shared time module unchanged for filelock and other threads
+            mock.patch.object(launch_coordinator, "time", wraps=time) as clock,
         ):
+            clock.sleep.return_value = None
             launch_coordinator.launch_and_wait_for_plugin_server(
                 project, "pycharm", plugin_server_wait_timeout=5.0, plugin_server_poll_interval=0.01
             )
         popen.assert_called_once()
         # 1 check right after acquiring the lock (raises) + 3 polls (2 raise, the 3rd succeeds)
         assert calls["n"] == 4
-        assert sleep.call_count == 2
+        assert clock.sleep.call_count == 2
 
     def test_gives_up_after_the_wait_timeout_without_raising(self, tmp_path) -> None:
         project = _make_project()


### PR DESCRIPTION
## Problem

The JetBrains launch-polling test intermittently fails its two-sleep assertion in unrelated PRs. The [existing report on #1914](https://github.com/oraios/serena/pull/1914#issuecomment-5549890627) identifies the shared mock. Upstream failures include:

| PR | failed job | observed assertion |
|:--|:--|:--|
| [#1914](https://github.com/oraios/serena/pull/1914) | [macOS catch-all](https://github.com/oraios/serena/actions/runs/33894793516/job/101094795089) | `585023 == 2` |
| [#1914](https://github.com/oraios/serena/pull/1914) | [Ubuntu catch-all](https://github.com/oraios/serena/actions/runs/33930936720/job/101209209328) | `307259 == 2` |
| [#1990](https://github.com/oraios/serena/pull/1990) | [Windows catch-all](https://github.com/oraios/serena/actions/runs/33946867498/job/101254445718) | `363603 == 2` |

The coordinator imports `time`, so patching `launch_coordinator.time.sleep` replaces `sleep` on the shared standard-library module. Sleeps from other threads can then count toward the test's assertion, even when the coordinator polls correctly.

## Change

Replace only the coordinator's `time` binding with a wrapping mock and make that mock's `sleep` a no-op. Other callers retain the real `time.sleep`; the coordinator retains real monotonic time and the test's existing five-second deadline.

The existing checks remain: one launch, four server lookups and two polling sleeps. Production code and the timeout/concurrent-launch tests are unchanged. The aggregate diff touches one test file only.

## Verification

The standalone example below demonstrates the isolation mechanism: both mocks count two coordinator sleeps, but an unrelated thread raises only the original mock's count to three. It does not recreate the full Serena test or identify every unrelated caller in the CI failures.

<details>
<summary>Reproduce with Python's standard library (no Serena checkout needed)</summary>

Run this Python code in a fresh interpreter:

```python
import threading
import time
from types import SimpleNamespace
from unittest import mock

coordinator = SimpleNamespace(time=time)


def exercise(sleep):
    coordinator.time.sleep(0)
    coordinator.time.sleep(0)
    before = sleep.call_count
    worker = threading.Thread(target=lambda: time.sleep(0))
    worker.start()
    worker.join(timeout=2)
    assert not worker.is_alive()
    return before, sleep.call_count


with mock.patch.object(coordinator.time, "sleep", return_value=None) as sleep:
    original = exercise(sleep)

with mock.patch.object(coordinator, "time", wraps=time) as clock:
    clock.sleep.return_value = None
    fixed = exercise(clock.sleep)

assert original == (2, 3) and fixed == (2, 2)
print(f"original: {original}; fixed: {fixed}")
```

Expected output: `original: (2, 3); fixed: (2, 2)`.

</details>

For the actual coordinator and client tests, run from a development checkout:

```sh
uv run pytest test/serena/test_jetbrains_launch_coordinator.py test/serena/test_jetbrains_plugin_client.py -q
uv run poe lint
uv run poe type-check
```

| check | result |
|:--|:--|
| JetBrains coordinator/client tests (Linux) | 14 passed in 0.33s |
| `poe lint` | pass |
| `poe type-check` | pass |

<sub>Generated by re-running each check on this revision.</sub>

## Checklist

- [x] This PR follows the guidelines in `CONTRIBUTING.md` regarding the scope of PRs.
- [x] For changes that add features or fix problems, I have added an entry to `CHANGELOG.md`, which concisely describes the change. *(N/A — test-only change; no user-facing behavior.)*