### PR TITLE
Fix: health-check reported success after reference search failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Status of the `main` branch. Changes prior to the next official version change w
     which could leave grandchildren as zombies; cleanup now waits for the discovered descendants (#1464)
   - Fix: `read_only` restriction in project definition was not applied to base tool set when in single-project context (#1938)
 
+* CLI:
+  - Fix: `project health-check` reported `Health check passed - All tools working correctly` and
+    exited 0 even when `FindReferencingSymbolsTool` had raised, because that failure was logged as
+    a warning while the verdict checked `FindSymbolTool` only. A reference-search failure now fails
+    the check; a symbol with no references is still a pass
+
 * Memories:
   - Fix: `save_memory`/`edit_memory` wrote directly to the memory file with `open(path, "w")`, which
     truncates it before the new content is written; a crash, OOM kill, or full disk partway through

--- a/src/serena/cli.py
+++ b/src/serena/cli.py
@@ -1020,7 +1020,12 @@ class ProjectCommands(AutoRegisteringGroup):
                         find_refs_data = json.loads(find_refs_result)
                         log.info("FindReferencingSymbolsTool found %d references for symbol %s", len(find_refs_data), symbol_name)
                 except Exception as e:
-                    log.warning("FindReferencingSymbolsTool failed for symbol %s: %s", symbol_name, str(e))
+                    # A symbol with no references at all is a legitimate result, so the number of
+                    # references is not asserted - but a *failure* of the reference search means the
+                    # language server is not functional, which is the single thing this command is
+                    # asked to determine. Logging it as a warning let the command print
+                    # "All tools working correctly" and exit 0 after the search had already failed.
+                    raise ProjectCommands._HealthCheckFailure(f"FindReferencingSymbolsTool failed for symbol {symbol_name}: {e}") from e
 
                 # Verify tools worked as expected
                 if not find_symbol_data:

--- a/test/serena/test_cli_project_commands.py
+++ b/test/serena/test_cli_project_commands.py
@@ -1,10 +1,15 @@
 """Tests for CLI project commands (create, index)."""
 
+import json
 import os
 import shutil
 import tempfile
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from click import Command, Option
@@ -382,3 +387,119 @@ if __name__ == "__main__":
     # For manual testing, you can run this file directly:
     # uv run pytest test/serena/test_cli_project_commands.py -v
     pytest.main([__file__, "-v"])
+
+
+class _FakeTool:
+    """A stand-in for a Serena tool: records the calls and returns a canned result."""
+
+    def __init__(self, result: str | Exception) -> None:
+        self._result = result
+
+    @contextmanager
+    def _noop_context(self) -> Iterator[None]:
+        yield
+
+    @property
+    def symbol_dict_grouper(self) -> Any:
+        return SimpleNamespace(disabled_context=self._noop_context)
+
+    def get_symbol_overview(self, *_args: Any, **_kwargs: Any) -> Any:
+        return self._call()
+
+    def apply(self, *_args: Any, **_kwargs: Any) -> Any:
+        return self._call()
+
+    def _call(self) -> Any:
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+def _run_health_check(
+    monkeypatch: pytest.MonkeyPatch,
+    cli_runner: CliRunner,
+    project_dir: str,
+    *,
+    refs_result: str | Exception,
+) -> Any:
+    """Run `project health-check` with every language-server dependency replaced by a double."""
+    import serena.agent
+    import serena.project
+    from serena.config.serena_config import SerenaConfig
+    from serena.tools import FindReferencingSymbolsTool, FindSymbolTool, GetSymbolsOverviewTool
+
+    overview = [{"name": "hello", "kind": "Function"}]
+    tools = {
+        GetSymbolsOverviewTool: _FakeTool(overview),
+        FindSymbolTool: _FakeTool(json.dumps([{"name": "hello"}])),
+        FindReferencingSymbolsTool: _FakeTool(refs_result),
+    }
+
+    fake_agent = SimpleNamespace(
+        get_tool=lambda tool_class: tools[tool_class],
+        execute_task=lambda task: task(),
+    )
+    fake_config = SimpleNamespace(
+        with_headless_mode_overrides=lambda: SimpleNamespace(language_backend=None),
+    )
+
+    monkeypatch.setattr(SerenaConfig, "from_config_file", classmethod(lambda cls, *a, **kw: fake_config))
+    monkeypatch.setattr(serena.agent, "SerenaAgent", lambda **_kwargs: fake_agent)
+    monkeypatch.setattr(
+        serena.project.Project,
+        "load",
+        classmethod(lambda cls, *a, **kw: SimpleNamespace(gather_source_files=lambda: ["big.py"])),
+    )
+
+    return cli_runner.invoke(ProjectCommands.health_check, [project_dir])
+
+
+@pytest.fixture
+def temp_project_dir_with_large_python_file() -> Iterator[str]:
+    """The health check skips files of 1000 bytes or less, so the fixture file must exceed that."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        Path(tmpdir, "big.py").write_text("def hello():\n    pass\n" + "# padding\n" * 200)
+        yield tmpdir
+    finally:
+        if os.name == "nt":
+            time.sleep(0.2)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_health_check_passes_when_all_tools_answer(
+    monkeypatch: pytest.MonkeyPatch, cli_runner: CliRunner, temp_project_dir_with_large_python_file: str
+) -> None:
+    result = _run_health_check(
+        monkeypatch, cli_runner, temp_project_dir_with_large_python_file, refs_result=json.dumps([{"name": "caller"}])
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Health check passed" in result.output
+
+
+def test_health_check_passes_when_symbol_has_no_references(
+    monkeypatch: pytest.MonkeyPatch, cli_runner: CliRunner, temp_project_dir_with_large_python_file: str
+) -> None:
+    """A symbol nobody calls is a legitimate result and must not be reported as a broken language server."""
+    result = _run_health_check(monkeypatch, cli_runner, temp_project_dir_with_large_python_file, refs_result=json.dumps([]))
+
+    assert result.exit_code == 0, result.output
+    assert "Health check passed" in result.output
+
+
+def test_health_check_fails_when_reference_search_raises(
+    monkeypatch: pytest.MonkeyPatch, cli_runner: CliRunner, temp_project_dir_with_large_python_file: str
+) -> None:
+    """The regression: the failure was logged as a warning, so the command reported success and exited 0."""
+    result = _run_health_check(
+        monkeypatch,
+        cli_runner,
+        temp_project_dir_with_large_python_file,
+        refs_result=RuntimeError("language server went away"),
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Health check failed" in result.output
+    assert "FindReferencingSymbolsTool" in result.output
+    assert "All tools working correctly" not in result.output


### PR DESCRIPTION
## The problem

`project health-check` runs three tools, but only two of them can fail the check. An exception from `FindReferencingSymbolsTool` is caught and logged as a warning, while the verdict tests `find_symbol_data` alone:

```python
                except Exception as e:
                    log.warning("FindReferencingSymbolsTool failed for symbol %s: %s", symbol_name, str(e))

                # Verify tools worked as expected
                if not find_symbol_data:
                    raise ProjectCommands._HealthCheckFailure("FindSymbolTool returned no results")
```

So on a project whose reference search has just blown up, the command prints `✅ Health check passed - All tools working correctly` and exits 0. Captured from a run against the unpatched code:

```
WARNING serena.cli:health_check:1023 - FindReferencingSymbolsTool failed for symbol hello: language server went away
INFO    serena.cli:health_check:1029 - Health check completed successfully
```

A false green here is worse than no check: the command exists to answer whether the project's tooling works, and it is used that way — `.github/workflows/python-versions.yml` gates each interpreter on it, and callers script on the exit code.

This also contradicts the principle stated a few lines below, in the outer handler:

> expected failures and unexpected exceptions are reported alike: both mean the project's tooling is not functional, which is the single thing this command is asked to determine

## The change

A reference-search **failure** now fails the check.

The number of references is deliberately still not asserted — a symbol nobody calls is a legitimate result and stays a pass. Only an exception from the tool is treated as "the language server is not functional".

## Tests

Three cases in `test/serena/test_cli_project_commands.py`, with the language-server dependencies replaced by doubles, so they need no running server and add ~0.1 s:

| case | expected |
|---|---|
| all tools answer | exit 0, "Health check passed" |
| symbol has no references | exit 0, "Health check passed" |
| reference search raises | exit 1, "Health check failed", no "All tools working correctly" |

The third fails on the unpatched code (`1 failed, 2 passed`), which is what makes the first two meaningful.

## Checks run

- `poe lint` — clean, `poe type-check` — clean
- `pytest test/serena/test_cli_project_commands.py` — 28 passed
- `serena project health-check test/resources/repos/python/test_repo` — passes with the change (9 references found for `UserService`), i.e. the workflow this fix makes stricter is green on your own fixture

## One thing worth naming

This makes `python-versions.yml` genuinely stricter. If that job starts failing on some interpreter after this merges, it is the check reporting a condition it previously hid, not a new defect introduced here.

---
